### PR TITLE
chore(coderabbit): add bots to ignore list in configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -31,9 +31,9 @@ reviews:
       - "develop"
     auto_incremental_review: true
     ignore_usernames:
-      - renovate[bot]
-      - dependabot[bot]
-      - github-actions[bot]
+      - "renovate[bot]"
+      - "dependabot[bot]"
+      - "github-actions[bot]"
   tools:
     eslint:
       enabled: true


### PR DESCRIPTION
This pull request updates the review configuration in `.coderabbit.yaml` to improve automation and reduce noise from bot-generated pull requests. The most significant change is the addition of a new setting to ignore certain bot usernames during the review process.

Configuration improvements:

* Added an `ignore_usernames` section to the `reviews` configuration, specifying `renovate[bot]`, `dependabot[bot]`, and `github-actions[bot]` to be ignored by automated reviews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated automated review configuration to ignore activity from common bot accounts (Renovate, Dependabot, GitHub Actions). This change reduces noise in pull request reviews and helps prioritize human-authored changes. No changes to product features, performance, or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->