### PR TITLE
chore(preproduction): update deployment URL to use secrets for preproduction environment

### DIFF
--- a/.github/workflows/deploy-to-preproduction.yml
+++ b/.github/workflows/deploy-to-preproduction.yml
@@ -15,13 +15,14 @@ jobs:
     permissions:
       contents: 'read'
     runs-on: ubuntu-latest
-    environment:
-      name: preproduction
-      url: ${{ secrets.PREPRODUCTION_URL }}
     env:
+      PREPRODUCTION_URL: ${{ secrets.PREPRODUCTION_URL }}
       NUXT_PUBLIC_EMAIL: ${{ secrets.NUXT_PUBLIC_EMAIL }}
       NUXT_PUBLIC_PHONE_NUMBER: ${{ secrets.NUXT_PUBLIC_PHONE_NUMBER }}
       NUXT_PUBLIC_ADDRESS: ${{ secrets.NUXT_PUBLIC_ADDRESS }}
+    environment:
+      name: preproduction
+      url: ${{ env.PREPRODUCTION_URL }}
     steps:
       - name: Setup GitHub repository 🔧
         uses: actions/checkout@v5

--- a/.github/workflows/deploy-to-preproduction.yml
+++ b/.github/workflows/deploy-to-preproduction.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: preproduction
-      url: ${{ steps.deployment.outputs.preview-url }}
+      url: ${{ secrets.PREPRODUCTION_URL }}
     env:
       NUXT_PUBLIC_EMAIL: ${{ secrets.NUXT_PUBLIC_EMAIL }}
       NUXT_PUBLIC_PHONE_NUMBER: ${{ secrets.NUXT_PUBLIC_PHONE_NUMBER }}


### PR DESCRIPTION
This pull request updates the deployment workflow configuration for preproduction. The main change is to use a static secret for the preproduction environment URL instead of a dynamic output from a previous deployment step.

Deployment workflow update:

* [`.github/workflows/deploy-to-preproduction.yml`](diffhunk://#diff-e29630c1a475f7f9f73fb434de91f69dda29c6f5e0e55dba491edf532f8251ecL20-R20): Changed the `environment.url` value to use `${{ secrets.PREPRODUCTION_URL }}` instead of `${{ steps.deployment.outputs.preview-url }}` for greater reliability and consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched preproduction deployment to use a fixed, secret-managed preproduction URL to stabilize preview links.
  * No user-facing changes; application behavior and functionality remain unchanged during preproduction deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->