### PR TITLE
ci(build): skip SonarQube checks for Renovate bot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -337,6 +337,7 @@ jobs:
       pull-requests: write
     needs:
       - unit-tests
+    if: github.actor != 'renovate[bot]'
     steps:
       - name: Checkout GitHub repository 📡
         uses: actions/checkout@v5


### PR DESCRIPTION
This pull request introduces a conditional check to the build workflow to prevent the job from running when triggered by the `renovate[bot]` user.

Workflow improvements:

* Added an `if: github.actor != 'renovate[bot]'` condition to the `jobs:` section in `.github/workflows/build.yml` to skip the job when the actor is Renovate bot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflow by conditionally skipping code analysis on automated dependency update pull requests, reducing unnecessary runs and speeding up pipeline feedback for maintainers.
  * Streamlines checks without altering build steps or introducing new jobs, improving overall CI efficiency.
  * No user-facing changes; application functionality and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->