### PR TITLE
ci(changelog): simplify release changelog generation script

### DIFF
--- a/.github/workflows/upsert-pr-release.yml
+++ b/.github/workflows/upsert-pr-release.yml
@@ -80,11 +80,7 @@ jobs:
 
       - name: Get next release version and create release changelog 🏷️
         id: release
-        run: |
-          npx semantic-release --dry-run --no-ci | awk '/^## [0-9]+\.[0-9]+\.[0-9]+ \(https:\/\/github\.com\/antoinezanardi/ {if (found) exit; found=1} found {print}' > RELEASE.md
-          awk '/^## /{header=1} header{print; header=0; next} {sub(/^ */, ""); sub(/ \(.+?\)$/, ""); print}' RELEASE.md > temp.md && mv temp.md RELEASE.md
-          awk '/^\* / { sub(/^\* /, "* **"); sub(/: /, "**: ", $0) } 1' RELEASE.md > temp.md && mv temp.md RELEASE.md
-          sed -E 's/^## ([0-9]+\.[0-9]+\.[0-9]+) \(https:\/\/github\.com\/antoinezanardi\/antoinezanardi.fr\/compare\/v[0-9]+\.[0-9]+\.[0-9]+...v[0-9]+\.[0-9]+\.[0-9]+\) \(([0-9-]+)\)/## Release v\1/' RELEASE.md > temp.md && mv temp.md RELEASE.md
+        run: pnpm run script:create-release-changelog
 
       - name: Cache release changelog 🥡
         uses: actions/cache@v4


### PR DESCRIPTION
This pull request simplifies the release changelog generation step in the GitHub Actions workflow by replacing a complex inline shell script with a dedicated npm script. This improves maintainability and readability of the workflow configuration.

Workflow simplification:

* The release changelog is now generated using the `pnpm run script:create-release-changelog` command instead of a multi-step shell script, making the process more straightforward and easier to maintain. (`.github/workflows/upsert-pr-release.yml`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the release changelog generation in CI by replacing a multi-command pipeline with a single script-driven step, improving reliability and maintainability of release automation.
  * Minor formatting cleanup in a workflow step; no impact on product behavior.
  * No user-facing changes; this update only affects the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->