### PR TITLE
ci(deployment): update environment names in preproduction and production workflows

### DIFF
--- a/.github/workflows/deploy-to-preproduction.yml
+++ b/.github/workflows/deploy-to-preproduction.yml
@@ -20,7 +20,7 @@ jobs:
       NUXT_PUBLIC_PHONE_NUMBER: ${{ secrets.NUXT_PUBLIC_PHONE_NUMBER }}
       NUXT_PUBLIC_ADDRESS: ${{ secrets.NUXT_PUBLIC_ADDRESS }}
     environment:
-      name: ⛵ Preproduction
+      name: Staging
       url: ${{ vars.PREPRODUCTION_URL }}
     steps:
       - name: Setup GitHub repository 🔧

--- a/.github/workflows/deploy-to-preproduction.yml
+++ b/.github/workflows/deploy-to-preproduction.yml
@@ -1,4 +1,4 @@
-name: ⛵️ Deploy To Preproduction Workflow
+name: ⛵️ Deploy To Staging Workflow
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
       NUXT_PUBLIC_ADDRESS: ${{ secrets.NUXT_PUBLIC_ADDRESS }}
     environment:
       name: Staging
-      url: ${{ vars.PREPRODUCTION_URL }}
+      url: ${{ vars.STAGING_URL }}
     steps:
       - name: Setup GitHub repository 🔧
         uses: actions/checkout@v5

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -20,7 +20,7 @@ jobs:
       NUXT_PUBLIC_PHONE_NUMBER: ${{ secrets.NUXT_PUBLIC_PHONE_NUMBER }}
       NUXT_PUBLIC_ADDRESS: ${{ secrets.NUXT_PUBLIC_ADDRESS }}
     environment:
-      name: 🚀 Production
+      name: Production
       url: ${{ vars.PRODUCTION_URL }}
     steps:
       - name: Setup GitHub repository 🔧


### PR DESCRIPTION
This pull request updates the environment names in the deployment workflow configuration files to use standardized naming without emojis. This helps keep the environment names consistent and improves clarity in deployment logs and dashboards.

Deployment workflow updates:

* [`.github/workflows/deploy-to-preproduction.yml`](diffhunk://#diff-e29630c1a475f7f9f73fb434de91f69dda29c6f5e0e55dba491edf532f8251ecL23-R23): Changed the environment name from "⛵ Preproduction" to "Staging".
* [`.github/workflows/deploy-to-production.yml`](diffhunk://#diff-723e855b03462c134e09828f2fba9f5d7af026a7362efa4a140d04e85c47db3bL23-R23): Changed the environment name from "🚀 Production" to "Production".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Standardized deployment environment labels: "Preproduction" is now labeled "Staging," and the Production label no longer includes an emoji.
  * Clarifies naming in deployment dashboards, checks, environment views, and notifications.
  * No functional changes to permissions, URLs, deployment steps, or release processes; behavior remains unchanged for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->