### PR TITLE
fix(script): handle curl command failure in create pull request script

### DIFF
--- a/scripts/create-pull-request.sh
+++ b/scripts/create-pull-request.sh
@@ -60,7 +60,7 @@ if [ "$current_branch" = "$base_branch" ]; then
   exit 1
 fi
 
-pr_url=$(curl -s "https://api.github.com/repos/$username/$repository/pulls?head=$username:$current_branch&base=$base_branch" | grep -Eo "https://github.com/$username/$repository/pull/[0-9]+" | head -n 1)
+pr_url=$(curl -s "https://api.github.com/repos/$username/$repository/pulls?head=$username:$current_branch&base=$base_branch" | grep -Eo "https://github.com/$username/$repository/pull/[0-9]+" | head -n 1 || true)
 
 if [ -n "$pr_url" ]; then
   echo "❌  A pull request already exists for $current_branch against $base_branch: $pr_url"

--- a/scripts/create-pull-request.sh
+++ b/scripts/create-pull-request.sh
@@ -12,8 +12,8 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-command -v curl >/dev/null 2>&1 || { echo "❌ curl is required." >&2; exit 1; }
-command -v git >/dev/null 2>&1 || { echo "❌ git is required." >&2; exit 1; }
+command -v curl >/dev/null 2>&1 || { echo "❌  curl is required." >&2; exit 1; }
+command -v git >/dev/null 2>&1 || { echo "❌  git is required." >&2; exit 1; }
 command -v ruby >/dev/null 2>&1 || echo "⚠️ ruby not found; labels/titles won't be URL-encoded."
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "❌ Not a git repository." >&2; exit 1; }
 


### PR DESCRIPTION
This pull request makes a minor improvement to the error handling in the `scripts/create-pull-request.sh` script. The change ensures that if no pull request URL is found, the script will not fail due to a command error.

* Added `|| true` to the command that assigns `pr_url`, preventing the script from exiting with an error if no matching pull request exists.