### PR TITLE
chore(eslint): update stylistic rules for arrow functions and quotes

### DIFF
--- a/config/eslint/flat-configs/eslint.stylistic-config.ts
+++ b/config/eslint/flat-configs/eslint.stylistic-config.ts
@@ -87,7 +87,7 @@ const ESLINT_STYLISTIC_CONFIG = {
       "all",
       {
         returnAssign: false,
-        enforceForArrowConditionals: false,
+        ignoredNodes: ["ArrowFunctionExpression"],
       },
     ],
     "@stylistic/no-extra-semi": "error",
@@ -138,7 +138,7 @@ const ESLINT_STYLISTIC_CONFIG = {
       },
     ],
     "@stylistic/quote-props": ["error", "consistent-as-needed"],
-    "@stylistic/quotes": ["error", "double", { allowTemplateLiterals: true }],
+    "@stylistic/quotes": ["error", "double", { allowTemplateLiterals: "always" }],
     "@stylistic/rest-spread-spacing": "error",
     "@stylistic/semi": ["error", "always"],
     "@stylistic/semi-spacing": "error",


### PR DESCRIPTION
This pull request makes targeted updates to the ESLint stylistic configuration to refine how specific linting rules are applied, particularly around arrow functions and the use of template literals.

ESLint stylistic rule adjustments:

* Changed the `@stylistic/no-return-assign` rule to ignore `ArrowFunctionExpression` nodes, which prevents the rule from flagging return assignments within arrow functions.
* Updated the `@stylistic/quotes` rule to always allow template literals, providing more flexibility in string formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated stylistic linting settings to improve code consistency, refining handling of parentheses in arrow functions and standardizing template literal usage. This reduces lint noise and aligns editor/CI feedback.
  - No user-facing changes or API modifications; impact is limited to development workflows. Developers may notice fewer false positives and clearer guidance during code reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->