### PR TITLE
ci(deployment): update environment names and fix variable references in deployment workflows

### DIFF
--- a/.github/workflows/deploy-to-preproduction.yml
+++ b/.github/workflows/deploy-to-preproduction.yml
@@ -13,16 +13,15 @@ jobs:
   deployment:
     name: Deploy to Vercel ⛵
     permissions:
-      contents: 'read'
+      contents: "read"
     runs-on: ubuntu-latest
     env:
-      PREPRODUCTION_URL: ${{ secrets.PREPRODUCTION_URL }}
       NUXT_PUBLIC_EMAIL: ${{ secrets.NUXT_PUBLIC_EMAIL }}
       NUXT_PUBLIC_PHONE_NUMBER: ${{ secrets.NUXT_PUBLIC_PHONE_NUMBER }}
       NUXT_PUBLIC_ADDRESS: ${{ secrets.NUXT_PUBLIC_ADDRESS }}
     environment:
-      name: preproduction
-      url: ${{ env.PREPRODUCTION_URL }}
+      name: "⛵ Preproduction"
+      url: ${{ vars.PREPRODUCTION_URL }}
     steps:
       - name: Setup GitHub repository 🔧
         uses: actions/checkout@v5
@@ -52,6 +51,6 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           working-directory: ./
-          vercel-args: '--prod'
+          vercel-args: "--prod"
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -19,6 +19,9 @@ jobs:
       NUXT_PUBLIC_EMAIL: ${{ secrets.NUXT_PUBLIC_EMAIL }}
       NUXT_PUBLIC_PHONE_NUMBER: ${{ secrets.NUXT_PUBLIC_PHONE_NUMBER }}
       NUXT_PUBLIC_ADDRESS: ${{ secrets.NUXT_PUBLIC_ADDRESS }}
+    environment:
+      name: "🚀 Production"
+      url: ${{ vars.PRODUCTION_URL }}
     steps:
       - name: Setup GitHub repository 🔧
         uses: actions/checkout@v5


### PR DESCRIPTION
This pull request updates the deployment workflow configuration for both preproduction and production environments, primarily to improve naming consistency and environment variable management. The most important changes are grouped below:

**Preproduction workflow improvements:**

* Changed the environment name in `.github/workflows/deploy-to-preproduction.yml` to `"⛵ Preproduction"` for clearer identification, and switched the environment URL to use `${{ vars.PREPRODUCTION_URL }}` instead of a secret, aligning with best practices for environment variables.
* Updated string formatting for permissions and Vercel arguments to use double quotes for consistency. [[1]](diffhunk://#diff-e29630c1a475f7f9f73fb434de91f69dda29c6f5e0e55dba491edf532f8251ecL16-R24) [[2]](diffhunk://#diff-e29630c1a475f7f9f73fb434de91f69dda29c6f5e0e55dba491edf532f8251ecL55-R54)

**Production workflow improvements:**

* Added an explicit `environment` block to `.github/workflows/deploy-to-production.yml`, setting the name to `"🚀 Production"` and the URL to `${{ vars.PRODUCTION_URL }}` for better clarity and maintainability.