### PR TITLE
chore(coderabbit): update Conventional Commits requirements to include build and ci types

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -18,7 +18,7 @@ reviews:
   pre_merge_checks:
     title:
       mode: "error"
-      requirements: "Use Conventional Commits: type(scope)?: subject — types: feat, fix, docs, style, refactor, perf, test, chore; no period at the end."
+      requirements: "Use Conventional Commits: type(scope)?: subject — types: feat, fix, docs, style, refactor, perf, test, chore, build, ci, revert; no period at the end."
     description:
       mode: "warning"
     docstrings:


### PR DESCRIPTION
This pull request makes a minor update to the `.coderabbit.yaml` configuration file, specifically expanding the allowed Conventional Commit types for pre-merge title checks.

* Added `build`, `ci`, and `revert` to the list of accepted Conventional Commit types in the `title` requirements for pre-merge checks in `.coderabbit.yaml`.