### PR TITLE
ci(env): correct environment variable references in CI configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,12 @@ jobs:
   build:
     name: Build ✨
     runs-on: ubuntu-latest
+    env:
+      NUXT_PUBLIC_EMAIL: ${{ secrets.NUXT_PUBLIC_EMAIL }}
+      NUXT_PUBLIC_PHONE_NUMBER: ${{ secrets.NUXT_PUBLIC_PHONE_NUMBER }}
+      NUXT_PUBLIC_ADDRESS: ${{ secrets.NUXT_PUBLIC_ADDRESS }}
+      NUXT_SITE_NAME: ${{ vars.STAGING_SITE_NAME }}
+      NUXT_SITE_URL: ${{ vars.STAGING_URL }}
     needs:
       - install
     steps:

--- a/.github/workflows/deploy-to-preproduction.yml
+++ b/.github/workflows/deploy-to-preproduction.yml
@@ -19,7 +19,7 @@ jobs:
       NUXT_PUBLIC_EMAIL: ${{ secrets.NUXT_PUBLIC_EMAIL }}
       NUXT_PUBLIC_PHONE_NUMBER: ${{ secrets.NUXT_PUBLIC_PHONE_NUMBER }}
       NUXT_PUBLIC_ADDRESS: ${{ secrets.NUXT_PUBLIC_ADDRESS }}
-      NUXT_SITE_NAME: ${{ secrets.STAGING_SITE_NAME }}
+      NUXT_SITE_NAME: ${{ vars.STAGING_SITE_NAME }}
       NUXT_SITE_URL: ${{ vars.STAGING_URL }}
     environment:
       name: Staging

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -19,7 +19,7 @@ jobs:
       NUXT_PUBLIC_EMAIL: ${{ secrets.NUXT_PUBLIC_EMAIL }}
       NUXT_PUBLIC_PHONE_NUMBER: ${{ secrets.NUXT_PUBLIC_PHONE_NUMBER }}
       NUXT_PUBLIC_ADDRESS: ${{ secrets.NUXT_PUBLIC_ADDRESS }}
-      NUXT_SITE_NAME: ${{ secrets.PRODUCTION_SITE_NAME }}
+      NUXT_SITE_NAME: ${{ vars.PRODUCTION_SITE_NAME }}
       NUXT_SITE_URL: ${{ vars.PRODUCTION_URL }}
     environment:
       name: Production


### PR DESCRIPTION
This pull request updates the way environment variables are set in GitHub Actions workflow files, specifically for the build, preproduction, and production deployment jobs. The main improvement is switching from using repository secrets to using repository or environment variables for certain site configuration values, which simplifies management and aligns with best practices.

Environment variable management:

* Updated `NUXT_SITE_NAME` and `NUXT_SITE_URL` in `.github/workflows/build.yml` to use `${{ vars.STAGING_SITE_NAME }}` and `${{ vars.STAGING_URL }}` instead of secrets, and added other public-facing environment variables for email, phone number, and address.
* Changed `NUXT_SITE_NAME` in `.github/workflows/deploy-to-preproduction.yml` from `${{ secrets.STAGING_SITE_NAME }}` to `${{ vars.STAGING_SITE_NAME }}` for consistency and easier management.
* Changed `NUXT_SITE_NAME` in `.github/workflows/deploy-to-production.yml` from `${{ secrets.PRODUCTION_SITE_NAME }}` to `${{ vars.PRODUCTION_SITE_NAME }}` for improved configuration management.