### PR TITLE
fix(eslint): add rule for no unnecessary type conversion in TypeScript

### DIFF
--- a/config/eslint/flat-configs/eslint.typescript-config.ts
+++ b/config/eslint/flat-configs/eslint.typescript-config.ts
@@ -153,6 +153,7 @@ const ESLINT_TYPESCRIPT_CONFIG = {
     "@typescript-eslint/no-unnecessary-type-arguments": "error",
     "@typescript-eslint/no-unnecessary-type-assertion": "error",
     "@typescript-eslint/no-unnecessary-type-constraint": "error",
+    "@typescript-eslint/no-unnecessary-type-conversion": "error",
     "@typescript-eslint/no-unnecessary-type-parameters": "error",
     "@typescript-eslint/no-unsafe-argument": "error",
     "@typescript-eslint/no-unsafe-assignment": "error",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated linting rules to enforce error-level checks for unnecessary type conversions in TypeScript code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->