### PR TITLE
chore(package): update node engine requirement to >=22

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "vue-tsc": "3.1.0"
   },
   "engines": {
-    "node": ">=24.9.0"
+    "node": ">=22"
   },
   "os": [
     "darwin",


### PR DESCRIPTION
This pull request makes a small update to the minimum required Node.js version in the `package.json` file. The change lowers the minimum version from 24.9.0 to 22.

* Lowered the minimum required Node.js version in the `engines.node` field of `package.json` from 24.9.0 to 22.