### PR TITLE
feat(eslint): add rule for vue/define-props-destructuring

### DIFF
--- a/config/eslint/flat-configs/eslint.vue-config.ts
+++ b/config/eslint/flat-configs/eslint.vue-config.ts
@@ -178,6 +178,11 @@ const ESLINT_VUE_CONFIG = {
     "vue/define-emits-declaration": "error",
     "vue/define-macros-order": "error",
     "vue/define-props-declaration": "error",
+    "vue/define-props-destructuring": [
+      "error", {
+        destructure: "never",
+      },
+    ],
     "vue/enforce-style-attribute": "error",
     "vue/html-button-has-type": "error",
     "vue/html-comment-content-newline": "error",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enforced a new rule to disallow destructuring of `defineProps` in Vue components, helping maintain consistent code style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->