### PR TITLE
feat(profile): preload profile picture for faster loading

### DIFF
--- a/app/components/MyProfile/MyProfile.vue
+++ b/app/components/MyProfile/MyProfile.vue
@@ -22,6 +22,7 @@
                   id="profile-pic"
                   :alt="$t('MyProfile.profilePicture')"
                   height="180"
+                  preload
                   src="/images/antoine.webp"
                   width="180"
                 />

--- a/tests/stryker/incremental/incremental.json
+++ b/tests/stryker/incremental/incremental.json
@@ -30,13 +30,13 @@
           "static": false,
           "testsCompleted": 3,
           "killedBy": [
-            "108"
+            "133"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109"
+            "131",
+            "132",
+            "133",
+            "134"
           ],
           "location": {
             "end": {
@@ -58,13 +58,13 @@
           "static": false,
           "testsCompleted": 3,
           "killedBy": [
-            "108"
+            "133"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109"
+            "131",
+            "132",
+            "133",
+            "134"
           ],
           "location": {
             "end": {
@@ -86,13 +86,13 @@
           "static": false,
           "testsCompleted": 3,
           "killedBy": [
-            "108"
+            "133"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109"
+            "131",
+            "132",
+            "133",
+            "134"
           ],
           "location": {
             "end": {
@@ -106,34 +106,6 @@
           }
         },
         {
-          "id": "1",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected 1st \"spy\" call to have been called with [ { title: 'App.meta.title', …(2) } ]",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 3,
-          "killedBy": [
-            "108"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109"
-          ],
-          "location": {
-            "end": {
-              "column": 28,
-              "line": 37
-            },
-            "start": {
-              "column": 12,
-              "line": 37
-            }
-          }
-        },
-        {
           "id": "4",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
@@ -142,13 +114,13 @@
           "static": false,
           "testsCompleted": 3,
           "killedBy": [
-            "108"
+            "133"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109"
+            "131",
+            "132",
+            "133",
+            "134"
           ],
           "location": {
             "end": {
@@ -162,6 +134,34 @@
           }
         },
         {
+          "id": "1",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected 1st \"spy\" call to have been called with [ { title: 'App.meta.title', …(2) } ]",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "133"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134"
+          ],
+          "location": {
+            "end": {
+              "column": 28,
+              "line": 37
+            },
+            "start": {
+              "column": 12,
+              "line": 37
+            }
+          }
+        },
+        {
           "id": "5",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
@@ -170,13 +170,13 @@
           "static": false,
           "testsCompleted": 3,
           "killedBy": [
-            "108"
+            "133"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109"
+            "131",
+            "132",
+            "133",
+            "134"
           ],
           "location": {
             "end": {
@@ -198,13 +198,13 @@
           "static": false,
           "testsCompleted": 3,
           "killedBy": [
-            "108"
+            "133"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109"
+            "131",
+            "132",
+            "133",
+            "134"
           ],
           "location": {
             "end": {
@@ -226,13 +226,13 @@
           "static": false,
           "testsCompleted": 2,
           "killedBy": [
-            "107"
+            "132"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109"
+            "131",
+            "132",
+            "133",
+            "134"
           ],
           "location": {
             "end": {
@@ -254,13 +254,13 @@
           "static": false,
           "testsCompleted": 4,
           "killedBy": [
-            "109"
+            "134"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109"
+            "131",
+            "132",
+            "133",
+            "134"
           ],
           "location": {
             "end": {
@@ -282,13 +282,13 @@
           "static": false,
           "testsCompleted": 4,
           "killedBy": [
-            "109"
+            "134"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109"
+            "131",
+            "132",
+            "133",
+            "134"
           ],
           "location": {
             "end": {
@@ -310,13 +310,13 @@
           "static": false,
           "testsCompleted": 1,
           "killedBy": [
-            "106"
+            "131"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109"
+            "131",
+            "132",
+            "133",
+            "134"
           ],
           "location": {
             "end": {
@@ -331,10360 +331,6 @@
         }
       ],
       "source": "<template>\n  <div>\n    <NavBar/>\n\n    <main class=\"app-content\">\n      <MyProfile/>\n\n      <AboutMe/>\n\n      <MySkills/>\n\n      <MyPortfolio/>\n\n      <MyExperience/>\n\n      <MyEducation/>\n\n      <PageFooter/>\n    </main>\n  </div>\n</template>\n\n<script lang=\"ts\" setup>\nimport aos from \"aos\";\nimport { stampInHtml } from \"dev-stamp\";\n\nimport { AboutMe, MyProfile, MySkills, MyPortfolio, MyExperience, MyEducation, PageFooter, NavBar } from \"#components\";\nimport { onMounted, useNuxtApp, useHead, defineOgImageComponent } from \"#imports\";\nimport { useAppSchemaOrg } from \"~/composables/useAppSchemaOrg\";\n\nconst { t, locale } = useI18n();\nconst { $bootstrap } = useNuxtApp();\n\nconst { setupAppSchemaOrg } = useAppSchemaOrg();\n\nuseHead({\n  title: t(\"App.meta.title\"),\n  meta: [{ name: \"description\", content: t(\"App.meta.description\") }],\n  htmlAttrs: { lang: locale.value },\n});\n\nsetupAppSchemaOrg();\n\ndefineOgImageComponent(\"DefaultOgImage\");\n\nonMounted(() => {\n  aos.init();\n  const tooltipTriggerList = document.querySelectorAll(\"[data-bs-toggle=\\\"tooltip\\\"]\");\n  // Stryker disable next-line all\n  tooltipTriggerList.forEach((tooltip: Element) => new $bootstrap.Tooltip(tooltip));\n  stampInHtml(\"👋 Hey ! J'ai aussi créé 💮 `dev-stamp` qui a généré ce message ! Retrouvez le sur GitHub ou npm !\");\n});\n</script>"
-    },
-    "app/components/AboutMe/AboutMyPersonalInfo/AboutMyPersonalInfo.vue": {
-      "language": "html",
-      "mutants": [
-        {
-          "id": "12",
-          "mutatorName": "BlockStatement",
-          "replacement": "{}",
-          "statusReason": "Snapshot `AboutMyPersonalInfo Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "59"
-          ],
-          "coveredBy": [
-            "59",
-            "60",
-            "61",
-            "62",
-            "63"
-          ],
-          "location": {
-            "end": {
-              "column": 2,
-              "line": 199
-            },
-            "start": {
-              "column": 36,
-              "line": 194
-            }
-          }
-        },
-        {
-          "id": "13",
-          "mutatorName": "ArithmeticOperator",
-          "replacement": "new Date(Date.now() - birthday.getTime()).getUTCFullYear() + epochYear",
-          "statusReason": "Snapshot `AboutMyPersonalInfo Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "59"
-          ],
-          "coveredBy": [
-            "59",
-            "60",
-            "61",
-            "62",
-            "63"
-          ],
-          "location": {
-            "end": {
-              "column": 80,
-              "line": 198
-            },
-            "start": {
-              "column": 10,
-              "line": 198
-            }
-          }
-        },
-        {
-          "id": "14",
-          "mutatorName": "ArithmeticOperator",
-          "replacement": "Date.now() + birthday.getTime()",
-          "statusReason": "Snapshot `AboutMyPersonalInfo Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "59"
-          ],
-          "coveredBy": [
-            "59",
-            "60",
-            "61",
-            "62",
-            "63"
-          ],
-          "location": {
-            "end": {
-              "column": 50,
-              "line": 198
-            },
-            "start": {
-              "column": 19,
-              "line": 198
-            }
-          }
-        },
-        {
-          "id": "15",
-          "mutatorName": "BlockStatement",
-          "replacement": "{}",
-          "statusReason": "Snapshot `AboutMyPersonalInfo Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "59"
-          ],
-          "coveredBy": [
-            "59",
-            "60",
-            "61",
-            "62",
-            "63"
-          ],
-          "location": {
-            "end": {
-              "column": 2,
-              "line": 205
-            },
-            "start": {
-              "column": 53,
-              "line": 201
-            }
-          }
-        },
-        {
-          "id": "16",
-          "mutatorName": "Regex",
-          "replacement": "/./gu",
-          "statusReason": "Snapshot `AboutMyPersonalInfo Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "59"
-          ],
-          "coveredBy": [
-            "59",
-            "60",
-            "61",
-            "62",
-            "63"
-          ],
-          "location": {
-            "end": {
-              "column": 59,
-              "line": 202
-            },
-            "start": {
-              "column": 51,
-              "line": 202
-            }
-          }
-        },
-        {
-          "id": "17",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Snapshot `AboutMyPersonalInfo Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "59"
-          ],
-          "coveredBy": [
-            "59",
-            "60",
-            "61",
-            "62",
-            "63"
-          ],
-          "location": {
-            "end": {
-              "column": 36,
-              "line": 204
-            },
-            "start": {
-              "column": 33,
-              "line": 204
-            }
-          }
-        },
-        {
-          "id": "18",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected '' to be '?' // Object.is equality",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "62"
-          ],
-          "coveredBy": [
-            "62"
-          ],
-          "location": {
-            "end": {
-              "column": 43,
-              "line": 204
-            },
-            "start": {
-              "column": 40,
-              "line": 204
-            }
-          }
-        }
-      ],
-      "source": "<template>\n  <div>\n    <div class=\"card-body\">\n      <h3 class=\"h3 mb-2 mt-0 title\">\n        <WrappedFontAwesomeIcon\n          classes=\"me-2\"\n          icon=\"fa-id-card\"\n        />\n\n        <span>\n          {{ $t('AboutMyPersonalInfo.personalInfo') }}\n        </span>\n      </h3>\n\n      <hr>\n\n      <div class=\"row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.genre')} :` }}\n          </b>\n        </div>\n\n        <div\n          id=\"genre\"\n          class=\"col-sm-8\"\n        >\n          {{ $t('AboutMyPersonalInfo.male') }}\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.age')} :` }}\n          </b>\n        </div>\n\n        <div\n          id=\"age\"\n          class=\"col-sm-8\"\n        >\n          {{ $t('AboutMyPersonalInfo.yearsOld', { age }) }}\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.email')} :` }}\n          </b>\n        </div>\n\n        <div class=\"col-sm-8\">\n          <b>\n            <a\n              :aria-label=\"$t('AboutMyPersonalInfo.emailLink', { 'email': config.public.email })\"\n              :href=\"`mailto:${config.public.email}`\"\n            >\n              {{ config.public.email }}\n            </a>\n          </b>\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.phone')} :` }}\n          </b>\n        </div>\n\n        <div class=\"col-sm-8\">\n          <b>\n            <a\n              id=\"phone-number\"\n              :aria-label=\"$t('AboutMyPersonalInfo.phoneLink', { 'phone': formattedPhoneNumber })\"\n              :href=\"`tel:${config.public.phoneNumber}`\"\n            >\n              {{ formattedPhoneNumber }}\n            </a>\n          </b>\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.address')} :` }}\n          </b>\n        </div>\n\n        <div\n          id=\"address\"\n          class=\"col-sm-8\"\n        >\n          {{ config.public.address }}\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.languages')} :` }}\n          </b>\n        </div>\n\n        <div\n          class=\"col-sm-8\"\n        >\n          {{ $t('AboutMyPersonalInfo.englishAndFrench') }}\n        </div>\n      </div>\n\n      <div class=\"align-items-center mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.licenses')} :` }}\n          </b>\n        </div>\n\n        <div class=\"col-sm-8 d-flex\">\n          <WrappedFontAwesomeIcon\n            :aria-label=\"$t('AboutMyPersonalInfo.car')\"\n            class=\"me-2\"\n            data-bs-toggle=\"tooltip\"\n            icon=\"fa-car\"\n            role=\"img\"\n            size=\"2x\"\n            :title=\"$t('AboutMyPersonalInfo.car')\"\n          />\n\n          <WrappedFontAwesomeIcon\n            :aria-label=\"$t('AboutMyPersonalInfo.boat')\"\n            class=\"me-2\"\n            data-bs-toggle=\"tooltip\"\n            icon=\"fa-anchor\"\n            role=\"img\"\n            size=\"2x\"\n            :title=\"$t('AboutMyPersonalInfo.boat')\"\n          />\n        </div>\n      </div>\n\n      <div class=\"align-items-center mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.workingAt')} :` }}\n          </b>\n        </div>\n\n        <div class=\"col-sm-8\">\n          <a\n            :aria-label=\"$t('AboutMyPersonalInfo.companyLink', { 'company': 'Daveo' })\"\n            href=\"https://www.daveo.fr/\"\n            rel=\"noopener noreferrer\"\n            target=\"_blank\"\n          >\n            <NuxtImg\n              alt=\"Daveo\"\n              class=\"daveo-logo\"\n              loading=\"lazy\"\n              src=\"/images/logos/daveo-logo.webp\"\n            />\n          </a>\n        </div>\n      </div>\n    </div>\n  </div>\n</template>\n\n<script setup lang=\"ts\">\nimport WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\nimport { ANTOINE_ZANARDI_BIRTH_DATE } from \"~/shared/constants/antoine-zanardi.constants\";\n\nconst config = useRuntimeConfig();\n\nconst age = computed<number>(() => {\n  const birthday = new Date(ANTOINE_ZANARDI_BIRTH_DATE);\n  const epochYear = 1970;\n\n  return new Date(Date.now() - birthday.getTime()).getUTCFullYear() - epochYear;\n});\n\nconst formattedPhoneNumber = computed<string>(() => {\n  const matches = config.public.phoneNumber.match(/.{2}/gu);\n\n  return matches ? matches.join(\" \") : \"?\";\n});\n</script>\n\n<style lang=\"scss\" scoped>\n.daveo-logo {\n  margin-left: -5px;\n  width: 150px;\n}\n</style>"
-    },
-    "app/components/MyEducation/EducationDegreeCard/EducationDegreeCard.vue": {
-      "language": "html",
-      "mutants": [
-        {
-          "id": "19",
-          "mutatorName": "ArrowFunction",
-          "replacement": "() => undefined",
-          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "45"
-          ],
-          "coveredBy": [
-            "45",
-            "46",
-            "47",
-            "48",
-            "49",
-            "50",
-            "51",
-            "52",
-            "53",
-            "54",
-            "55",
-            "56",
-            "57",
-            "58"
-          ],
-          "location": {
-            "end": {
-              "column": 101,
-              "line": 74
-            },
-            "start": {
-              "column": 38,
-              "line": 74
-            }
-          }
-        },
-        {
-          "id": "20",
-          "mutatorName": "LogicalOperator",
-          "replacement": "props.educationDegree.school.image && \"college-icon.webp\"",
-          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "45"
-          ],
-          "coveredBy": [
-            "45",
-            "46",
-            "47",
-            "48",
-            "49",
-            "50",
-            "51",
-            "52",
-            "53",
-            "54",
-            "55",
-            "56",
-            "57",
-            "58"
-          ],
-          "location": {
-            "end": {
-              "column": 101,
-              "line": 74
-            },
-            "start": {
-              "column": 44,
-              "line": 74
-            }
-          }
-        },
-        {
-          "id": "21",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected '' to be 'college-icon.webp' // Object.is equality",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "51"
-          ],
-          "coveredBy": [
-            "51"
-          ],
-          "location": {
-            "end": {
-              "column": 101,
-              "line": 74
-            },
-            "start": {
-              "column": 82,
-              "line": 74
-            }
-          }
-        },
-        {
-          "id": "22",
-          "mutatorName": "BlockStatement",
-          "replacement": "{}",
-          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "45"
-          ],
-          "coveredBy": [
-            "45",
-            "46",
-            "47",
-            "48",
-            "49",
-            "50",
-            "51",
-            "52",
-            "53",
-            "54",
-            "55",
-            "56",
-            "57",
-            "58"
-          ],
-          "location": {
-            "end": {
-              "column": 2,
-              "line": 83
-            },
-            "start": {
-              "column": 44,
-              "line": 76
-            }
-          }
-        },
-        {
-          "id": "23",
-          "mutatorName": "LogicalOperator",
-          "replacement": "school.translatedName && \"?\"",
-          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "45"
-          ],
-          "coveredBy": [
-            "45",
-            "46",
-            "47",
-            "48",
-            "49",
-            "50",
-            "51",
-            "52",
-            "53",
-            "54",
-            "55",
-            "56",
-            "57",
-            "58"
-          ],
-          "location": {
-            "end": {
-              "column": 43,
-              "line": 78
-            },
-            "start": {
-              "column": 15,
-              "line": 78
-            }
-          }
-        },
-        {
-          "id": "24",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected '' to be '?' // Object.is equality",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "56"
-          ],
-          "coveredBy": [
-            "50",
-            "51",
-            "56"
-          ],
-          "location": {
-            "end": {
-              "column": 43,
-              "line": 78
-            },
-            "start": {
-              "column": 40,
-              "line": 78
-            }
-          }
-        },
-        {
-          "id": "25",
-          "mutatorName": "ConditionalExpression",
-          "replacement": "true",
-          "statusReason": "expected 'Schools.epitech, undefined' to be 'Schools.epitech' // Object.is equality",
-          "status": "Killed",
-          "testsCompleted": 11,
-          "static": false,
-          "killedBy": [
-            "55"
-          ],
-          "coveredBy": [
-            "45",
-            "46",
-            "47",
-            "48",
-            "49",
-            "50",
-            "51",
-            "52",
-            "53",
-            "54",
-            "55",
-            "56",
-            "57",
-            "58"
-          ],
-          "location": {
-            "end": {
-              "column": 32,
-              "line": 79
-            },
-            "start": {
-              "column": 7,
-              "line": 79
-            }
-          }
-        },
-        {
-          "id": "26",
-          "mutatorName": "ConditionalExpression",
-          "replacement": "false",
-          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "45"
-          ],
-          "coveredBy": [
-            "45",
-            "46",
-            "47",
-            "48",
-            "49",
-            "50",
-            "51",
-            "52",
-            "53",
-            "54",
-            "55",
-            "56",
-            "57",
-            "58"
-          ],
-          "location": {
-            "end": {
-              "column": 32,
-              "line": 79
-            },
-            "start": {
-              "column": 7,
-              "line": 79
-            }
-          }
-        },
-        {
-          "id": "27",
-          "mutatorName": "EqualityOperator",
-          "replacement": "school.city === undefined",
-          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "45"
-          ],
-          "coveredBy": [
-            "45",
-            "46",
-            "47",
-            "48",
-            "49",
-            "50",
-            "51",
-            "52",
-            "53",
-            "54",
-            "55",
-            "56",
-            "57",
-            "58"
-          ],
-          "location": {
-            "end": {
-              "column": 32,
-              "line": 79
-            },
-            "start": {
-              "column": 7,
-              "line": 79
-            }
-          }
-        },
-        {
-          "id": "28",
-          "mutatorName": "BlockStatement",
-          "replacement": "{}",
-          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "45"
-          ],
-          "coveredBy": [
-            "45",
-            "46",
-            "47",
-            "48",
-            "49",
-            "50",
-            "51",
-            "52",
-            "53",
-            "54",
-            "55",
-            "56",
-            "57",
-            "58"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 81
-            },
-            "start": {
-              "column": 34,
-              "line": 79
-            }
-          }
-        },
-        {
-          "id": "29",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "45"
-          ],
-          "coveredBy": [
-            "45",
-            "46",
-            "47",
-            "48",
-            "49",
-            "50",
-            "51",
-            "52",
-            "53",
-            "54",
-            "55",
-            "56",
-            "57",
-            "58"
-          ],
-          "location": {
-            "end": {
-              "column": 32,
-              "line": 80
-            },
-            "start": {
-              "column": 14,
-              "line": 80
-            }
-          }
-        },
-        {
-          "id": "30",
-          "mutatorName": "ArrowFunction",
-          "replacement": "() => undefined",
-          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "45"
-          ],
-          "coveredBy": [
-            "45",
-            "46",
-            "47",
-            "48",
-            "49",
-            "50",
-            "51",
-            "52",
-            "53",
-            "54",
-            "55",
-            "56",
-            "57",
-            "58"
-          ],
-          "location": {
-            "end": {
-              "column": 97,
-              "line": 85
-            },
-            "start": {
-              "column": 41,
-              "line": 85
-            }
-          }
-        },
-        {
-          "id": "31",
-          "mutatorName": "LogicalOperator",
-          "replacement": "props.educationDegree.school.translatedName && \"?\"",
-          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "45"
-          ],
-          "coveredBy": [
-            "45",
-            "46",
-            "47",
-            "48",
-            "49",
-            "50",
-            "51",
-            "52",
-            "53",
-            "54",
-            "55",
-            "56",
-            "57",
-            "58"
-          ],
-          "location": {
-            "end": {
-              "column": 97,
-              "line": 85
-            },
-            "start": {
-              "column": 47,
-              "line": 85
-            }
-          }
-        },
-        {
-          "id": "32",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected '' to be '?' // Object.is equality",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "50"
-          ],
-          "coveredBy": [
-            "50",
-            "51",
-            "56"
-          ],
-          "location": {
-            "end": {
-              "column": 97,
-              "line": 85
-            },
-            "start": {
-              "column": 94,
-              "line": 85
-            }
-          }
-        },
-        {
-          "id": "33",
-          "mutatorName": "BlockStatement",
-          "replacement": "{}",
-          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "45"
-          ],
-          "coveredBy": [
-            "45",
-            "46",
-            "47",
-            "48",
-            "49",
-            "50",
-            "51",
-            "52",
-            "53",
-            "54",
-            "55",
-            "56",
-            "57",
-            "58"
-          ],
-          "location": {
-            "end": {
-              "column": 2,
-              "line": 94
-            },
-            "start": {
-              "column": 53,
-              "line": 87
-            }
-          }
-        },
-        {
-          "id": "34",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "45"
-          ],
-          "coveredBy": [
-            "45",
-            "46",
-            "47",
-            "48",
-            "49",
-            "50",
-            "51",
-            "52",
-            "53",
-            "54",
-            "55",
-            "56",
-            "57",
-            "58"
-          ],
-          "location": {
-            "end": {
-              "column": 59,
-              "line": 90
-            },
-            "start": {
-              "column": 12,
-              "line": 90
-            }
-          }
-        },
-        {
-          "id": "35",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "45"
-          ],
-          "coveredBy": [
-            "45",
-            "46",
-            "47",
-            "48",
-            "49",
-            "50",
-            "51",
-            "52",
-            "53",
-            "54",
-            "55",
-            "56",
-            "57",
-            "58"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 93
-            },
-            "start": {
-              "column": 61,
-              "line": 90
-            }
-          }
-        }
-      ],
-      "source": "<template>\n  <div class=\"card\">\n    <div class=\"row\">\n      <div\n        class=\"background-primary col-md-3\"\n        data-aos=\"fade-right\"\n        data-aos-duration=\"500\"\n        data-aos-offset=\"50\"\n      >\n        <div class=\"card-body cc-education-header\">\n          <PeriodTimeline\n            class=\"education-timeline\"\n            does-show-year-only\n            :finished-at=\"educationDegree.degree.obtainedAt\"\n            :image=\"schoolImage\"\n            :image-alt=\"schoolImageAlt\"\n            :period-dates-aria-label=\"periodDatesAriaLabel\"\n            :started-at=\"educationDegree.degree.startedAt\"\n            :url=\"educationDegree.school.url\"\n          />\n        </div>\n      </div>\n\n      <div\n        class=\"col-md-9\"\n        data-aos=\"fade-left\"\n        data-aos-duration=\"500\"\n        data-aos-offset=\"50\"\n      >\n        <div class=\"card-body\">\n          <h3\n            class=\"degree-name font-weight-bold h4 mb-2 mt-0\"\n          >\n            {{ educationDegree.degree.name }}\n          </h3>\n\n          <div class=\"d-flex\">\n            <p\n              class=\"category font-weight-bold mb-0 school-name\"\n            >\n              {{ schoolLabel }}\n            </p>\n\n            <CountryFlag\n              class=\"ms-2 school-flag\"\n              :country=\"educationDegree.school.country\"\n            />\n          </div>\n\n          <hr>\n\n          <p\n            v-for=\"(paragraph, index) in educationDegree.degree.description\"\n            :key=\"index\"\n            class=\"degree-description\"\n          >\n            {{ paragraph }}\n          </p>\n        </div>\n      </div>\n    </div>\n  </div>\n</template>\n\n<script lang=\"ts\" setup>\nimport type { EducationDegreeCardProps } from \"~/components/MyEducation/EducationDegreeCard/education-degree-card.types\";\nimport CountryFlag from \"~/components/shared/Images/CountryFlag/CountryFlag.vue\";\nimport PeriodTimeline from \"~/components/shared/Period/PeriodTimeline.vue\";\n\nconst props = defineProps<EducationDegreeCardProps>();\n\nconst { t } = useI18n();\n\nconst schoolImage = computed<string>(() => props.educationDegree.school.image ?? \"college-icon.webp\");\n\nconst schoolLabel = computed<string>(() => {\n  const { school } = props.educationDegree;\n  let label = school.translatedName ?? \"?\";\n  if (school.city !== undefined) {\n    label += `, ${school.city}`;\n  }\n  return label;\n});\n\nconst schoolImageAlt = computed<string>(() => props.educationDegree.school.translatedName ?? \"?\");\n\nconst periodDatesAriaLabel = computed<string>(() => {\n  const finishedAtYear = props.educationDegree.degree.obtainedAt.getFullYear().toString();\n\n  return t(\"EducationDegreeCard.degreeObtainedAtAriaLabel\", {\n    degreeName: props.educationDegree.degree.name,\n    obtainedAt: finishedAtYear,\n  });\n});\n</script>\n\n<style lang=\"scss\" scoped>\n.cc-education-header {\n  padding-top: 25px !important;\n}\n@media (max-width: 768px) {\n  .cc-education-header {\n    padding-right: 1.25rem !important;\n  }\n}\n</style>"
-    },
-    "app/components/MyEducation/MyEducation.vue": {
-      "language": "html",
-      "mutants": [
-        {
-          "id": "36",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 2,
-              "line": 96
-            },
-            "start": {
-              "column": 45,
-              "line": 35
-            }
-          }
-        },
-        {
-          "id": "37",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 46
-            },
-            "start": {
-              "column": 3,
-              "line": 36
-            }
-          }
-        },
-        {
-          "id": "38",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 41
-            },
-            "start": {
-              "column": 13,
-              "line": 37
-            }
-          }
-        },
-        {
-          "id": "39",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 31,
-              "line": 38
-            },
-            "start": {
-              "column": 15,
-              "line": 38
-            }
-          }
-        },
-        {
-          "id": "40",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "expected { degree: { …(3) }, school: { …(5) } } to strictly equal { degree: { …(3) }, school: { …(5) } }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "87"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 58,
-              "line": 39
-            },
-            "start": {
-              "column": 20,
-              "line": 39
-            }
-          }
-        },
-        {
-          "id": "41",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { degree: { …(3) }, school: { …(5) } } to strictly equal { degree: { …(3) }, school: { …(5) } }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "87"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 56,
-              "line": 39
-            },
-            "start": {
-              "column": 23,
-              "line": 39
-            }
-          }
-        },
-        {
-          "id": "42",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { degree: { …(3) }, school: { …(5) } } to strictly equal { degree: { …(3) }, school: { …(5) } }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "87"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 40,
-              "line": 40
-            },
-            "start": {
-              "column": 28,
-              "line": 40
-            }
-          }
-        },
-        {
-          "id": "43",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected { degree: { …(3) }, school: {} } to strictly equal { degree: { …(3) }, school: { …(5) } }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "87"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 45
-            },
-            "start": {
-              "column": 13,
-              "line": 42
-            }
-          }
-        },
-        {
-          "id": "44",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "expected { degree: { …(3) }, school: { …(5) } } to strictly equal { degree: { …(3) }, school: { …(5) } }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "87"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 57,
-              "line": 44
-            },
-            "start": {
-              "column": 25,
-              "line": 44
-            }
-          }
-        },
-        {
-          "id": "45",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 56
-            },
-            "start": {
-              "column": 6,
-              "line": 46
-            }
-          }
-        },
-        {
-          "id": "46",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 51
-            },
-            "start": {
-              "column": 13,
-              "line": 47
-            }
-          }
-        },
-        {
-          "id": "47",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 29,
-              "line": 48
-            },
-            "start": {
-              "column": 15,
-              "line": 48
-            }
-          }
-        },
-        {
-          "id": "48",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "expected { degree: { …(3) }, school: { …(5) } } to strictly equal { degree: { …(3) }, school: { …(5) } }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "88"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 62,
-              "line": 49
-            },
-            "start": {
-              "column": 20,
-              "line": 49
-            }
-          }
-        },
-        {
-          "id": "49",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { degree: { …(3) }, school: { …(5) } } to strictly equal { degree: { …(3) }, school: { …(5) } }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "88"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 60,
-              "line": 49
-            },
-            "start": {
-              "column": 23,
-              "line": 49
-            }
-          }
-        },
-        {
-          "id": "50",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { degree: { …(3) }, school: { …(5) } } to strictly equal { degree: { …(3) }, school: { …(5) } }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "88"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 40,
-              "line": 50
-            },
-            "start": {
-              "column": 28,
-              "line": 50
-            }
-          }
-        },
-        {
-          "id": "51",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected { degree: { …(3) }, school: {} } to strictly equal { degree: { …(3) }, school: { …(5) } }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "88"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 55
-            },
-            "start": {
-              "column": 13,
-              "line": 52
-            }
-          }
-        },
-        {
-          "id": "52",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "expected { degree: { …(3) }, school: { …(5) } } to strictly equal { degree: { …(3) }, school: { …(5) } }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "88"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 81,
-              "line": 54
-            },
-            "start": {
-              "column": 25,
-              "line": 54
-            }
-          }
-        },
-        {
-          "id": "53",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 70
-            },
-            "start": {
-              "column": 6,
-              "line": 56
-            }
-          }
-        },
-        {
-          "id": "54",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 65
-            },
-            "start": {
-              "column": 13,
-              "line": 57
-            }
-          }
-        },
-        {
-          "id": "55",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 39,
-              "line": 58
-            },
-            "start": {
-              "column": 15,
-              "line": 58
-            }
-          }
-        },
-        {
-          "id": "56",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "89"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 8,
-              "line": 62
-            },
-            "start": {
-              "column": 20,
-              "line": 59
-            }
-          }
-        },
-        {
-          "id": "57",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "89"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 49,
-              "line": 60
-            },
-            "start": {
-              "column": 11,
-              "line": 60
-            }
-          }
-        },
-        {
-          "id": "58",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "89"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 43,
-              "line": 61
-            },
-            "start": {
-              "column": 11,
-              "line": 61
-            }
-          }
-        },
-        {
-          "id": "59",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "89"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 39,
-              "line": 63
-            },
-            "start": {
-              "column": 27,
-              "line": 63
-            }
-          }
-        },
-        {
-          "id": "60",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "89"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 40,
-              "line": 64
-            },
-            "start": {
-              "column": 28,
-              "line": 64
-            }
-          }
-        },
-        {
-          "id": "61",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected { degree: { …(4) }, school: {} } to strictly equal { degree: { …(4) }, school: { …(6) } }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "89"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 69
-            },
-            "start": {
-              "column": 13,
-              "line": 66
-            }
-          }
-        },
-        {
-          "id": "62",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "89"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 58,
-              "line": 68
-            },
-            "start": {
-              "column": 25,
-              "line": 68
-            }
-          }
-        },
-        {
-          "id": "63",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 84
-            },
-            "start": {
-              "column": 6,
-              "line": 70
-            }
-          }
-        },
-        {
-          "id": "64",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 79
-            },
-            "start": {
-              "column": 13,
-              "line": 71
-            }
-          }
-        },
-        {
-          "id": "65",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 40,
-              "line": 72
-            },
-            "start": {
-              "column": 15,
-              "line": 72
-            }
-          }
-        },
-        {
-          "id": "66",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "90"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 8,
-              "line": 76
-            },
-            "start": {
-              "column": 20,
-              "line": 73
-            }
-          }
-        },
-        {
-          "id": "67",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "90"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 61,
-              "line": 74
-            },
-            "start": {
-              "column": 11,
-              "line": 74
-            }
-          }
-        },
-        {
-          "id": "68",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "90"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 45,
-              "line": 75
-            },
-            "start": {
-              "column": 11,
-              "line": 75
-            }
-          }
-        },
-        {
-          "id": "69",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "90"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 39,
-              "line": 77
-            },
-            "start": {
-              "column": 27,
-              "line": 77
-            }
-          }
-        },
-        {
-          "id": "70",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "90"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 40,
-              "line": 78
-            },
-            "start": {
-              "column": 28,
-              "line": 78
-            }
-          }
-        },
-        {
-          "id": "71",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected { degree: { …(4) }, school: {} } to strictly equal { degree: { …(4) }, school: { …(6) } }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "90"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 83
-            },
-            "start": {
-              "column": 13,
-              "line": 80
-            }
-          }
-        },
-        {
-          "id": "72",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "90"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 56,
-              "line": 82
-            },
-            "start": {
-              "column": 25,
-              "line": 82
-            }
-          }
-        },
-        {
-          "id": "73",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 95
-            },
-            "start": {
-              "column": 6,
-              "line": 84
-            }
-          }
-        },
-        {
-          "id": "74",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 90
-            },
-            "start": {
-              "column": 13,
-              "line": 85
-            }
-          }
-        },
-        {
-          "id": "75",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 42,
-              "line": 86
-            },
-            "start": {
-              "column": 15,
-              "line": 86
-            }
-          }
-        },
-        {
-          "id": "76",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "expected { degree: { …(4) }, school: { …(5) } } to strictly equal { degree: { …(4) }, school: { …(5) } }",
-          "status": "Killed",
-          "testsCompleted": 7,
-          "static": false,
-          "killedBy": [
-            "91"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 65,
-              "line": 87
-            },
-            "start": {
-              "column": 20,
-              "line": 87
-            }
-          }
-        },
-        {
-          "id": "77",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { degree: { …(4) }, school: { …(5) } } to strictly equal { degree: { …(4) }, school: { …(5) } }",
-          "status": "Killed",
-          "testsCompleted": 7,
-          "static": false,
-          "killedBy": [
-            "91"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 63,
-              "line": 87
-            },
-            "start": {
-              "column": 23,
-              "line": 87
-            }
-          }
-        },
-        {
-          "id": "78",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { degree: { …(4) }, school: { …(5) } } to strictly equal { degree: { …(4) }, school: { …(5) } }",
-          "status": "Killed",
-          "testsCompleted": 7,
-          "static": false,
-          "killedBy": [
-            "91"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 39,
-              "line": 88
-            },
-            "start": {
-              "column": 27,
-              "line": 88
-            }
-          }
-        },
-        {
-          "id": "79",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { degree: { …(4) }, school: { …(5) } } to strictly equal { degree: { …(4) }, school: { …(5) } }",
-          "status": "Killed",
-          "testsCompleted": 7,
-          "static": false,
-          "killedBy": [
-            "91"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 40,
-              "line": 89
-            },
-            "start": {
-              "column": 28,
-              "line": 89
-            }
-          }
-        },
-        {
-          "id": "80",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected { degree: { …(4) }, school: {} } to strictly equal { degree: { …(4) }, school: { …(5) } }",
-          "status": "Killed",
-          "testsCompleted": 7,
-          "static": false,
-          "killedBy": [
-            "91"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 94
-            },
-            "start": {
-              "column": 13,
-              "line": 91
-            }
-          }
-        },
-        {
-          "id": "81",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "expected { degree: { …(4) }, school: { …(5) } } to strictly equal { degree: { …(4) }, school: { …(5) } }",
-          "status": "Killed",
-          "testsCompleted": 7,
-          "static": false,
-          "killedBy": [
-            "91"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 56,
-              "line": 93
-            },
-            "start": {
-              "column": 25,
-              "line": 93
-            }
-          }
-        },
-        {
-          "id": "82",
-          "mutatorName": "BlockStatement",
-          "replacement": "{}",
-          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 2,
-              "line": 100
-            },
-            "start": {
-              "column": 90,
-              "line": 98
-            }
-          }
-        },
-        {
-          "id": "83",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 49,
-              "line": 99
-            },
-            "start": {
-              "column": 10,
-              "line": 99
-            }
-          }
-        },
-        {
-          "id": "84",
-          "mutatorName": "ArithmeticOperator",
-          "replacement": "index - 1",
-          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "85"
-          ],
-          "coveredBy": [
-            "85",
-            "86",
-            "87",
-            "88",
-            "89",
-            "90",
-            "91"
-          ],
-          "location": {
-            "end": {
-              "column": 22,
-              "line": 99
-            },
-            "start": {
-              "column": 13,
-              "line": 99
-            }
-          }
-        }
-      ],
-      "source": "<template>\n  <section\n    id=\"education\"\n    aria-labelledby=\"education-title\"\n    class=\"section\"\n  >\n    <div class=\"cc-education container\">\n      <SectionTitle\n        id=\"education-title\"\n        icon=\"fa fa-graduation-cap\"\n        icon-color=\"#F05033\"\n        :title=\"$t('MyEducation.education')\"\n      />\n\n      <EducationDegreeCard\n        v-for=\"(educationDegree, index) in educationDegrees\"\n        :key=\"index\"\n        :aria-label=\"getEducationDegreeAriaLabel(educationDegree.degree.name, index)\"\n        class=\"education-degree-card\"\n        :education-degree=\"educationDegree\"\n        role=\"region\"\n      />\n    </div>\n  </section>\n</template>\n\n<script setup lang=\"ts\">\nimport type { EducationDegree } from \"~/models/education-degree/education-degree.types\";\nimport { SCHOOLS } from \"~/models/school/school.constants\";\nimport EducationDegreeCard from \"~/components/MyEducation/EducationDegreeCard/EducationDegreeCard.vue\";\nimport SectionTitle from \"~/components/shared/Layouts/SectionTitle/SectionTitle.vue\";\n\nconst { t } = useI18n();\n\nconst educationDegrees: EducationDegree[] = [\n  {\n    degree: {\n      name: t(`Degrees.gcpACE`),\n      description: [t(\"MyEducation.gcpACECertification\")],\n      obtainedAt: new Date(\"2022-12-01\"),\n    },\n    school: {\n      ...SCHOOLS.google,\n      translatedName: t(`Schools.${SCHOOLS.google.name}`),\n    },\n  }, {\n    degree: {\n      name: t(`Degrees.CKAD`),\n      description: [t(\"MyEducation.kubernetesCertification\")],\n      obtainedAt: new Date(\"2022-08-01\"),\n    },\n    school: {\n      ...SCHOOLS.cloudNativeComputingFoundation,\n      translatedName: t(`Schools.${SCHOOLS.cloudNativeComputingFoundation.name}`),\n    },\n  }, {\n    degree: {\n      name: t(`Degrees.ITMasterDegree`),\n      description: [\n        t(\"MyEducation.firstThreeYearsInEpitech\"),\n        t(\"MyEducation.lastYearsInEpitech\"),\n      ],\n      startedAt: new Date(\"2014-01-01\"),\n      obtainedAt: new Date(\"2019-01-01\"),\n    },\n    school: {\n      ...SCHOOLS.epitech,\n      translatedName: t(`Schools.${SCHOOLS.epitech.name}`),\n    },\n  }, {\n    degree: {\n      name: t(`Degrees.ITCertification`),\n      description: [\n        t(\"MyEducation.internationalExperienceForManagement\"),\n        t(\"MyEducation.softManagementSkills\"),\n      ],\n      startedAt: new Date(\"2017-01-01\"),\n      obtainedAt: new Date(\"2018-01-01\"),\n    },\n    school: {\n      ...SCHOOLS.laval,\n      translatedName: t(`Schools.${SCHOOLS.laval.name}`),\n    },\n  }, {\n    degree: {\n      name: t(`Degrees.highSchoolDiploma`),\n      description: [t(\"MyEducation.scientistHighSchoolDiploma\")],\n      startedAt: new Date(\"2011-01-01\"),\n      obtainedAt: new Date(\"2014-01-01\"),\n    },\n    school: {\n      ...SCHOOLS.vimeu,\n      translatedName: t(`Schools.${SCHOOLS.vimeu.name}`),\n    },\n  },\n];\n\nfunction getEducationDegreeAriaLabel(educationDegreeName: string, index: number): string {\n  return `${index + 1} - ${educationDegreeName}`;\n}\n</script>"
-    },
-    "app/components/MyExperience/MyExperience.vue": {
-      "language": "html",
-      "mutants": [
-        {
-          "id": "85",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 2,
-              "line": 95
-            },
-            "start": {
-              "column": 59,
-              "line": 35
-            }
-          }
-        },
-        {
-          "id": "86",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 49
-            },
-            "start": {
-              "column": 3,
-              "line": 36
-            }
-          }
-        },
-        {
-          "id": "87",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 47
-            },
-            "start": {
-              "column": 10,
-              "line": 37
-            }
-          }
-        },
-        {
-          "id": "88",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 58,
-              "line": 38
-            },
-            "start": {
-              "column": 15,
-              "line": 38
-            }
-          }
-        },
-        {
-          "id": "89",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "expected { job: { …(3) }, company: { …(3) } } to strictly equal { …(2) }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "66"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 8,
-              "line": 45
-            },
-            "start": {
-              "column": 20,
-              "line": 39
-            }
-          }
-        },
-        {
-          "id": "90",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(3) }, company: { …(3) } } to strictly equal { …(2) }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "66"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 38,
-              "line": 40
-            },
-            "start": {
-              "column": 11,
-              "line": 40
-            }
-          }
-        },
-        {
-          "id": "91",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(3) }, company: { …(3) } } to strictly equal { …(2) }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "66"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 42,
-              "line": 41
-            },
-            "start": {
-              "column": 11,
-              "line": 41
-            }
-          }
-        },
-        {
-          "id": "92",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(3) }, company: { …(3) } } to strictly equal { …(2) }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "66"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 48,
-              "line": 42
-            },
-            "start": {
-              "column": 11,
-              "line": 42
-            }
-          }
-        },
-        {
-          "id": "93",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(3) }, company: { …(3) } } to strictly equal { …(2) }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "66"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 52,
-              "line": 43
-            },
-            "start": {
-              "column": 11,
-              "line": 43
-            }
-          }
-        },
-        {
-          "id": "94",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(3) }, company: { …(3) } } to strictly equal { …(2) }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "66"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 48,
-              "line": 44
-            },
-            "start": {
-              "column": 11,
-              "line": 44
-            }
-          }
-        },
-        {
-          "id": "95",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(3) }, company: { …(3) } } to strictly equal { …(2) }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "66"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 39,
-              "line": 46
-            },
-            "start": {
-              "column": 27,
-              "line": 46
-            }
-          }
-        },
-        {
-          "id": "96",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 62
-            },
-            "start": {
-              "column": 6,
-              "line": 49
-            }
-          }
-        },
-        {
-          "id": "97",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 60
-            },
-            "start": {
-              "column": 10,
-              "line": 50
-            }
-          }
-        },
-        {
-          "id": "98",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 43,
-              "line": 51
-            },
-            "start": {
-              "column": 15,
-              "line": 51
-            }
-          }
-        },
-        {
-          "id": "99",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "67"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 8,
-              "line": 57
-            },
-            "start": {
-              "column": 20,
-              "line": 52
-            }
-          }
-        },
-        {
-          "id": "100",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "67"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 48,
-              "line": 53
-            },
-            "start": {
-              "column": 11,
-              "line": 53
-            }
-          }
-        },
-        {
-          "id": "101",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "67"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 42,
-              "line": 54
-            },
-            "start": {
-              "column": 11,
-              "line": 54
-            }
-          }
-        },
-        {
-          "id": "102",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "67"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 36,
-              "line": 55
-            },
-            "start": {
-              "column": 11,
-              "line": 55
-            }
-          }
-        },
-        {
-          "id": "103",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "67"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 53,
-              "line": 56
-            },
-            "start": {
-              "column": 11,
-              "line": 56
-            }
-          }
-        },
-        {
-          "id": "104",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "67"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 39,
-              "line": 58
-            },
-            "start": {
-              "column": 27,
-              "line": 58
-            }
-          }
-        },
-        {
-          "id": "105",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "67"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 40,
-              "line": 59
-            },
-            "start": {
-              "column": 28,
-              "line": 59
-            }
-          }
-        },
-        {
-          "id": "106",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 70
-            },
-            "start": {
-              "column": 6,
-              "line": 62
-            }
-          }
-        },
-        {
-          "id": "107",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 68
-            },
-            "start": {
-              "column": 10,
-              "line": 63
-            }
-          }
-        },
-        {
-          "id": "108",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 54,
-              "line": 64
-            },
-            "start": {
-              "column": 15,
-              "line": 64
-            }
-          }
-        },
-        {
-          "id": "109",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "68"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 98,
-              "line": 65
-            },
-            "start": {
-              "column": 20,
-              "line": 65
-            }
-          }
-        },
-        {
-          "id": "110",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "68"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 57,
-              "line": 65
-            },
-            "start": {
-              "column": 23,
-              "line": 65
-            }
-          }
-        },
-        {
-          "id": "111",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "68"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 96,
-              "line": 65
-            },
-            "start": {
-              "column": 62,
-              "line": 65
-            }
-          }
-        },
-        {
-          "id": "112",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "68"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 39,
-              "line": 66
-            },
-            "start": {
-              "column": 27,
-              "line": 66
-            }
-          }
-        },
-        {
-          "id": "113",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "68"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 40,
-              "line": 67
-            },
-            "start": {
-              "column": 28,
-              "line": 67
-            }
-          }
-        },
-        {
-          "id": "114",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 78
-            },
-            "start": {
-              "column": 6,
-              "line": 70
-            }
-          }
-        },
-        {
-          "id": "115",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 76
-            },
-            "start": {
-              "column": 10,
-              "line": 71
-            }
-          }
-        },
-        {
-          "id": "116",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 54,
-              "line": 72
-            },
-            "start": {
-              "column": 15,
-              "line": 72
-            }
-          }
-        },
-        {
-          "id": "117",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "69"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 105,
-              "line": 73
-            },
-            "start": {
-              "column": 20,
-              "line": 73
-            }
-          }
-        },
-        {
-          "id": "118",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "69"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 58,
-              "line": 73
-            },
-            "start": {
-              "column": 23,
-              "line": 73
-            }
-          }
-        },
-        {
-          "id": "119",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "69"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 103,
-              "line": 73
-            },
-            "start": {
-              "column": 63,
-              "line": 73
-            }
-          }
-        },
-        {
-          "id": "120",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "69"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 39,
-              "line": 74
-            },
-            "start": {
-              "column": 27,
-              "line": 74
-            }
-          }
-        },
-        {
-          "id": "121",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "69"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 40,
-              "line": 75
-            },
-            "start": {
-              "column": 28,
-              "line": 75
-            }
-          }
-        },
-        {
-          "id": "122",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 86
-            },
-            "start": {
-              "column": 6,
-              "line": 78
-            }
-          }
-        },
-        {
-          "id": "123",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 84
-            },
-            "start": {
-              "column": 10,
-              "line": 79
-            }
-          }
-        },
-        {
-          "id": "124",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 57,
-              "line": 80
-            },
-            "start": {
-              "column": 15,
-              "line": 80
-            }
-          }
-        },
-        {
-          "id": "125",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { …(2) }",
-          "status": "Killed",
-          "testsCompleted": 7,
-          "static": false,
-          "killedBy": [
-            "70"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 100,
-              "line": 81
-            },
-            "start": {
-              "column": 20,
-              "line": 81
-            }
-          }
-        },
-        {
-          "id": "126",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { …(2) }",
-          "status": "Killed",
-          "testsCompleted": 7,
-          "static": false,
-          "killedBy": [
-            "70"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 58,
-              "line": 81
-            },
-            "start": {
-              "column": 23,
-              "line": 81
-            }
-          }
-        },
-        {
-          "id": "127",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { …(2) }",
-          "status": "Killed",
-          "testsCompleted": 7,
-          "static": false,
-          "killedBy": [
-            "70"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 98,
-              "line": 81
-            },
-            "start": {
-              "column": 63,
-              "line": 81
-            }
-          }
-        },
-        {
-          "id": "128",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { …(2) }",
-          "status": "Killed",
-          "testsCompleted": 7,
-          "static": false,
-          "killedBy": [
-            "70"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 39,
-              "line": 82
-            },
-            "start": {
-              "column": 27,
-              "line": 82
-            }
-          }
-        },
-        {
-          "id": "129",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { …(2) }",
-          "status": "Killed",
-          "testsCompleted": 7,
-          "static": false,
-          "killedBy": [
-            "70"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 40,
-              "line": 83
-            },
-            "start": {
-              "column": 28,
-              "line": 83
-            }
-          }
-        },
-        {
-          "id": "130",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 94
-            },
-            "start": {
-              "column": 6,
-              "line": 86
-            }
-          }
-        },
-        {
-          "id": "131",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 92
-            },
-            "start": {
-              "column": 10,
-              "line": 87
-            }
-          }
-        },
-        {
-          "id": "132",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 54,
-              "line": 88
-            },
-            "start": {
-              "column": 15,
-              "line": 88
-            }
-          }
-        },
-        {
-          "id": "133",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { …(2) }",
-          "status": "Killed",
-          "testsCompleted": 8,
-          "static": false,
-          "killedBy": [
-            "71"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 55,
-              "line": 89
-            },
-            "start": {
-              "column": 20,
-              "line": 89
-            }
-          }
-        },
-        {
-          "id": "134",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { …(2) }",
-          "status": "Killed",
-          "testsCompleted": 8,
-          "static": false,
-          "killedBy": [
-            "71"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 53,
-              "line": 89
-            },
-            "start": {
-              "column": 23,
-              "line": 89
-            }
-          }
-        },
-        {
-          "id": "135",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { …(2) }",
-          "status": "Killed",
-          "testsCompleted": 8,
-          "static": false,
-          "killedBy": [
-            "71"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 39,
-              "line": 90
-            },
-            "start": {
-              "column": 27,
-              "line": 90
-            }
-          }
-        },
-        {
-          "id": "136",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { …(2) }",
-          "status": "Killed",
-          "testsCompleted": 8,
-          "static": false,
-          "killedBy": [
-            "71"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 40,
-              "line": 91
-            },
-            "start": {
-              "column": 28,
-              "line": 91
-            }
-          }
-        },
-        {
-          "id": "137",
-          "mutatorName": "BlockStatement",
-          "replacement": "{}",
-          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 2,
-              "line": 99
-            },
-            "start": {
-              "column": 73,
-              "line": 97
-            }
-          }
-        },
-        {
-          "id": "138",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 37,
-              "line": 98
-            },
-            "start": {
-              "column": 10,
-              "line": 98
-            }
-          }
-        },
-        {
-          "id": "139",
-          "mutatorName": "ArithmeticOperator",
-          "replacement": "index - 1",
-          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "64"
-          ],
-          "coveredBy": [
-            "64",
-            "65",
-            "66",
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
-          ],
-          "location": {
-            "end": {
-              "column": 22,
-              "line": 98
-            },
-            "start": {
-              "column": 13,
-              "line": 98
-            }
-          }
-        }
-      ],
-      "source": "<template>\n  <section\n    id=\"experience\"\n    aria-labelledby=\"experience-title\"\n    class=\"section\"\n  >\n    <div class=\"cc-experience container\">\n      <SectionTitle\n        id=\"experience-title\"\n        icon=\"fa fa-briefcase\"\n        icon-color=\"#4D9344\"\n        :title=\"$t('MyExperience.professionalExperience')\"\n      />\n\n      <ProfessionalExperienceCard\n        v-for=\"(professionalExperience, index) in professionalExperiences\"\n        :key=\"index\"\n        :aria-label=\"getExperienceAriaLabel(professionalExperience.job.name, index)\"\n        class=\"professional-experience-card\"\n        :professional-experience=\"professionalExperience\"\n        role=\"region\"\n      />\n    </div>\n  </section>\n</template>\n\n<script setup lang=\"ts\">\nimport ProfessionalExperienceCard from \"~/components/MyExperience/ProfessionalExperienceCard/ProfessionalExperienceCard.vue\";\nimport SectionTitle from \"~/components/shared/Layouts/SectionTitle/SectionTitle.vue\";\nimport { COMPANIES } from \"~/models/company/company.constants\";\nimport type { ProfessionalExperience } from \"~/models/professional-experience/professional-experience.types\";\n\nconst { t } = useI18n();\n\nconst professionalExperiences: ProfessionalExperience[] = [\n  {\n    job: {\n      name: t(\"MyExperience.fullStackDeveloperConsultant\"),\n      description: [\n        t(\"MyExperience.iJoinedDaveo\"),\n        t(\"MyExperience.whatIsConsulting\"),\n        t(\"MyExperience.myMissionsAsConsultant\"),\n        t(\"MyExperience.cloudProductCertifications\"),\n        t(\"MyExperience.conferenceAndWorkshops\"),\n      ],\n      startedAt: new Date(\"2022-04-01\"),\n    },\n    company: COMPANIES.Daveo,\n  }, {\n    job: {\n      name: t(\"MyExperience.itR&DEngineer\"),\n      description: [\n        t(\"MyExperience.firstPermanentContract\"),\n        t(\"MyExperience.asProjectManager\"),\n        t(\"MyExperience.softSkills\"),\n        t(\"MyExperience.expertiseAndTechnicalSkills\"),\n      ],\n      startedAt: new Date(\"2019-09-01\"),\n      finishedAt: new Date(\"2022-03-31\"),\n    },\n    company: COMPANIES.OhMyCode,\n  }, {\n    job: {\n      name: t(\"MyExperience.internFullStackDeveloper\"),\n      description: [t(\"MyExperience.distributionProject\"), t(\"MyExperience.thisFinalInternship\")],\n      startedAt: new Date(\"2018-09-01\"),\n      finishedAt: new Date(\"2019-08-30\"),\n    },\n    company: COMPANIES.OhMyCode,\n  }, {\n    job: {\n      name: t(\"MyExperience.internFullStackDeveloper\"),\n      description: [t(\"MyExperience.firstStepsInOhMyCode\"), t(\"MyExperience.allFunctionalitiesInOnApp\")],\n      startedAt: new Date(\"2016-09-01\"),\n      finishedAt: new Date(\"2017-04-30\"),\n    },\n    company: COMPANIES.OhMyCode,\n  }, {\n    job: {\n      name: t(\"MyExperience.freelanceFullStackDeveloper\"),\n      description: [t(\"MyExperience.reiterateAsFreelance\"), t(\"MyExperience.moreResponsibilities\")],\n      startedAt: new Date(\"2016-02-01\"),\n      finishedAt: new Date(\"2016-08-30\"),\n    },\n    company: COMPANIES.SoBook,\n  }, {\n    job: {\n      name: t(\"MyExperience.internFullStackDeveloper\"),\n      description: [t(\"MyExperience.firstInternship\")],\n      startedAt: new Date(\"2015-07-01\"),\n      finishedAt: new Date(\"2015-12-31\"),\n    },\n    company: COMPANIES.SoBook,\n  },\n];\n\nfunction getExperienceAriaLabel(jobName: string, index: number): string {\n  return `${index + 1} - ${jobName}`;\n}\n</script>"
-    },
-    "app/components/MyPortfolio/MyPortfolio.vue": {
-      "language": "html",
-      "mutants": [
-        {
-          "id": "140",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: '.portfolio.name', …(3) } to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "94"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 47,
-              "line": 50
-            },
-            "start": {
-              "column": 25,
-              "line": 50
-            }
-          }
-        },
-        {
-          "id": "141",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "Snapshot `My Portfolio Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "92"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 2,
-              "line": 76
-            },
-            "start": {
-              "column": 29,
-              "line": 51
-            }
-          }
-        },
-        {
-          "id": "142",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "94"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 57
-            },
-            "start": {
-              "column": 3,
-              "line": 52
-            }
-          }
-        },
-        {
-          "id": "143",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "expected { name: '', …(3) } to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "94"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 48,
-              "line": 53
-            },
-            "start": {
-              "column": 13,
-              "line": 53
-            }
-          }
-        },
-        {
-          "id": "144",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "94"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 62,
-              "line": 54
-            },
-            "start": {
-              "column": 20,
-              "line": 54
-            }
-          }
-        },
-        {
-          "id": "145",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "94"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 38,
-              "line": 55
-            },
-            "start": {
-              "column": 12,
-              "line": 55
-            }
-          }
-        },
-        {
-          "id": "146",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "95"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 63
-            },
-            "start": {
-              "column": 3,
-              "line": 58
-            }
-          }
-        },
-        {
-          "id": "147",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "expected { name: '', …(3) } to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "95"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 58,
-              "line": 59
-            },
-            "start": {
-              "column": 13,
-              "line": 59
-            }
-          }
-        },
-        {
-          "id": "148",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "95"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 72,
-              "line": 60
-            },
-            "start": {
-              "column": 20,
-              "line": 60
-            }
-          }
-        },
-        {
-          "id": "149",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "95"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 49,
-              "line": 61
-            },
-            "start": {
-              "column": 12,
-              "line": 61
-            }
-          }
-        },
-        {
-          "id": "150",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "95"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 44,
-              "line": 62
-            },
-            "start": {
-              "column": 10,
-              "line": 62
-            }
-          }
-        },
-        {
-          "id": "151",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "96"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 69
-            },
-            "start": {
-              "column": 3,
-              "line": 64
-            }
-          }
-        },
-        {
-          "id": "152",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "expected { name: '', …(3) } to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "96"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 51,
-              "line": 65
-            },
-            "start": {
-              "column": 13,
-              "line": 65
-            }
-          }
-        },
-        {
-          "id": "153",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "96"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 65,
-              "line": 66
-            },
-            "start": {
-              "column": 20,
-              "line": 66
-            }
-          }
-        },
-        {
-          "id": "154",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "96"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 41,
-              "line": 67
-            },
-            "start": {
-              "column": 12,
-              "line": 67
-            }
-          }
-        },
-        {
-          "id": "155",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "96"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 42,
-              "line": 68
-            },
-            "start": {
-              "column": 10,
-              "line": 68
-            }
-          }
-        },
-        {
-          "id": "156",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "97"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 75
-            },
-            "start": {
-              "column": 3,
-              "line": 70
-            }
-          }
-        },
-        {
-          "id": "157",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "expected { name: '', …(3) } to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "97"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 45,
-              "line": 71
-            },
-            "start": {
-              "column": 13,
-              "line": 71
-            }
-          }
-        },
-        {
-          "id": "158",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "97"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 59,
-              "line": 72
-            },
-            "start": {
-              "column": 20,
-              "line": 72
-            }
-          }
-        },
-        {
-          "id": "159",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "97"
-          ],
-          "coveredBy": [
-            "92",
-            "93",
-            "94",
-            "95",
-            "96",
-            "97"
-          ],
-          "location": {
-            "end": {
-              "column": 25,
-              "line": 73
-            },
-            "start": {
-              "column": 12,
-              "line": 73
-            }
-          }
-        }
-      ],
-      "source": "<template>\n  <section\n    id=\"portfolio\"\n    aria-labelledby=\"portfolio-title\"\n    class=\"section\"\n  >\n    <div class=\"container\">\n      <SectionTitle\n        id=\"portfolio-title\"\n        icon=\"fa fa-star\"\n        icon-color=\"#EEC624\"\n        :title=\"$t('MyPortfolio.portfolio')\"\n      />\n\n      <div class=\"gallery tab-content\">\n        <div\n          id=\"web-development\"\n          class=\"active tab-pane\"\n        >\n          <div class=\"me-auto ms-auto\">\n            <div class=\"align-items-center row\">\n              <div\n                v-for=\"project in projects\"\n                :key=\"project.name\"\n                class=\"col-md-6\"\n              >\n                <MyProject\n                  class=\"project\"\n                  :project=\"project\"\n                />\n              </div>\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n  </section>\n</template>\n\n<script setup lang=\"ts\">\nimport { useSiteConfig } from \"#imports\";\nimport MyProject from \"~/components/MyPortfolio/MyProject/MyProject.vue\";\nimport SectionTitle from \"~/components/shared/Layouts/SectionTitle/SectionTitle.vue\";\nimport type { Project } from \"~/models/project/project.types\";\nimport { ANTOINE_ZANARDI_GITHUB_URL } from \"~/shared/constants/antoine-zanardi.constants\";\n\nconst { t } = useI18n();\nconst { url: siteUrl } = useSiteConfig();\n\nconst i18nProjectPath = \"MyPortfolio.projects\";\nconst projects: Project[] = [\n  {\n    name: t(`${i18nProjectPath}.portfolio.name`),\n    description: t(`${i18nProjectPath}.portfolio.description`),\n    image: \"portfolio-thumbnail.webp\",\n    url: siteUrl,\n  },\n  {\n    name: t(`${i18nProjectPath}.werewolvesAssistant.name`),\n    description: t(`${i18nProjectPath}.werewolvesAssistant.description`),\n    image: \"werewolves-assistant-thumbnail.webp\",\n    url: \"https://werewolves-assistant.com\",\n  },\n  {\n    name: t(`${i18nProjectPath}.distribution.name`),\n    description: t(`${i18nProjectPath}.distribution.description`),\n    image: \"distribution-thumbnail.webp\",\n    url: \"https://www.airvey-editions.fr\",\n  },\n  {\n    name: t(`${i18nProjectPath}.gitHub.name`),\n    description: t(`${i18nProjectPath}.gitHub.description`),\n    image: \"github.webp\",\n    url: ANTOINE_ZANARDI_GITHUB_URL,\n  },\n];\n</script>"
-    },
-    "app/components/MySkills/MySkills.vue": {
-      "language": "html",
-      "mutants": [
-        {
-          "id": "160",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.html', …(4) } to strictly equal { name: 'MySkills.html', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "2"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 54,
-              "line": 79
-            },
-            "start": {
-              "column": 17,
-              "line": 79
-            }
-          }
-        },
-        {
-          "id": "161",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.css', …(4) } to strictly equal { name: 'MySkills.css', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "3"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 76,
-              "line": 80
-            },
-            "start": {
-              "column": 16,
-              "line": 80
-            }
-          }
-        },
-        {
-          "id": "162",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.javascript', …(4) } to strictly equal { name: 'MySkills.javascript', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "4"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 57,
-              "line": 81
-            },
-            "start": {
-              "column": 15,
-              "line": 81
-            }
-          }
-        },
-        {
-          "id": "163",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.typescript', …(4) } to strictly equal { name: 'MySkills.typescript', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "5"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 48,
-              "line": 82
-            },
-            "start": {
-              "column": 15,
-              "line": 82
-            }
-          }
-        },
-        {
-          "id": "164",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.vue', …(4) } to strictly equal { name: 'MySkills.vue', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 7,
-          "static": false,
-          "killedBy": [
-            "6"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 36,
-              "line": 83
-            },
-            "start": {
-              "column": 16,
-              "line": 83
-            }
-          }
-        },
-        {
-          "id": "165",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.nuxt', …(4) } to strictly equal { name: 'MySkills.nuxt', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 8,
-          "static": false,
-          "killedBy": [
-            "7"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 41,
-              "line": 84
-            },
-            "start": {
-              "column": 17,
-              "line": 84
-            }
-          }
-        },
-        {
-          "id": "166",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.mysql', …(4) } to strictly equal { name: 'MySkills.mysql', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 9,
-          "static": false,
-          "killedBy": [
-            "8"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 45,
-              "line": 85
-            },
-            "start": {
-              "column": 18,
-              "line": 85
-            }
-          }
-        },
-        {
-          "id": "167",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.mongodb', …(4) } to strictly equal { name: 'MySkills.mongodb', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 10,
-          "static": false,
-          "killedBy": [
-            "9"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 46,
-              "line": 86
-            },
-            "start": {
-              "column": 20,
-              "line": 86
-            }
-          }
-        },
-        {
-          "id": "168",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.rust', …(4) } to strictly equal { name: 'MySkills.rust', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 11,
-          "static": false,
-          "killedBy": [
-            "10"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 45,
-              "line": 87
-            },
-            "start": {
-              "column": 17,
-              "line": 87
-            }
-          }
-        },
-        {
-          "id": "169",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "Snapshot `My Skills Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "0"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 2,
-              "line": 152
-            },
-            "start": {
-              "column": 25,
-              "line": 88
-            }
-          }
-        },
-        {
-          "id": "170",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { name: 'MySkills.html', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "2"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 95
-            },
-            "start": {
-              "column": 3,
-              "line": 89
-            }
-          }
-        },
-        {
-          "id": "171",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: '', …(4) } to strictly equal { name: 'MySkills.html', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "2"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 28,
-              "line": 90
-            },
-            "start": {
-              "column": 13,
-              "line": 90
-            }
-          }
-        },
-        {
-          "id": "172",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.html', …(4) } to strictly equal { name: 'MySkills.html', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "2"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 32,
-              "line": 91
-            },
-            "start": {
-              "column": 18,
-              "line": 91
-            }
-          }
-        },
-        {
-          "id": "173",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.html', …(4) } to strictly equal { name: 'MySkills.html', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "2"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 92
-            },
-            "start": {
-              "column": 12,
-              "line": 92
-            }
-          }
-        },
-        {
-          "id": "174",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.html', …(4) } to strictly equal { name: 'MySkills.html', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 3,
-          "static": false,
-          "killedBy": [
-            "2"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 19,
-              "line": 93
-            },
-            "start": {
-              "column": 14,
-              "line": 93
-            }
-          }
-        },
-        {
-          "id": "175",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { name: 'MySkills.css', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "3"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 102
-            },
-            "start": {
-              "column": 3,
-              "line": 96
-            }
-          }
-        },
-        {
-          "id": "176",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: '', …(4) } to strictly equal { name: 'MySkills.css', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "3"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 27,
-              "line": 97
-            },
-            "start": {
-              "column": 13,
-              "line": 97
-            }
-          }
-        },
-        {
-          "id": "177",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.css', …(4) } to strictly equal { name: 'MySkills.css', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "3"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 35,
-              "line": 98
-            },
-            "start": {
-              "column": 18,
-              "line": 98
-            }
-          }
-        },
-        {
-          "id": "178",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.css', …(4) } to strictly equal { name: 'MySkills.css', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "3"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 99
-            },
-            "start": {
-              "column": 12,
-              "line": 99
-            }
-          }
-        },
-        {
-          "id": "179",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.css', …(4) } to strictly equal { name: 'MySkills.css', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "3"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 19,
-              "line": 100
-            },
-            "start": {
-              "column": 14,
-              "line": 100
-            }
-          }
-        },
-        {
-          "id": "180",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { name: 'MySkills.javascript', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "4"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 109
-            },
-            "start": {
-              "column": 3,
-              "line": 103
-            }
-          }
-        },
-        {
-          "id": "181",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: '', …(4) } to strictly equal { name: 'MySkills.javascript', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "4"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 34,
-              "line": 104
-            },
-            "start": {
-              "column": 13,
-              "line": 104
-            }
-          }
-        },
-        {
-          "id": "182",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.javascript', …(4) } to strictly equal { name: 'MySkills.javascript', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "4"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 29,
-              "line": 105
-            },
-            "start": {
-              "column": 18,
-              "line": 105
-            }
-          }
-        },
-        {
-          "id": "183",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.javascript', …(4) } to strictly equal { name: 'MySkills.javascript', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "4"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 106
-            },
-            "start": {
-              "column": 12,
-              "line": 106
-            }
-          }
-        },
-        {
-          "id": "184",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.javascript', …(4) } to strictly equal { name: 'MySkills.javascript', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "4"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 19,
-              "line": 107
-            },
-            "start": {
-              "column": 14,
-              "line": 107
-            }
-          }
-        },
-        {
-          "id": "185",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { name: 'MySkills.typescript', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "5"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 116
-            },
-            "start": {
-              "column": 3,
-              "line": 110
-            }
-          }
-        },
-        {
-          "id": "186",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: '', …(4) } to strictly equal { name: 'MySkills.typescript', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "5"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 34,
-              "line": 111
-            },
-            "start": {
-              "column": 13,
-              "line": 111
-            }
-          }
-        },
-        {
-          "id": "187",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.typescript', …(4) } to strictly equal { name: 'MySkills.typescript', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "5"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 33,
-              "line": 112
-            },
-            "start": {
-              "column": 18,
-              "line": 112
-            }
-          }
-        },
-        {
-          "id": "188",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.typescript', …(4) } to strictly equal { name: 'MySkills.typescript', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "5"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 113
-            },
-            "start": {
-              "column": 12,
-              "line": 113
-            }
-          }
-        },
-        {
-          "id": "189",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.typescript', …(4) } to strictly equal { name: 'MySkills.typescript', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 6,
-          "static": false,
-          "killedBy": [
-            "5"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 19,
-              "line": 114
-            },
-            "start": {
-              "column": 14,
-              "line": 114
-            }
-          }
-        },
-        {
-          "id": "190",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { name: 'MySkills.vue', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 7,
-          "static": false,
-          "killedBy": [
-            "6"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 123
-            },
-            "start": {
-              "column": 3,
-              "line": 117
-            }
-          }
-        },
-        {
-          "id": "191",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: '', …(4) } to strictly equal { name: 'MySkills.vue', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 7,
-          "static": false,
-          "killedBy": [
-            "6"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 27,
-              "line": 118
-            },
-            "start": {
-              "column": 13,
-              "line": 118
-            }
-          }
-        },
-        {
-          "id": "192",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.vue', …(4) } to strictly equal { name: 'MySkills.vue', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 7,
-          "static": false,
-          "killedBy": [
-            "6"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 32,
-              "line": 119
-            },
-            "start": {
-              "column": 18,
-              "line": 119
-            }
-          }
-        },
-        {
-          "id": "193",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.vue', …(4) } to strictly equal { name: 'MySkills.vue', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 7,
-          "static": false,
-          "killedBy": [
-            "6"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 120
-            },
-            "start": {
-              "column": 12,
-              "line": 120
-            }
-          }
-        },
-        {
-          "id": "194",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.vue', …(4) } to strictly equal { name: 'MySkills.vue', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 7,
-          "static": false,
-          "killedBy": [
-            "6"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 19,
-              "line": 121
-            },
-            "start": {
-              "column": 14,
-              "line": 121
-            }
-          }
-        },
-        {
-          "id": "195",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { name: 'MySkills.nuxt', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 8,
-          "static": false,
-          "killedBy": [
-            "7"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 130
-            },
-            "start": {
-              "column": 3,
-              "line": 124
-            }
-          }
-        },
-        {
-          "id": "196",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: '', …(4) } to strictly equal { name: 'MySkills.nuxt', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 8,
-          "static": false,
-          "killedBy": [
-            "7"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 28,
-              "line": 125
-            },
-            "start": {
-              "column": 13,
-              "line": 125
-            }
-          }
-        },
-        {
-          "id": "197",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.nuxt', …(4) } to strictly equal { name: 'MySkills.nuxt', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 8,
-          "static": false,
-          "killedBy": [
-            "7"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 39,
-              "line": 126
-            },
-            "start": {
-              "column": 18,
-              "line": 126
-            }
-          }
-        },
-        {
-          "id": "198",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.nuxt', …(4) } to strictly equal { name: 'MySkills.nuxt', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 8,
-          "static": false,
-          "killedBy": [
-            "7"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 127
-            },
-            "start": {
-              "column": 12,
-              "line": 127
-            }
-          }
-        },
-        {
-          "id": "199",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.nuxt', …(4) } to strictly equal { name: 'MySkills.nuxt', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 8,
-          "static": false,
-          "killedBy": [
-            "7"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 19,
-              "line": 128
-            },
-            "start": {
-              "column": 14,
-              "line": 128
-            }
-          }
-        },
-        {
-          "id": "200",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { name: 'MySkills.mysql', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 9,
-          "static": false,
-          "killedBy": [
-            "8"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 137
-            },
-            "start": {
-              "column": 3,
-              "line": 131
-            }
-          }
-        },
-        {
-          "id": "201",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: '', …(4) } to strictly equal { name: 'MySkills.mysql', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 9,
-          "static": false,
-          "killedBy": [
-            "8"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 29,
-              "line": 132
-            },
-            "start": {
-              "column": 13,
-              "line": 132
-            }
-          }
-        },
-        {
-          "id": "202",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.mysql', …(4) } to strictly equal { name: 'MySkills.mysql', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 9,
-          "static": false,
-          "killedBy": [
-            "8"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 35,
-              "line": 133
-            },
-            "start": {
-              "column": 18,
-              "line": 133
-            }
-          }
-        },
-        {
-          "id": "203",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.mysql', …(4) } to strictly equal { name: 'MySkills.mysql', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 9,
-          "static": false,
-          "killedBy": [
-            "8"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 134
-            },
-            "start": {
-              "column": 12,
-              "line": 134
-            }
-          }
-        },
-        {
-          "id": "204",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.mysql', …(4) } to strictly equal { name: 'MySkills.mysql', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 9,
-          "static": false,
-          "killedBy": [
-            "8"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 19,
-              "line": 135
-            },
-            "start": {
-              "column": 14,
-              "line": 135
-            }
-          }
-        },
-        {
-          "id": "205",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { name: 'MySkills.mongodb', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 10,
-          "static": false,
-          "killedBy": [
-            "9"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 144
-            },
-            "start": {
-              "column": 3,
-              "line": 138
-            }
-          }
-        },
-        {
-          "id": "206",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: '', …(4) } to strictly equal { name: 'MySkills.mongodb', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 10,
-          "static": false,
-          "killedBy": [
-            "9"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 31,
-              "line": 139
-            },
-            "start": {
-              "column": 13,
-              "line": 139
-            }
-          }
-        },
-        {
-          "id": "207",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.mongodb', …(4) } to strictly equal { name: 'MySkills.mongodb', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 10,
-          "static": false,
-          "killedBy": [
-            "9"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 31,
-              "line": 140
-            },
-            "start": {
-              "column": 18,
-              "line": 140
-            }
-          }
-        },
-        {
-          "id": "208",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.mongodb', …(4) } to strictly equal { name: 'MySkills.mongodb', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 10,
-          "static": false,
-          "killedBy": [
-            "9"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 141
-            },
-            "start": {
-              "column": 12,
-              "line": 141
-            }
-          }
-        },
-        {
-          "id": "209",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.mongodb', …(4) } to strictly equal { name: 'MySkills.mongodb', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 10,
-          "static": false,
-          "killedBy": [
-            "9"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 19,
-              "line": 142
-            },
-            "start": {
-              "column": 14,
-              "line": 142
-            }
-          }
-        },
-        {
-          "id": "210",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { name: 'MySkills.rust', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 11,
-          "static": false,
-          "killedBy": [
-            "10"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 151
-            },
-            "start": {
-              "column": 3,
-              "line": 145
-            }
-          }
-        },
-        {
-          "id": "211",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: '', …(4) } to strictly equal { name: 'MySkills.rust', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 11,
-          "static": false,
-          "killedBy": [
-            "10"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 28,
-              "line": 146
-            },
-            "start": {
-              "column": 13,
-              "line": 146
-            }
-          }
-        },
-        {
-          "id": "212",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.rust', …(4) } to strictly equal { name: 'MySkills.rust', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 11,
-          "static": false,
-          "killedBy": [
-            "10"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 31,
-              "line": 147
-            },
-            "start": {
-              "column": 18,
-              "line": 147
-            }
-          }
-        },
-        {
-          "id": "213",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.rust', …(4) } to strictly equal { name: 'MySkills.rust', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 11,
-          "static": false,
-          "killedBy": [
-            "10"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 148
-            },
-            "start": {
-              "column": 12,
-              "line": 148
-            }
-          }
-        },
-        {
-          "id": "214",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { name: 'MySkills.rust', …(4) } to strictly equal { name: 'MySkills.rust', …(4) }",
-          "status": "Killed",
-          "testsCompleted": 11,
-          "static": false,
-          "killedBy": [
-            "10"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 19,
-              "line": 149
-            },
-            "start": {
-              "column": 14,
-              "line": 149
-            }
-          }
-        },
-        {
-          "id": "215",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "Snapshot `My Skills Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "0"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 2,
-              "line": 220
-            },
-            "start": {
-              "column": 23,
-              "line": 154
-            }
-          }
-        },
-        {
-          "id": "216",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 13,
-          "static": false,
-          "killedBy": [
-            "12"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 159
-            },
-            "start": {
-              "column": 3,
-              "line": 155
-            }
-          }
-        },
-        {
-          "id": "217",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 13,
-          "static": false,
-          "killedBy": [
-            "12"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 46,
-              "line": 156
-            },
-            "start": {
-              "column": 20,
-              "line": 156
-            }
-          }
-        },
-        {
-          "id": "218",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 13,
-          "static": false,
-          "killedBy": [
-            "12"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 32,
-              "line": 157
-            },
-            "start": {
-              "column": 18,
-              "line": 157
-            }
-          }
-        },
-        {
-          "id": "219",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 13,
-          "static": false,
-          "killedBy": [
-            "12"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 158
-            },
-            "start": {
-              "column": 12,
-              "line": 158
-            }
-          }
-        },
-        {
-          "id": "220",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 14,
-          "static": false,
-          "killedBy": [
-            "13"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 164
-            },
-            "start": {
-              "column": 3,
-              "line": 160
-            }
-          }
-        },
-        {
-          "id": "221",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 14,
-          "static": false,
-          "killedBy": [
-            "13"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 56,
-              "line": 161
-            },
-            "start": {
-              "column": 20,
-              "line": 161
-            }
-          }
-        },
-        {
-          "id": "222",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 14,
-          "static": false,
-          "killedBy": [
-            "13"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 34,
-              "line": 162
-            },
-            "start": {
-              "column": 18,
-              "line": 162
-            }
-          }
-        },
-        {
-          "id": "223",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 14,
-          "static": false,
-          "killedBy": [
-            "13"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 163
-            },
-            "start": {
-              "column": 12,
-              "line": 163
-            }
-          }
-        },
-        {
-          "id": "224",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 15,
-          "static": false,
-          "killedBy": [
-            "14"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 169
-            },
-            "start": {
-              "column": 3,
-              "line": 165
-            }
-          }
-        },
-        {
-          "id": "225",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 15,
-          "static": false,
-          "killedBy": [
-            "14"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 51,
-              "line": 166
-            },
-            "start": {
-              "column": 20,
-              "line": 166
-            }
-          }
-        },
-        {
-          "id": "226",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 15,
-          "static": false,
-          "killedBy": [
-            "14"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 30,
-              "line": 167
-            },
-            "start": {
-              "column": 18,
-              "line": 167
-            }
-          }
-        },
-        {
-          "id": "227",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 15,
-          "static": false,
-          "killedBy": [
-            "14"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 168
-            },
-            "start": {
-              "column": 12,
-              "line": 168
-            }
-          }
-        },
-        {
-          "id": "228",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 16,
-          "static": false,
-          "killedBy": [
-            "15"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 174
-            },
-            "start": {
-              "column": 3,
-              "line": 170
-            }
-          }
-        },
-        {
-          "id": "229",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 16,
-          "static": false,
-          "killedBy": [
-            "15"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 43,
-              "line": 171
-            },
-            "start": {
-              "column": 20,
-              "line": 171
-            }
-          }
-        },
-        {
-          "id": "230",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 16,
-          "static": false,
-          "killedBy": [
-            "15"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 38,
-              "line": 172
-            },
-            "start": {
-              "column": 18,
-              "line": 172
-            }
-          }
-        },
-        {
-          "id": "231",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 16,
-          "static": false,
-          "killedBy": [
-            "15"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 173
-            },
-            "start": {
-              "column": 12,
-              "line": 173
-            }
-          }
-        },
-        {
-          "id": "232",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 17,
-          "static": false,
-          "killedBy": [
-            "16"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 179
-            },
-            "start": {
-              "column": 3,
-              "line": 175
-            }
-          }
-        },
-        {
-          "id": "233",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 17,
-          "static": false,
-          "killedBy": [
-            "16"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 47,
-              "line": 176
-            },
-            "start": {
-              "column": 20,
-              "line": 176
-            }
-          }
-        },
-        {
-          "id": "234",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 17,
-          "static": false,
-          "killedBy": [
-            "16"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 34,
-              "line": 177
-            },
-            "start": {
-              "column": 18,
-              "line": 177
-            }
-          }
-        },
-        {
-          "id": "235",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 17,
-          "static": false,
-          "killedBy": [
-            "16"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 178
-            },
-            "start": {
-              "column": 12,
-              "line": 178
-            }
-          }
-        },
-        {
-          "id": "236",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 18,
-          "static": false,
-          "killedBy": [
-            "17"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 184
-            },
-            "start": {
-              "column": 3,
-              "line": 180
-            }
-          }
-        },
-        {
-          "id": "237",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 18,
-          "static": false,
-          "killedBy": [
-            "17"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 48,
-              "line": 181
-            },
-            "start": {
-              "column": 20,
-              "line": 181
-            }
-          }
-        },
-        {
-          "id": "238",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 18,
-          "static": false,
-          "killedBy": [
-            "17"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 35,
-              "line": 182
-            },
-            "start": {
-              "column": 18,
-              "line": 182
-            }
-          }
-        },
-        {
-          "id": "239",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 18,
-          "static": false,
-          "killedBy": [
-            "17"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 183
-            },
-            "start": {
-              "column": 12,
-              "line": 183
-            }
-          }
-        },
-        {
-          "id": "240",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 19,
-          "static": false,
-          "killedBy": [
-            "18"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 189
-            },
-            "start": {
-              "column": 3,
-              "line": 185
-            }
-          }
-        },
-        {
-          "id": "241",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 19,
-          "static": false,
-          "killedBy": [
-            "18"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 44,
-              "line": 186
-            },
-            "start": {
-              "column": 20,
-              "line": 186
-            }
-          }
-        },
-        {
-          "id": "242",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 19,
-          "static": false,
-          "killedBy": [
-            "18"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 36,
-              "line": 187
-            },
-            "start": {
-              "column": 18,
-              "line": 187
-            }
-          }
-        },
-        {
-          "id": "243",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 19,
-          "static": false,
-          "killedBy": [
-            "18"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 188
-            },
-            "start": {
-              "column": 12,
-              "line": 188
-            }
-          }
-        },
-        {
-          "id": "244",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 20,
-          "static": false,
-          "killedBy": [
-            "19"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 194
-            },
-            "start": {
-              "column": 3,
-              "line": 190
-            }
-          }
-        },
-        {
-          "id": "245",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 20,
-          "static": false,
-          "killedBy": [
-            "19"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 44,
-              "line": 191
-            },
-            "start": {
-              "column": 20,
-              "line": 191
-            }
-          }
-        },
-        {
-          "id": "246",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 20,
-          "static": false,
-          "killedBy": [
-            "19"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 32,
-              "line": 192
-            },
-            "start": {
-              "column": 18,
-              "line": 192
-            }
-          }
-        },
-        {
-          "id": "247",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 20,
-          "static": false,
-          "killedBy": [
-            "19"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 193
-            },
-            "start": {
-              "column": 12,
-              "line": 193
-            }
-          }
-        },
-        {
-          "id": "248",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 21,
-          "static": false,
-          "killedBy": [
-            "20"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 199
-            },
-            "start": {
-              "column": 3,
-              "line": 195
-            }
-          }
-        },
-        {
-          "id": "249",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 21,
-          "static": false,
-          "killedBy": [
-            "20"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 44,
-              "line": 196
-            },
-            "start": {
-              "column": 20,
-              "line": 196
-            }
-          }
-        },
-        {
-          "id": "250",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 21,
-          "static": false,
-          "killedBy": [
-            "20"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 30,
-              "line": 197
-            },
-            "start": {
-              "column": 18,
-              "line": 197
-            }
-          }
-        },
-        {
-          "id": "251",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 21,
-          "static": false,
-          "killedBy": [
-            "20"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 198
-            },
-            "start": {
-              "column": 12,
-              "line": 198
-            }
-          }
-        },
-        {
-          "id": "252",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 22,
-          "static": false,
-          "killedBy": [
-            "21"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 204
-            },
-            "start": {
-              "column": 3,
-              "line": 200
-            }
-          }
-        },
-        {
-          "id": "253",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 22,
-          "static": false,
-          "killedBy": [
-            "21"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 53,
-              "line": 201
-            },
-            "start": {
-              "column": 20,
-              "line": 201
-            }
-          }
-        },
-        {
-          "id": "254",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 22,
-          "static": false,
-          "killedBy": [
-            "21"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 38,
-              "line": 202
-            },
-            "start": {
-              "column": 18,
-              "line": 202
-            }
-          }
-        },
-        {
-          "id": "255",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 22,
-          "static": false,
-          "killedBy": [
-            "21"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 203
-            },
-            "start": {
-              "column": 12,
-              "line": 203
-            }
-          }
-        },
-        {
-          "id": "256",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 23,
-          "static": false,
-          "killedBy": [
-            "22"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 209
-            },
-            "start": {
-              "column": 3,
-              "line": 205
-            }
-          }
-        },
-        {
-          "id": "257",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 23,
-          "static": false,
-          "killedBy": [
-            "22"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 40,
-              "line": 206
-            },
-            "start": {
-              "column": 20,
-              "line": 206
-            }
-          }
-        },
-        {
-          "id": "258",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 23,
-          "static": false,
-          "killedBy": [
-            "22"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 32,
-              "line": 207
-            },
-            "start": {
-              "column": 18,
-              "line": 207
-            }
-          }
-        },
-        {
-          "id": "259",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 23,
-          "static": false,
-          "killedBy": [
-            "22"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 208
-            },
-            "start": {
-              "column": 12,
-              "line": 208
-            }
-          }
-        },
-        {
-          "id": "260",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 24,
-          "static": false,
-          "killedBy": [
-            "23"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 214
-            },
-            "start": {
-              "column": 3,
-              "line": 210
-            }
-          }
-        },
-        {
-          "id": "261",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 24,
-          "static": false,
-          "killedBy": [
-            "23"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 41,
-              "line": 211
-            },
-            "start": {
-              "column": 20,
-              "line": 211
-            }
-          }
-        },
-        {
-          "id": "262",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 24,
-          "static": false,
-          "killedBy": [
-            "23"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 45,
-              "line": 212
-            },
-            "start": {
-              "column": 18,
-              "line": 212
-            }
-          }
-        },
-        {
-          "id": "263",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
-          "status": "Killed",
-          "testsCompleted": 24,
-          "static": false,
-          "killedBy": [
-            "23"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 213
-            },
-            "start": {
-              "column": 12,
-              "line": 213
-            }
-          }
-        },
-        {
-          "id": "264",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected {} to strictly equal { Object (description, iconClasses, ...) }",
-          "status": "Killed",
-          "testsCompleted": 25,
-          "static": false,
-          "killedBy": [
-            "24"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 219
-            },
-            "start": {
-              "column": 3,
-              "line": 215
-            }
-          }
-        },
-        {
-          "id": "265",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { description: '', …(2) } to strictly equal { Object (description, iconClasses, ...) }",
-          "status": "Killed",
-          "testsCompleted": 25,
-          "static": false,
-          "killedBy": [
-            "24"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 37,
-              "line": 216
-            },
-            "start": {
-              "column": 20,
-              "line": 216
-            }
-          }
-        },
-        {
-          "id": "266",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { Object (description, iconClasses, ...) } to strictly equal { Object (description, iconClasses, ...) }",
-          "status": "Killed",
-          "testsCompleted": 25,
-          "static": false,
-          "killedBy": [
-            "24"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 33,
-              "line": 217
-            },
-            "start": {
-              "column": 18,
-              "line": 217
-            }
-          }
-        },
-        {
-          "id": "267",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { Object (description, iconClasses, ...) } to strictly equal { Object (description, iconClasses, ...) }",
-          "status": "Killed",
-          "testsCompleted": 25,
-          "static": false,
-          "killedBy": [
-            "24"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "15",
-            "16",
-            "17",
-            "18",
-            "19",
-            "20",
-            "21",
-            "22",
-            "23",
-            "24"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 218
-            },
-            "start": {
-              "column": 12,
-              "line": 218
-            }
-          }
-        }
-      ],
-      "source": "<template>\n  <section\n    id=\"skills\"\n    aria-labelledby=\"skills-title\"\n    class=\"section\"\n  >\n    <div class=\"container\">\n      <SectionTitle\n        id=\"skills-title\"\n        icon=\"fa fa-code\"\n        icon-color=\"#007EB8\"\n        :title=\"$t('MySkills.itSkills')\"\n      />\n\n      <div\n        class=\"card\"\n        data-aos=\"fade-up\"\n        data-aos-anchor-placement=\"top-bottom\"\n      >\n        <div class=\"card-body\">\n          <div class=\"row\">\n            <div\n              v-for=\"skill in skills\"\n              :key=\"skill.name\"\n              class=\"col-md-6\"\n            >\n              <SkillProgressBar\n                class=\"skill\"\n                :skill=\"skill\"\n              />\n            </div>\n          </div>\n\n          <hr>\n\n          <div class=\"row\">\n            <div class=\"col-md-12 text-center\">\n              <h3\n                class=\"mb-0\"\n              >\n                {{ $t('MySkills.myTools') }}\n              </h3>\n            </div>\n          </div>\n\n          <div class=\"mb-2 row\">\n            <div\n              class=\"col-12 font-italic my-1 small text-center text-muted\"\n            >\n              {{ `(${$t('MySkills.hoverIconsForDetails')})` }}\n            </div>\n          </div>\n\n          <div class=\"row\">\n            <div class=\"col-md-12 d-flex flex-wrap gap-1 justify-content-center text-center\">\n              <MyTool\n                v-for=\"tool in tools\"\n                :key=\"tool.iconClasses\"\n                class=\"tool\"\n                :tool=\"tool\"\n              />\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n  </section>\n</template>\n\n<script lang=\"ts\" setup>\nimport MyTool from \"~/components/MySkills/MyTool/MyTool.vue\";\nimport SkillProgressBar from \"~/components/MySkills/SkillProgressBar/SkillProgressBar.vue\";\nimport SectionTitle from \"~/components/shared/Layouts/SectionTitle/SectionTitle.vue\";\nimport type { Skill } from \"~/models/skill/skill.types\";\nimport type { Tool } from \"~/models/tool/tool.types\";\n\nconst { t } = useI18n();\n\nconst htmlUrl = \"https://fr.wikipedia.org/wiki/HTML5\";\nconst cssUrl = \"https://fr.wikipedia.org/wiki/Feuilles_de_style_en_cascade\";\nconst jsUrl = \"https://fr.wikipedia.org/wiki/JavaScript\";\nconst tsUrl = \"https://www.typescriptlang.org/\";\nconst vueUrl = \"https://vuejs.org/\";\nconst nuxtUrl = \"https://v3.nuxtjs.org/\";\nconst mysqlUrl = \"https://www.mysql.com/fr/\";\nconst mongodbUrl = \"https://www.mongodb.com/\";\nconst rustUrl = \"https://www.rust-lang.org/\";\nconst skills: Skill[] = [\n  {\n    name: t(\"MySkills.html\"),\n    iconClasses: \"fab fa-html5\",\n    color: \"#E44D27\",\n    percent: \"95%\",\n    url: htmlUrl,\n  },\n  {\n    name: t(\"MySkills.css\"),\n    iconClasses: \"fab fa-css3-alt\",\n    color: \"#0162B0\",\n    percent: \"90%\",\n    url: cssUrl,\n  },\n  {\n    name: t(\"MySkills.javascript\"),\n    iconClasses: \"fab fa-js\",\n    color: \"#EFC624\",\n    percent: \"95%\",\n    url: jsUrl,\n  },\n  {\n    name: t(\"MySkills.typescript\"),\n    iconClasses: \"fas fa-rocket\",\n    color: \"#3077C6\",\n    percent: \"85%\",\n    url: tsUrl,\n  },\n  {\n    name: t(\"MySkills.vue\"),\n    iconClasses: \"fab fa-vuejs\",\n    color: \"#38956A\",\n    percent: \"95%\",\n    url: vueUrl,\n  },\n  {\n    name: t(\"MySkills.nuxt\"),\n    iconClasses: \"fas fa-mountain-sun\",\n    color: \"#00DC81\",\n    percent: \"90%\",\n    url: nuxtUrl,\n  },\n  {\n    name: t(\"MySkills.mysql\"),\n    iconClasses: \"fas fa-database\",\n    color: \"#017395\",\n    percent: \"85%\",\n    url: mysqlUrl,\n  },\n  {\n    name: t(\"MySkills.mongodb\"),\n    iconClasses: \"fas fa-leaf\",\n    color: \"#4E9445\",\n    percent: \"90%\",\n    url: mongodbUrl,\n  },\n  {\n    name: t(\"MySkills.rust\"),\n    iconClasses: \"fab fa-rust\",\n    color: \"#E3884F\",\n    percent: \"60%\",\n    url: rustUrl,\n  },\n];\n\nconst tools: Tool[] = [\n  {\n    description: t(\"MySkills.linuxForServers\"),\n    iconClasses: \"fab fa-linux\",\n    color: \"#2C2C2C\",\n  },\n  {\n    description: t(\"MySkills.microServicesArchitecture\"),\n    iconClasses: \"fas fa-sitemap\",\n    color: \"#007EB8\",\n  },\n  {\n    description: t(\"MySkills.gitForVersionControl\"),\n    iconClasses: \"fab fa-git\",\n    color: \"#F05033\",\n  },\n  {\n    description: t(\"MySkills.multipleEnvs\"),\n    iconClasses: \"fas fa-code-branch\",\n    color: \"#6C757D\",\n  },\n  {\n    description: t(\"MySkills.gitHubAndActions\"),\n    iconClasses: \"fab fa-github \",\n    color: \"#000000\",\n  },\n  {\n    description: t(\"MySkills.nodeJsForProjects\"),\n    iconClasses: \"fab fa-node-js \",\n    color: \"#539E43\",\n  },\n  {\n    description: t(\"MySkills.cssFrameworks\"),\n    iconClasses: \"fab fa-css3-alt \",\n    color: \"#0162B0\",\n  },\n  {\n    description: t(\"MySkills.vueJsWithNuxt\"),\n    iconClasses: \"fab fa-vuejs\",\n    color: \"#38956A\",\n  },\n  {\n    description: t(\"MySkills.openSourceNpm\"),\n    iconClasses: \"fab fa-npm\",\n    color: \"#C63635\",\n  },\n  {\n    description: t(\"MySkills.esLintForGoodPractises\"),\n    iconClasses: \"fas fa-spell-check\",\n    color: \"#00B819\",\n  },\n  {\n    description: t(\"MySkills.unitTests\"),\n    iconClasses: \"fas fa-tasks\",\n    color: \"#35485E\",\n  },\n  {\n    description: t(\"MySkills.openSource\"),\n    iconClasses: \"fas fa-hand-holding-heart\",\n    color: \"#C41B1B\",\n  },\n  {\n    description: t(\"MySkills.docker\"),\n    iconClasses: \"fab fa-docker\",\n    color: \"#2F87E3\",\n  },\n];\n</script>"
-    },
-    "app/components/MySkills/SkillProgressBar/SkillProgressBar.vue": {
-      "language": "html",
-      "mutants": [
-        {
-          "id": "268",
-          "mutatorName": "ArrowFunction",
-          "replacement": "() => undefined",
-          "statusReason": "Snapshot `Skill Progress Bar Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "98"
-          ],
-          "coveredBy": [
-            "98",
-            "99",
-            "100",
-            "101",
-            "102",
-            "103",
-            "104",
-            "105"
-          ],
-          "location": {
-            "end": {
-              "column": 3,
-              "line": 59
-            },
-            "start": {
-              "column": 59,
-              "line": 56
-            }
-          }
-        },
-        {
-          "id": "269",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Snapshot `Skill Progress Bar Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "98"
-          ],
-          "coveredBy": [
-            "98",
-            "99",
-            "100",
-            "101",
-            "102",
-            "103",
-            "104",
-            "105"
-          ],
-          "location": {
-            "end": {
-              "column": 2,
-              "line": 59
-            },
-            "start": {
-              "column": 66,
-              "line": 56
-            }
-          }
-        },
-        {
-          "id": "270",
-          "mutatorName": "ArrowFunction",
-          "replacement": "() => undefined",
-          "statusReason": "Snapshot `Skill Progress Bar Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "98"
-          ],
-          "coveredBy": [
-            "98",
-            "99",
-            "100",
-            "101",
-            "102",
-            "103",
-            "104",
-            "105"
-          ],
-          "location": {
-            "end": {
-              "column": 3,
-              "line": 64
-            },
-            "start": {
-              "column": 47,
-              "line": 61
-            }
-          }
-        },
-        {
-          "id": "271",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Snapshot `Skill Progress Bar Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "98"
-          ],
-          "coveredBy": [
-            "98",
-            "99",
-            "100",
-            "101",
-            "102",
-            "103",
-            "104",
-            "105"
-          ],
-          "location": {
-            "end": {
-              "column": 87,
-              "line": 61
-            },
-            "start": {
-              "column": 55,
-              "line": 61
-            }
-          }
-        },
-        {
-          "id": "272",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Snapshot `Skill Progress Bar Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "98"
-          ],
-          "coveredBy": [
-            "98",
-            "99",
-            "100",
-            "101",
-            "102",
-            "103",
-            "104",
-            "105"
-          ],
-          "location": {
-            "end": {
-              "column": 2,
-              "line": 64
-            },
-            "start": {
-              "column": 89,
-              "line": 61
-            }
-          }
-        }
-      ],
-      "source": "<template>\n  <div class=\"progress-container\">\n    <span\n      id=\"badge-html\"\n      class=\"progress-badge\"\n    >\n      <WrappedFontAwesomeIcon\n        class=\"skill-icon\"\n        classes=\"me-2\"\n        :icon=\"skill.iconClasses\"\n        :icon-color=\"skill.color\"\n      />\n\n      <b>\n        <a\n          class=\"skill-name text-muted\"\n          :href=\"skill.url\"\n          rel=\"noopener noreferrer\"\n          target=\"_blank\"\n        >\n          {{ skill.name }}\n        </a>\n      </b>\n    </span>\n\n    <div class=\"progress\">\n      <div\n        :aria-label=\"progressBarAriaLabel\"\n        aria-valuemax=\"100\"\n        aria-valuemin=\"0\"\n        class=\"progress-bar progress-bar-primary\"\n        data-aos=\"progress-full\"\n        data-aos-duration=\"2000\"\n        data-aos-offset=\"10\"\n        role=\"progressbar\"\n        :style=\"progressBarStyle\"\n      />\n\n      <span\n        class=\"font-weight-bold progress-value\"\n      >\n        {{ skill.percent }}\n      </span>\n    </div>\n  </div>\n</template>\n\n<script setup lang=\"ts\">\nimport type { SkillProgressBarProps } from \"~/components/MySkills/SkillProgressBar/skill-progress-bar.types\";\nimport WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\n\nconst props = defineProps<SkillProgressBarProps>();\n\nconst { t } = useI18n();\n\nconst progressBarStyle = computed<Record<string, string>>(() => ({\n  width: props.skill.percent,\n  backgroundColor: props.skill.color,\n}));\n\nconst progressBarAriaLabel = computed<string>(() => t(\"SkillProgressBar.skillProgress\", {\n  skillName: props.skill.name,\n  skillPercent: props.skill.percent,\n}));\n</script>"
-    },
-    "app/components/NavBar/NavBar.vue": {
-      "language": "html",
-      "mutants": [
-        {
-          "id": "273",
-          "mutatorName": "BooleanLiteral",
-          "replacement": "false",
-          "statusReason": "Snapshot `NavBar Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "80"
-          ],
-          "coveredBy": [
-            "80",
-            "81",
-            "82",
-            "83",
-            "84"
-          ],
-          "location": {
-            "end": {
-              "column": 50,
-              "line": 101
-            },
-            "start": {
-              "column": 46,
-              "line": 101
-            }
-          }
-        },
-        {
-          "id": "274",
-          "mutatorName": "BlockStatement",
-          "replacement": "{}",
-          "statusReason": "expected [ 'collapse', …(2) ] to include 'show'",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "82"
-          ],
-          "coveredBy": [
-            "82",
-            "83",
-            "84"
-          ],
-          "location": {
-            "end": {
-              "column": 2,
-              "line": 105
-            },
-            "start": {
-              "column": 43,
-              "line": 103
-            }
-          }
-        },
-        {
-          "id": "275",
-          "mutatorName": "BooleanLiteral",
-          "replacement": "isMobileNavBarCollapsed.value",
-          "statusReason": "expected [ 'collapse', …(2) ] to include 'show'",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "82"
-          ],
-          "coveredBy": [
-            "82",
-            "83",
-            "84"
-          ],
-          "location": {
-            "end": {
-              "column": 65,
-              "line": 104
-            },
-            "start": {
-              "column": 35,
-              "line": 104
-            }
-          }
-        },
-        {
-          "id": "276",
-          "mutatorName": "BlockStatement",
-          "replacement": "{}",
-          "statusReason": "expected [ 'collapse', …(3) ] to not include 'show'",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "84"
-          ],
-          "coveredBy": [
-            "84"
-          ],
-          "location": {
-            "end": {
-              "column": 2,
-              "line": 109
-            },
-            "start": {
-              "column": 40,
-              "line": 107
-            }
-          }
-        },
-        {
-          "id": "277",
-          "mutatorName": "BooleanLiteral",
-          "replacement": "false",
-          "statusReason": "expected [ 'collapse', …(3) ] to not include 'show'",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "84"
-          ],
-          "coveredBy": [
-            "84"
-          ],
-          "location": {
-            "end": {
-              "column": 39,
-              "line": 108
-            },
-            "start": {
-              "column": 35,
-              "line": 108
-            }
-          }
-        }
-      ],
-      "source": "<template>\n  <header>\n    <div class=\"profile-page sidebar-collapse\">\n      <nav\n        class=\"background-primary fixed-top navbar navbar-expand-lg\"\n        data-color-on-scroll=\"100\"\n      >\n        <div class=\"container\">\n          <div class=\"navbar-translate\">\n            <a\n              class=\"navbar-brand text-uppercase\"\n              href=\"#\"\n            >\n              {{ ANTOINE_ZANARDI_FULL_NAME }}\n            </a>\n\n            <button\n              aria-controls=\"navigation\"\n              :aria-expanded=\"false\"\n              :aria-label=\"$t('NavBar.openNavigation')\"\n              class=\"navbar-toggler\"\n              data-target=\"#navigation\"\n              data-toggle=\"collapse\"\n              type=\"button\"\n              @click=\"onClickFromNavBarToggler\"\n            >\n              <span class=\"bar1 navbar-toggler-bar\"/>\n\n              <span class=\"bar2 navbar-toggler-bar\"/>\n\n              <span class=\"bar3 navbar-toggler-bar\"/>\n            </button>\n          </div>\n\n          <div\n            id=\"navigation\"\n            class=\"collapse justify-content-end navbar-collapse\"\n            :class=\"{ 'show': !isMobileNavBarCollapsed }\"\n          >\n            <ul class=\"navbar-nav w-100\">\n              <li class=\"nav-item\">\n                <a\n                  class=\"nav-link smooth-scroll\"\n                  href=\"#about\"\n                  @click=\"onClickFromNavBarLink\"\n                >\n                  {{ $t('AboutMyProfile.whoAmI') }}\n                </a>\n              </li>\n\n              <li class=\"nav-item\">\n                <a\n                  class=\"nav-link smooth-scroll\"\n                  href=\"#skills\"\n                  @click=\"onClickFromNavBarLink\"\n                >\n                  {{ $t('MySkills.itSkills') }}\n                </a>\n              </li>\n\n              <li class=\"nav-item\">\n                <a\n                  class=\"nav-link smooth-scroll\"\n                  href=\"#portfolio\"\n                  @click=\"onClickFromNavBarLink\"\n                >\n                  {{ $t('MyPortfolio.portfolio') }}\n                </a>\n              </li>\n\n              <li class=\"nav-item\">\n                <a\n                  class=\"nav-link smooth-scroll\"\n                  href=\"#experience\"\n                  @click=\"onClickFromNavBarLink\"\n                >\n                  {{ $t('MyExperience.professionalExperience') }}\n                </a>\n              </li>\n\n              <li class=\"nav-item\">\n                <a\n                  class=\"nav-link smooth-scroll\"\n                  href=\"#education\"\n                  @click=\"onClickFromNavBarLink\"\n                >\n                  {{ $t('MyEducation.education') }}\n                </a>\n              </li>\n            </ul>\n          </div>\n        </div>\n      </nav>\n    </div>\n  </header>\n</template>\n\n<script lang=\"ts\" setup>\nimport { ANTOINE_ZANARDI_FULL_NAME } from \"~/shared/constants/antoine-zanardi.constants\";\n\nconst isMobileNavBarCollapsed = ref<boolean>(true);\n\nfunction onClickFromNavBarToggler(): void {\n  isMobileNavBarCollapsed.value = !isMobileNavBarCollapsed.value;\n}\n\nfunction onClickFromNavBarLink(): void {\n  isMobileNavBarCollapsed.value = true;\n}\n</script>\n\n<style lang=\"scss\" scoped>\n.navbar {\n  box-shadow: 0px -5px 20px 5px black;\n\n  #navigation.show {\n    transform: unset;\n  }\n\n  .nav-item {\n    display: flex;\n    align-items: center;\n    justify-content: center;\n    text-align: center;\n  }\n\n  .navbar-toggler {\n    border: 0;\n  }\n}\n</style>"
-    },
-    "app/components/PageFooter/PageFooter.vue": {
-      "language": "html",
-      "mutants": [
-        {
-          "id": "280",
-          "mutatorName": "ArrowFunction",
-          "replacement": "() => undefined",
-          "statusReason": "Snapshot `Page Footer Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "141"
-          ],
-          "coveredBy": [
-            "141",
-            "142"
-          ],
-          "location": {
-            "end": {
-              "column": 65,
-              "line": 30
-            },
-            "start": {
-              "column": 35,
-              "line": 30
-            }
-          }
-        }
-      ],
-      "source": "<template>\n  <footer class=\"footer py-1\">\n    <div\n      class=\"container text-center\"\n      data-aos=\"fade-up\"\n      data-aos-anchor-placement=\"top-bottom\"\n    >\n      <LinkedInButton class=\"me-2\"/>\n\n      <GitHubButton/>\n    </div>\n\n    <div class=\"font-italic h4 my-2 text-center text-muted title\">\n      <span>\n        {{ ANTOINE_ZANARDI_FULL_NAME }}\n      </span>\n\n      <span>\n        {{ ` - ${fullYear}` }}\n      </span>\n    </div>\n  </footer>\n</template>\n\n<script lang=\"ts\" setup>\nimport GitHubButton from \"~/components/shared/Buttons/GitHubButton.vue\";\nimport LinkedInButton from \"~/components/shared/Buttons/LinkedInButton.vue\";\nimport { ANTOINE_ZANARDI_FULL_NAME } from \"~/shared/constants/antoine-zanardi.constants\";\n\nconst fullYear = computed<number>(() => new Date().getFullYear());\n</script>"
     },
     "app/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue": {
       "language": "html",
@@ -10745,157 +391,6 @@
         }
       ],
       "source": "<template>\n  <span>\n    <ClientOnly>\n      <FontAwesomeIcon\n        class=\"font-awesome-icon\"\n        :class=\"classes\"\n        :icon=\"icon\"\n        :size=\"size\"\n        :style=\"{ 'color': iconColor }\"\n      />\n    </ClientOnly>\n  </span>\n</template>\n\n<script lang=\"ts\" setup>\nimport { FontAwesomeIcon } from \"@fortawesome/vue-fontawesome\";\n\nimport type { WrappedFontAwesomeIconProps } from \"~/components/shared/Icons/WrappedFontAwesomeIcon/wrapped-font-awesome-icon.types\";\n\nwithDefaults(defineProps<WrappedFontAwesomeIconProps>(), {\n  iconColor: \"#000000\",\n  size: undefined,\n  classes: \"\",\n});\n</script>"
-    },
-    "app/components/shared/Images/CountryFlag/CountryFlag.vue": {
-      "language": "html",
-      "mutants": [
-        {
-          "id": "284",
-          "mutatorName": "BlockStatement",
-          "replacement": "{}",
-          "statusReason": "Snapshot `Country Flag Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "110"
-          ],
-          "coveredBy": [
-            "110",
-            "111",
-            "112",
-            "113",
-            "114"
-          ],
-          "location": {
-            "end": {
-              "column": 2,
-              "line": 28
-            },
-            "start": {
-              "column": 47,
-              "line": 20
-            }
-          }
-        },
-        {
-          "id": "285",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Snapshot `Country Flag Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "110"
-          ],
-          "coveredBy": [
-            "110",
-            "111",
-            "112",
-            "113",
-            "114"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 25
-            },
-            "start": {
-              "column": 52,
-              "line": 21
-            }
-          }
-        },
-        {
-          "id": "286",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Snapshot `Country Flag Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "110"
-          ],
-          "coveredBy": [
-            "110",
-            "111",
-            "112",
-            "113",
-            "114"
-          ],
-          "location": {
-            "end": {
-              "column": 31,
-              "line": 22
-            },
-            "start": {
-              "column": 13,
-              "line": 22
-            }
-          }
-        },
-        {
-          "id": "287",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected '/images/flags/' to be '/images/flags/usa-flag.webp' // Object.is equality",
-          "status": "Killed",
-          "testsCompleted": 4,
-          "static": false,
-          "killedBy": [
-            "113"
-          ],
-          "coveredBy": [
-            "110",
-            "111",
-            "112",
-            "113",
-            "114"
-          ],
-          "location": {
-            "end": {
-              "column": 25,
-              "line": 23
-            },
-            "start": {
-              "column": 10,
-              "line": 23
-            }
-          }
-        },
-        {
-          "id": "288",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected '/images/flags/' to be '/images/flags/canada-flag.webp' // Object.is equality",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "114"
-          ],
-          "coveredBy": [
-            "110",
-            "111",
-            "112",
-            "113",
-            "114"
-          ],
-          "location": {
-            "end": {
-              "column": 31,
-              "line": 24
-            },
-            "start": {
-              "column": 13,
-              "line": 24
-            }
-          }
-        }
-      ],
-      "source": "<template>\n  <NuxtImg\n    :alt=\"`${country} flag`\"\n    class=\"country-flag\"\n    data-bs-toggle=\"tooltip\"\n    height=\"25\"\n    loading=\"lazy\"\n    :src=\"`/images/flags/${countryFlagSrc}`\"\n    :title=\"$t(`Countries.${country}`)\"\n    width=\"25\"\n  />\n</template>\n\n<script setup lang=\"ts\">\nimport type { CountryFlagProps } from \"~/components/shared/Images/CountryFlag/country-flag.types\";\nimport type { Country } from \"~/models/country/country.types\";\n\nconst props = defineProps<CountryFlagProps>();\n\nconst countryFlagSrc = computed<string>(() => {\n  const countryFlagsSrc: Record<Country, string> = {\n    france: \"france-flag.webp\",\n    usa: \"usa-flag.webp\",\n    canada: \"canada-flag.webp\",\n  };\n\n  return countryFlagsSrc[props.country];\n});\n</script>\n\n<style scoped lang=\"scss\">\n.country-flag {\n  width: 25px;\n  height: 25px;\n}\n</style>"
     },
     "app/components/shared/Layouts/SectionTitle/SectionTitle.vue": {
       "language": "html",
@@ -10984,8 +479,8 @@
           "replacement": "{}",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 11,
           "static": false,
+          "testsCompleted": 11,
           "killedBy": [
             "35"
           ],
@@ -11028,8 +523,8 @@
           "replacement": "props.startedAt",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 11,
           "static": false,
+          "testsCompleted": 11,
           "killedBy": [
             "35"
           ],
@@ -11072,8 +567,8 @@
           "replacement": "true",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 11,
           "static": false,
+          "testsCompleted": 11,
           "killedBy": [
             "35"
           ],
@@ -11111,101 +606,13 @@
           }
         },
         {
-          "id": "296",
-          "mutatorName": "ConditionalExpression",
-          "replacement": "false",
-          "statusReason": "expected undefined to be '' // Object.is equality",
-          "status": "Killed",
-          "testsCompleted": 17,
-          "static": false,
-          "killedBy": [
-            "41"
-          ],
-          "coveredBy": [
-            "25",
-            "26",
-            "27",
-            "28",
-            "29",
-            "30",
-            "31",
-            "32",
-            "33",
-            "34",
-            "35",
-            "36",
-            "37",
-            "38",
-            "39",
-            "40",
-            "41",
-            "42",
-            "43",
-            "44"
-          ],
-          "location": {
-            "end": {
-              "column": 23,
-              "line": 87
-            },
-            "start": {
-              "column": 7,
-              "line": 87
-            }
-          }
-        },
-        {
-          "id": "297",
-          "mutatorName": "BlockStatement",
-          "replacement": "{}",
-          "statusReason": "expected undefined to be '' // Object.is equality",
-          "status": "Killed",
-          "testsCompleted": 17,
-          "static": false,
-          "killedBy": [
-            "41"
-          ],
-          "coveredBy": [
-            "25",
-            "26",
-            "27",
-            "28",
-            "29",
-            "30",
-            "31",
-            "32",
-            "33",
-            "34",
-            "35",
-            "36",
-            "37",
-            "38",
-            "39",
-            "40",
-            "41",
-            "42",
-            "43",
-            "44"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 89
-            },
-            "start": {
-              "column": 25,
-              "line": 87
-            }
-          }
-        },
-        {
           "id": "298",
           "mutatorName": "StringLiteral",
           "replacement": "\"Stryker was here!\"",
           "statusReason": "Snapshot `Period Timeline Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "25"
           ],
@@ -11243,13 +650,101 @@
           }
         },
         {
+          "id": "297",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "expected undefined to be '' // Object.is equality",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 17,
+          "killedBy": [
+            "41"
+          ],
+          "coveredBy": [
+            "25",
+            "26",
+            "27",
+            "28",
+            "29",
+            "30",
+            "31",
+            "32",
+            "33",
+            "34",
+            "35",
+            "36",
+            "37",
+            "38",
+            "39",
+            "40",
+            "41",
+            "42",
+            "43",
+            "44"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 89
+            },
+            "start": {
+              "column": 25,
+              "line": 87
+            }
+          }
+        },
+        {
+          "id": "296",
+          "mutatorName": "ConditionalExpression",
+          "replacement": "false",
+          "statusReason": "expected undefined to be '' // Object.is equality",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 17,
+          "killedBy": [
+            "41"
+          ],
+          "coveredBy": [
+            "25",
+            "26",
+            "27",
+            "28",
+            "29",
+            "30",
+            "31",
+            "32",
+            "33",
+            "34",
+            "35",
+            "36",
+            "37",
+            "38",
+            "39",
+            "40",
+            "41",
+            "42",
+            "43",
+            "44"
+          ],
+          "location": {
+            "end": {
+              "column": 23,
+              "line": 87
+            },
+            "start": {
+              "column": 7,
+              "line": 87
+            }
+          }
+        },
+        {
           "id": "299",
           "mutatorName": "LogicalOperator",
           "replacement": "props.finishedAt && new Date()",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 2,
           "static": false,
+          "testsCompleted": 2,
           "killedBy": [
             "35"
           ],
@@ -11281,8 +776,8 @@
           "replacement": "\"Stryker was here!\"",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 2,
           "static": false,
+          "testsCompleted": 2,
           "killedBy": [
             "35"
           ],
@@ -11314,8 +809,8 @@
           "replacement": "true",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 2,
           "static": false,
+          "testsCompleted": 2,
           "killedBy": [
             "35"
           ],
@@ -11347,8 +842,8 @@
           "replacement": "false",
           "statusReason": "expected '(  shared.and shared.months, {\"monthC…' to be '( shared.years, {\"yearCount\":2}, 2 sh…' // Object.is equality",
           "status": "Killed",
-          "testsCompleted": 5,
           "static": false,
+          "testsCompleted": 5,
           "killedBy": [
             "38"
           ],
@@ -11380,8 +875,8 @@
           "replacement": "{}",
           "statusReason": "expected '(  shared.and shared.months, {\"monthC…' to be '( shared.years, {\"yearCount\":2}, 2 sh…' // Object.is equality",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "38"
           ],
@@ -11408,8 +903,8 @@
           "replacement": "periodText -= t(\"shared.years\", {\n  yearCount: period.year\n}, period.year)",
           "statusReason": "expected '( NaN shared.and shared.months, {\"mon…' to be '( shared.years, {\"yearCount\":2}, 2 sh…' // Object.is equality",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "38"
           ],
@@ -11436,8 +931,8 @@
           "replacement": "\"\"",
           "statusReason": "expected '( , {\"yearCount\":2}, 2 shared.and sha…' to be '( shared.years, {\"yearCount\":2}, 2 sh…' // Object.is equality",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "38"
           ],
@@ -11464,8 +959,8 @@
           "replacement": "{}",
           "statusReason": "expected '( shared.years, {}, 2 shared.and shar…' to be '( shared.years, {\"yearCount\":2}, 2 sh…' // Object.is equality",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "38"
           ],
@@ -11492,8 +987,8 @@
           "replacement": "props.doesShowYearOnly",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 2,
           "static": false,
+          "testsCompleted": 2,
           "killedBy": [
             "35"
           ],
@@ -11525,8 +1020,8 @@
           "replacement": "true",
           "statusReason": "expected '( shared.years, {\"yearCount\":2}, 2 sh…' to be '( shared.years, {\"yearCount\":2}, 2 )' // Object.is equality",
           "status": "Killed",
-          "testsCompleted": 9,
           "static": false,
+          "testsCompleted": 9,
           "killedBy": [
             "44"
           ],
@@ -11558,8 +1053,8 @@
           "replacement": "false",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 2,
           "static": false,
+          "testsCompleted": 2,
           "killedBy": [
             "35"
           ],
@@ -11591,8 +1086,8 @@
           "replacement": "{}",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 2,
           "static": false,
+          "testsCompleted": 2,
           "killedBy": [
             "35"
           ],
@@ -11622,8 +1117,8 @@
           "replacement": "true",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 2,
           "static": false,
+          "testsCompleted": 2,
           "killedBy": [
             "35"
           ],
@@ -11653,8 +1148,8 @@
           "replacement": "false",
           "statusReason": "expected '( shared.years, {\"yearCount\":2}, 2sha…' to be '( shared.years, {\"yearCount\":2}, 2 sh…' // Object.is equality",
           "status": "Killed",
-          "testsCompleted": 4,
           "static": false,
+          "testsCompleted": 4,
           "killedBy": [
             "38"
           ],
@@ -11684,8 +1179,8 @@
           "replacement": "period.month || period.year",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 2,
           "static": false,
+          "testsCompleted": 2,
           "killedBy": [
             "35"
           ],
@@ -11715,8 +1210,8 @@
           "replacement": "{}",
           "statusReason": "expected '( shared.years, {\"yearCount\":2}, 2sha…' to be '( shared.years, {\"yearCount\":2}, 2 sh…' // Object.is equality",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "38"
           ],
@@ -11741,8 +1236,8 @@
           "replacement": "``",
           "statusReason": "expected '( shared.years, {\"yearCount\":2}, 2sha…' to be '( shared.years, {\"yearCount\":2}, 2 sh…' // Object.is equality",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "38"
           ],
@@ -11767,8 +1262,8 @@
           "replacement": "\"\"",
           "statusReason": "expected '( shared.years, {\"yearCount\":2}, 2  s…' to be '( shared.years, {\"yearCount\":2}, 2 sh…' // Object.is equality",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "38"
           ],
@@ -11793,8 +1288,8 @@
           "replacement": "true",
           "statusReason": "expected '( shared.years, {\"yearCount\":1}, 1sha…' to be '( shared.years, {\"yearCount\":1}, 1 )' // Object.is equality",
           "status": "Killed",
-          "testsCompleted": 6,
           "static": false,
+          "testsCompleted": 6,
           "killedBy": [
             "42"
           ],
@@ -11824,8 +1319,8 @@
           "replacement": "false",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 2,
           "static": false,
+          "testsCompleted": 2,
           "killedBy": [
             "35"
           ],
@@ -11855,8 +1350,8 @@
           "replacement": "{}",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 2,
           "static": false,
+          "testsCompleted": 2,
           "killedBy": [
             "35"
           ],
@@ -11885,8 +1380,8 @@
           "replacement": "periodText -= t(\"shared.months\", {\n  monthCount: period.month\n})",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 2,
           "static": false,
+          "testsCompleted": 2,
           "killedBy": [
             "35"
           ],
@@ -11915,8 +1410,8 @@
           "replacement": "\"\"",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 2,
           "static": false,
+          "testsCompleted": 2,
           "killedBy": [
             "35"
           ],
@@ -11945,8 +1440,8 @@
           "replacement": "{}",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 2,
           "static": false,
+          "testsCompleted": 2,
           "killedBy": [
             "35"
           ],
@@ -11975,8 +1470,8 @@
           "replacement": "``",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 2,
           "static": false,
+          "testsCompleted": 2,
           "killedBy": [
             "35"
           ],
@@ -12008,8 +1503,8 @@
           "replacement": "{}",
           "statusReason": "expected false to be truthy",
           "status": "Killed",
-          "testsCompleted": 9,
           "static": false,
+          "testsCompleted": 9,
           "killedBy": [
             "33"
           ],
@@ -12052,8 +1547,8 @@
           "replacement": "startedAt",
           "statusReason": "expected false to be truthy",
           "status": "Killed",
-          "testsCompleted": 9,
           "static": false,
+          "testsCompleted": 9,
           "killedBy": [
             "33"
           ],
@@ -12096,54 +1591,10 @@
           "replacement": "true",
           "statusReason": "expected false to be truthy",
           "status": "Killed",
-          "testsCompleted": 9,
           "static": false,
+          "testsCompleted": 9,
           "killedBy": [
             "33"
-          ],
-          "coveredBy": [
-            "25",
-            "26",
-            "27",
-            "28",
-            "29",
-            "30",
-            "31",
-            "32",
-            "33",
-            "34",
-            "35",
-            "36",
-            "37",
-            "38",
-            "39",
-            "40",
-            "41",
-            "42",
-            "43",
-            "44"
-          ],
-          "location": {
-            "end": {
-              "column": 17,
-              "line": 109
-            },
-            "start": {
-              "column": 7,
-              "line": 109
-            }
-          }
-        },
-        {
-          "id": "327",
-          "mutatorName": "ConditionalExpression",
-          "replacement": "false",
-          "statusReason": "expected undefined to be '' // Object.is equality",
-          "status": "Killed",
-          "testsCompleted": 10,
-          "static": false,
-          "killedBy": [
-            "34"
           ],
           "coveredBy": [
             "25",
@@ -12184,8 +1635,8 @@
           "replacement": "{}",
           "statusReason": "expected undefined to be '' // Object.is equality",
           "status": "Killed",
-          "testsCompleted": 10,
           "static": false,
+          "testsCompleted": 10,
           "killedBy": [
             "34"
           ],
@@ -12223,13 +1674,57 @@
           }
         },
         {
+          "id": "327",
+          "mutatorName": "ConditionalExpression",
+          "replacement": "false",
+          "statusReason": "expected undefined to be '' // Object.is equality",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 10,
+          "killedBy": [
+            "34"
+          ],
+          "coveredBy": [
+            "25",
+            "26",
+            "27",
+            "28",
+            "29",
+            "30",
+            "31",
+            "32",
+            "33",
+            "34",
+            "35",
+            "36",
+            "37",
+            "38",
+            "39",
+            "40",
+            "41",
+            "42",
+            "43",
+            "44"
+          ],
+          "location": {
+            "end": {
+              "column": 17,
+              "line": 109
+            },
+            "start": {
+              "column": 7,
+              "line": 109
+            }
+          }
+        },
+        {
           "id": "329",
           "mutatorName": "StringLiteral",
           "replacement": "\"Stryker was here!\"",
           "statusReason": "Snapshot `Period Timeline Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "25"
           ],
@@ -12272,8 +1767,8 @@
           "replacement": "``",
           "statusReason": "expected false to be truthy",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "33"
           ],
@@ -12298,57 +1793,13 @@
           }
         },
         {
-          "id": "331",
-          "mutatorName": "BlockStatement",
-          "replacement": "{}",
-          "statusReason": "Snapshot `Period Timeline Component > should match snapshot when rendered. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "25"
-          ],
-          "coveredBy": [
-            "25",
-            "26",
-            "27",
-            "28",
-            "29",
-            "30",
-            "31",
-            "32",
-            "33",
-            "34",
-            "35",
-            "36",
-            "37",
-            "38",
-            "39",
-            "40",
-            "41",
-            "42",
-            "43",
-            "44"
-          ],
-          "location": {
-            "end": {
-              "column": 2,
-              "line": 126
-            },
-            "start": {
-              "column": 52,
-              "line": 118
-            }
-          }
-        },
-        {
           "id": "332",
           "mutatorName": "ConditionalExpression",
           "replacement": "true",
           "statusReason": "Snapshot `Period Timeline Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "25"
           ],
@@ -12386,13 +1837,57 @@
           }
         },
         {
+          "id": "331",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "Snapshot `Period Timeline Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "25"
+          ],
+          "coveredBy": [
+            "25",
+            "26",
+            "27",
+            "28",
+            "29",
+            "30",
+            "31",
+            "32",
+            "33",
+            "34",
+            "35",
+            "36",
+            "37",
+            "38",
+            "39",
+            "40",
+            "41",
+            "42",
+            "43",
+            "44"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 126
+            },
+            "start": {
+              "column": 52,
+              "line": 118
+            }
+          }
+        },
+        {
           "id": "333",
           "mutatorName": "ConditionalExpression",
           "replacement": "false",
           "statusReason": "expected 'shared.today' to be 'janvier 2022' // Object.is equality",
           "status": "Killed",
-          "testsCompleted": 6,
           "static": false,
+          "testsCompleted": 6,
           "killedBy": [
             "30"
           ],
@@ -12435,8 +1930,8 @@
           "replacement": "{}",
           "statusReason": "expected 'shared.today' to be 'janvier 2022' // Object.is equality",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "30"
           ],
@@ -12468,8 +1963,8 @@
           "replacement": "``",
           "statusReason": "expected '' to be 'janvier 2022' // Object.is equality",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "30"
           ],
@@ -12499,8 +1994,8 @@
           "replacement": "\"\"",
           "statusReason": "Snapshot `Period Timeline Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "25"
           ],
@@ -12543,8 +2038,8 @@
           "replacement": "() => undefined",
           "statusReason": "expected false to be truthy",
           "status": "Killed",
-          "testsCompleted": 9,
           "static": false,
+          "testsCompleted": 9,
           "killedBy": [
             "33"
           ],
@@ -12587,8 +2082,8 @@
           "replacement": "!formattedStartedAt.value",
           "statusReason": "Snapshot `Period Timeline Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "25"
           ],
@@ -12631,8 +2126,8 @@
           "replacement": "formattedStartedAt.value",
           "statusReason": "Snapshot `Period Timeline Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "25"
           ],
@@ -12675,8 +2170,8 @@
           "replacement": "{}",
           "statusReason": "Snapshot `Period Timeline Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "25"
           ],
@@ -12719,8 +2214,8 @@
           "replacement": "true",
           "statusReason": "Snapshot `Period Timeline Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "25"
           ],
@@ -12763,8 +2258,8 @@
           "replacement": "false",
           "statusReason": "expected 'PeriodTimeline.obtainedAtAriaLabel, {…' to be 'aria-label' // Object.is equality",
           "status": "Killed",
-          "testsCompleted": 4,
           "static": false,
+          "testsCompleted": 4,
           "killedBy": [
             "28"
           ],
@@ -12807,8 +2302,8 @@
           "replacement": "props.periodDatesAriaLabel === undefined",
           "statusReason": "Snapshot `Period Timeline Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "25"
           ],
@@ -12851,8 +2346,8 @@
           "replacement": "{}",
           "statusReason": "expected 'PeriodTimeline.obtainedAtAriaLabel, {…' to be 'aria-label' // Object.is equality",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "28"
           ],
@@ -12876,8 +2371,8 @@
           "replacement": "true",
           "statusReason": "Snapshot `Period Timeline Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "25"
           ],
@@ -12920,8 +2415,8 @@
           "replacement": "false",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 11,
           "static": false,
+          "testsCompleted": 11,
           "killedBy": [
             "35"
           ],
@@ -12959,46 +2454,13 @@
           }
         },
         {
-          "id": "347",
-          "mutatorName": "BlockStatement",
-          "replacement": "{}",
-          "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 2,
-          "static": false,
-          "killedBy": [
-            "35"
-          ],
-          "coveredBy": [
-            "33",
-            "35",
-            "36",
-            "37",
-            "38",
-            "39",
-            "42",
-            "43",
-            "44"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 140
-            },
-            "start": {
-              "column": 18,
-              "line": 135
-            }
-          }
-        },
-        {
           "id": "348",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 2,
           "static": false,
+          "testsCompleted": 2,
           "killedBy": [
             "35"
           ],
@@ -13025,13 +2487,13 @@
           }
         },
         {
-          "id": "349",
-          "mutatorName": "ObjectLiteral",
+          "id": "347",
+          "mutatorName": "BlockStatement",
           "replacement": "{}",
           "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 2,
           "static": false,
+          "testsCompleted": 2,
           "killedBy": [
             "35"
           ],
@@ -13048,12 +2510,12 @@
           ],
           "location": {
             "end": {
-              "column": 6,
-              "line": 139
+              "column": 4,
+              "line": 140
             },
             "start": {
-              "column": 53,
-              "line": 136
+              "column": 18,
+              "line": 135
             }
           }
         },
@@ -13063,8 +2525,8 @@
           "replacement": "\"\"",
           "statusReason": "Snapshot `Period Timeline Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "25"
           ],
@@ -13102,13 +2564,46 @@
           }
         },
         {
+          "id": "349",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 2,
+          "killedBy": [
+            "35"
+          ],
+          "coveredBy": [
+            "33",
+            "35",
+            "36",
+            "37",
+            "38",
+            "39",
+            "42",
+            "43",
+            "44"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 139
+            },
+            "start": {
+              "column": 53,
+              "line": 136
+            }
+          }
+        },
+        {
           "id": "351",
           "mutatorName": "ObjectLiteral",
           "replacement": "{}",
           "statusReason": "Snapshot `Period Timeline Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 1,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
             "25"
           ],
@@ -13146,7 +2641,4610 @@
           }
         }
       ],
-      "source": "<template>\n  <div\n    id=\"period-timeline\"\n    class=\"d-flex flex-column h-100\"\n  >\n    <a\n      id=\"timeline-logo\"\n      :href=\"url\"\n      rel=\"noopener noreferrer\"\n      target=\"_blank\"\n    >\n      <NuxtImg\n        :alt=\"imageAlt\"\n        class=\"logo timeline-logo-image white-logo\"\n        loading=\"lazy\"\n        :src=\"`/images/logos/${image}`\"\n      />\n    </a>\n\n    <hr class=\"my-3\">\n\n    <div class=\"d-flex flex-column flex-grow-1\">\n      <div\n        id=\"period-dates\"\n        :aria-label=\"periodDatesAriaLabel\"\n        class=\"align-items-center d-flex flex-column flex-grow-1 justify-content-center\"\n        role=\"region\"\n      >\n        <div\n          id=\"finished-at-date\"\n          class=\"period-date\"\n        >\n          {{ formattedFinishedAt }}\n        </div>\n\n        <WrappedFontAwesomeIcon\n          v-if=\"doesPeriodHaveTwoDates\"\n          id=\"arrow-up-icon\"\n          classes=\"my-3\"\n          icon=\"fa-arrow-up\"\n          icon-color=\"#00000\"\n          size=\"2x\"\n        />\n\n        <div\n          v-if=\"formattedStartedAt\"\n          id=\"started-at-date\"\n          class=\"period-date\"\n        >\n          {{ formattedStartedAt }}\n        </div>\n      </div>\n\n      <div\n        v-if=\"formattedPeriod\"\n        id=\"period-label\"\n        class=\"align-items-center d-flex flex-column\"\n      >\n        <hr class=\"w-100\">\n\n        <div\n          class=\"font-italic font-weight-bold small\"\n        >\n          {{ formattedPeriod }}\n        </div>\n      </div>\n    </div>\n  </div>\n</template>\n\n<script lang=\"ts\" setup>\nimport type { PeriodTimelineProps } from \"~/components/shared/Period/period-timeline.types\";\nimport { useDates } from \"~/composables/useDates\";\nimport WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\nimport { Period } from \"~/models/period/period.class\";\n\nconst props = withDefaults(defineProps<PeriodTimelineProps>(), {\n  doesShowYearOnly: false,\n  startedAt: undefined,\n  finishedAt: undefined,\n});\n\nconst { t } = useI18n();\nconst { getMonthFullName } = useDates();\n\nconst formattedPeriod = computed<string>(() => {\n  if (!props.startedAt) {\n    return \"\";\n  }\n  const finishedAt = props.finishedAt ?? new Date();\n  const period = new Period(props.startedAt, finishedAt);\n  let periodText = \"\";\n  if (period.year) {\n    periodText += t(\"shared.years\", { yearCount: period.year }, period.year);\n  }\n  if (!props.doesShowYearOnly) {\n    if (period.month && period.year) {\n      periodText += ` ${t(\"shared.and\")} `;\n    }\n    if (period.month) {\n      periodText += t(\"shared.months\", { monthCount: period.month });\n    }\n  }\n  return `( ${periodText} )`;\n});\n\nconst formattedStartedAt = computed<string>(() => {\n  const { startedAt, doesShowYearOnly } = props;\n  if (!startedAt) {\n    return \"\";\n  }\n  const startedAtMonth = getMonthFullName(startedAt);\n  const startedAtYear = startedAt.getFullYear().toString();\n\n  return doesShowYearOnly ? startedAtYear : `${startedAtMonth} ${startedAtYear}`;\n});\n\nconst formattedFinishedAt = computed<string>(() => {\n  const { finishedAt, doesShowYearOnly } = props;\n  if (finishedAt) {\n    const finishedAtYear = finishedAt.getFullYear().toString();\n\n    return doesShowYearOnly ? finishedAtYear : `${getMonthFullName(finishedAt)} ${finishedAtYear}`;\n  }\n  return t(\"shared.today\");\n});\n\nconst doesPeriodHaveTwoDates = computed<boolean>(() => !!formattedStartedAt.value);\n\nconst periodDatesAriaLabel = computed<string>(() => {\n  const { startedAt } = props;\n  if (props.periodDatesAriaLabel !== undefined) {\n    return props.periodDatesAriaLabel;\n  }\n  if (startedAt) {\n    return t(\"PeriodTimeline.periodDatesAriaLabel\", {\n      startedAt: formattedStartedAt.value,\n      finishedAt: formattedFinishedAt.value,\n    });\n  }\n  return t(\"PeriodTimeline.obtainedAtAriaLabel\", {\n    obtainedAt: formattedFinishedAt.value,\n  });\n});\n</script>\n\n<style lang=\"scss\" scoped>\n.period-date {\n  font-size: 1.25rem;\n}\n.logo {\n  max-width: 180px;\n  max-height: 75px;\n  filter: brightness(0) invert(1);\n}\n</style>"
+      "source": "<template>\n  <div\n    id=\"period-timeline\"\n    class=\"d-flex flex-column h-100\"\n  >\n    <a\n      id=\"timeline-logo\"\n      :href=\"url\"\n      rel=\"noopener noreferrer\"\n      target=\"_blank\"\n    >\n      <NuxtImg\n        :alt=\"imageAlt\"\n        class=\"logo timeline-logo-image white-logo\"\n        loading=\"lazy\"\n        :src=\"`/images/logos/${image}`\"\n      />\n    </a>\n\n    <hr class=\"my-3\">\n\n    <div class=\"d-flex flex-column flex-grow-1\">\n      <div\n        id=\"period-dates\"\n        :aria-label=\"periodDatesAriaLabel\"\n        class=\"align-items-center d-flex flex-column flex-grow-1 justify-content-center\"\n        role=\"region\"\n      >\n        <div\n          id=\"finished-at-date\"\n          class=\"period-date\"\n        >\n          {{ formattedFinishedAt }}\n        </div>\n\n        <WrappedFontAwesomeIcon\n          v-if=\"doesPeriodHaveTwoDates\"\n          id=\"arrow-up-icon\"\n          classes=\"my-3\"\n          icon=\"fa-arrow-up\"\n          icon-color=\"#00000\"\n          size=\"2x\"\n        />\n\n        <div\n          v-if=\"formattedStartedAt\"\n          id=\"started-at-date\"\n          class=\"period-date\"\n        >\n          {{ formattedStartedAt }}\n        </div>\n      </div>\n\n      <div\n        v-if=\"formattedPeriod\"\n        id=\"period-label\"\n        class=\"align-items-center d-flex flex-column\"\n      >\n        <hr class=\"w-100\">\n\n        <div\n          class=\"font-italic font-weight-bold small\"\n        >\n          {{ formattedPeriod }}\n        </div>\n      </div>\n    </div>\n  </div>\n</template>\n\n<script lang=\"ts\" setup>\nimport type { PeriodTimelineProps } from \"~/components/shared/Period/period-timeline.types\";\nimport { useDates } from \"~/composables/useDates\";\nimport WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\nimport { Period } from \"~/models/period/period.class\";\n\nconst props = withDefaults(defineProps<PeriodTimelineProps>(), {\n  doesShowYearOnly: false,\n  startedAt: undefined,\n  finishedAt: undefined,\n});\n\nconst { t } = useI18n();\nconst { getMonthFullName } = useDates();\n\nconst formattedPeriod = computed<string>(() => {\n  if (!props.startedAt) {\n    return \"\";\n  }\n  const finishedAt = props.finishedAt ?? new Date();\n  const period = new Period(props.startedAt, finishedAt);\n  let periodText = \"\";\n  if (period.year) {\n    periodText += t(\"shared.years\", { yearCount: period.year }, period.year);\n  }\n  if (!props.doesShowYearOnly) {\n    if (period.month && period.year) {\n      periodText += ` ${t(\"shared.and\")} `;\n    }\n    if (period.month) {\n      periodText += t(\"shared.months\", { monthCount: period.month });\n    }\n  }\n  return `( ${periodText} )`;\n});\n\nconst formattedStartedAt = computed<string>(() => {\n  const { startedAt, doesShowYearOnly } = props;\n  if (!startedAt) {\n    return \"\";\n  }\n  const startedAtMonth = getMonthFullName(startedAt);\n  const startedAtYear = startedAt.getFullYear().toString();\n\n  return doesShowYearOnly ? startedAtYear : `${startedAtMonth} ${startedAtYear}`;\n});\n\nconst formattedFinishedAt = computed<string>(() => {\n  const { finishedAt, doesShowYearOnly } = props;\n  if (finishedAt) {\n    const finishedAtYear = finishedAt.getFullYear().toString();\n\n    return doesShowYearOnly ? finishedAtYear : `${getMonthFullName(finishedAt)} ${finishedAtYear}`;\n  }\n  return t(\"shared.today\");\n});\n\nconst doesPeriodHaveTwoDates = computed<boolean>(() => !!formattedStartedAt.value);\n\nconst periodDatesAriaLabel = computed<string>(() => {\n  const { startedAt } = props;\n  if (props.periodDatesAriaLabel !== undefined) {\n    return props.periodDatesAriaLabel;\n  }\n  if (startedAt) {\n    return t(\"PeriodTimeline.periodDatesAriaLabel\", {\n      startedAt: formattedStartedAt.value,\n      finishedAt: formattedFinishedAt.value,\n    });\n  }\n  return t(\"PeriodTimeline.obtainedAtAriaLabel\", {\n    obtainedAt: formattedFinishedAt.value,\n  });\n});\n</script>\n\n<style lang=\"scss\" scoped>\n.period-date {\n  font-size: 1.25rem;\n}\n.logo {\n  width: 100%;\n  height: 100%;\n  object-fit: contain;\n  max-height: 100px;\n  max-width: 200px;\n  filter: brightness(0) invert(1);\n}\n</style>"
+    },
+    "app/composables/useAppSchemaOrg.ts": {
+      "language": "typescript",
+      "mutants": [
+        {
+          "id": "354",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "app/composables/useAppSchemaOrg.ts(17,88): error TS2345: Argument of type '{}' is not assignable to parameter of type 'WebSite'.\n  Property 'name' is missing in type '{}' but required in type 'WebSite'.\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "146",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 23
+            },
+            "start": {
+              "column": 88,
+              "line": 17
+            }
+          }
+        },
+        {
+          "id": "353",
+          "mutatorName": "ArrowFunction",
+          "replacement": "() => undefined",
+          "statusReason": "app/composables/useAppSchemaOrg.ts(103,5): error TS2322: Type '() => undefined' is not assignable to type '() => WebSite & Record<string, any>'.\n  Type 'undefined' is not assignable to type 'WebSite & Record<string, any>'.\n    Type 'undefined' is not assignable to type 'WebSite'.\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "146",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 5,
+              "line": 23
+            },
+            "start": {
+              "column": 34,
+              "line": 17
+            }
+          }
+        },
+        {
+          "id": "352",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "app/composables/useAppSchemaOrg.ts(12,29): error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "146",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 113
+            },
+            "start": {
+              "column": 52,
+              "line": 12
+            }
+          }
+        },
+        {
+          "id": "358",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "app/composables/useAppSchemaOrg.ts(25,85): error TS2345: Argument of type '{}' is not assignable to parameter of type 'Person'.\n  Property 'name' is missing in type '{}' but required in type 'Person'.\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 100
+            },
+            "start": {
+              "column": 85,
+              "line": 25
+            }
+          }
+        },
+        {
+          "id": "357",
+          "mutatorName": "ArrowFunction",
+          "replacement": "() => undefined",
+          "statusReason": "app/composables/useAppSchemaOrg.ts(35,5): error TS2322: Type '() => undefined' is not assignable to type '() => Person & Record<string, any>'.\n  Type 'undefined' is not assignable to type 'Person & Record<string, any>'.\n    Type 'undefined' is not assignable to type 'Person'.\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "146",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 5,
+              "line": 100
+            },
+            "start": {
+              "column": 33,
+              "line": 25
+            }
+          }
+        },
+        {
+          "id": "414",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "app/composables/useAppSchemaOrg.ts(108,3): error TS2739: Type '{}' is missing the following properties from type 'AppSchemaOrgComposable': getAppSchemaOrgWebSite, getAppSchemaOrgPerson, setupAppSchemaOrg\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "146",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 112
+            },
+            "start": {
+              "column": 10,
+              "line": 108
+            }
+          }
+        },
+        {
+          "id": "355",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': '', …(4) } to strictly equal { '@type': 'WebSite', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "146"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "146",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 23,
+              "line": 18
+            },
+            "start": {
+              "column": 14,
+              "line": 18
+            }
+          }
+        },
+        {
+          "id": "356",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'WebSite', …(4) } to strictly equal { '@type': 'WebSite', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "146"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "146",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 44,
+              "line": 21
+            },
+            "start": {
+              "column": 22,
+              "line": 21
+            }
+          }
+        },
+        {
+          "id": "359",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': '', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 22,
+              "line": 26
+            },
+            "start": {
+              "column": 14,
+              "line": 26
+            }
+          }
+        },
+        {
+          "id": "362",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 45,
+              "line": 30
+            },
+            "start": {
+              "column": 27,
+              "line": 30
+            }
+          }
+        },
+        {
+          "id": "360",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 31
+            },
+            "start": {
+              "column": 16,
+              "line": 27
+            }
+          }
+        },
+        {
+          "id": "364",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 37,
+              "line": 33
+            },
+            "start": {
+              "column": 16,
+              "line": 33
+            }
+          }
+        },
+        {
+          "id": "365",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 24,
+              "line": 34
+            },
+            "start": {
+              "column": 15,
+              "line": 34
+            }
+          }
+        },
+        {
+          "id": "366",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 39,
+              "line": 35
+            },
+            "start": {
+              "column": 14,
+              "line": 35
+            }
+          }
+        },
+        {
+          "id": "370",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 33,
+              "line": 40
+            },
+            "start": {
+              "column": 9,
+              "line": 40
+            }
+          }
+        },
+        {
+          "id": "361",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 31,
+              "line": 28
+            },
+            "start": {
+              "column": 16,
+              "line": 28
+            }
+          }
+        },
+        {
+          "id": "369",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 34,
+              "line": 39
+            },
+            "start": {
+              "column": 9,
+              "line": 39
+            }
+          }
+        },
+        {
+          "id": "363",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 36
+            },
+            "start": {
+              "column": 17,
+              "line": 32
+            }
+          }
+        },
+        {
+          "id": "368",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 36,
+              "line": 38
+            },
+            "start": {
+              "column": 9,
+              "line": 38
+            }
+          }
+        },
+        {
+          "id": "371",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 23,
+              "line": 41
+            },
+            "start": {
+              "column": 9,
+              "line": 41
+            }
+          }
+        },
+        {
+          "id": "367",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 43
+            },
+            "start": {
+              "column": 14,
+              "line": 37
+            }
+          }
+        },
+        {
+          "id": "372",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 25,
+              "line": 42
+            },
+            "start": {
+              "column": 9,
+              "line": 42
+            }
+          }
+        },
+        {
+          "id": "373",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 49,
+              "line": 45
+            },
+            "start": {
+              "column": 22,
+              "line": 45
+            }
+          }
+        },
+        {
+          "id": "375",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 52
+            },
+            "start": {
+              "column": 22,
+              "line": 48
+            }
+          }
+        },
+        {
+          "id": "374",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 47
+            },
+            "start": {
+              "column": 15,
+              "line": 47
+            }
+          }
+        },
+        {
+          "id": "376",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 28,
+              "line": 49
+            },
+            "start": {
+              "column": 16,
+              "line": 49
+            }
+          }
+        },
+        {
+          "id": "378",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 54,
+              "line": 51
+            },
+            "start": {
+              "column": 24,
+              "line": 51
+            }
+          }
+        },
+        {
+          "id": "377",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 41,
+              "line": 50
+            },
+            "start": {
+              "column": 17,
+              "line": 50
+            }
+          }
+        },
+        {
+          "id": "380",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 65
+            },
+            "start": {
+              "column": 19,
+              "line": 55
+            }
+          }
+        },
+        {
+          "id": "379",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 43,
+              "line": 54
+            },
+            "start": {
+              "column": 19,
+              "line": 54
+            }
+          }
+        },
+        {
+          "id": "382",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 23,
+              "line": 57
+            },
+            "start": {
+              "column": 9,
+              "line": 57
+            }
+          }
+        },
+        {
+          "id": "381",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 24,
+              "line": 56
+            },
+            "start": {
+              "column": 9,
+              "line": 56
+            }
+          }
+        },
+        {
+          "id": "383",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 30,
+              "line": 58
+            },
+            "start": {
+              "column": 9,
+              "line": 58
+            }
+          }
+        },
+        {
+          "id": "384",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 30,
+              "line": 59
+            },
+            "start": {
+              "column": 9,
+              "line": 59
+            }
+          }
+        },
+        {
+          "id": "385",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 23,
+              "line": 60
+            },
+            "start": {
+              "column": 9,
+              "line": 60
+            }
+          }
+        },
+        {
+          "id": "386",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 24,
+              "line": 61
+            },
+            "start": {
+              "column": 9,
+              "line": 61
+            }
+          }
+        },
+        {
+          "id": "387",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 25,
+              "line": 62
+            },
+            "start": {
+              "column": 9,
+              "line": 62
+            }
+          }
+        },
+        {
+          "id": "388",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 27,
+              "line": 63
+            },
+            "start": {
+              "column": 9,
+              "line": 63
+            }
+          }
+        },
+        {
+          "id": "389",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 24,
+              "line": 64
+            },
+            "start": {
+              "column": 9,
+              "line": 64
+            }
+          }
+        },
+        {
+          "id": "391",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 8,
+              "line": 71
+            },
+            "start": {
+              "column": 7,
+              "line": 67
+            }
+          }
+        },
+        {
+          "id": "390",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 77
+            },
+            "start": {
+              "column": 22,
+              "line": 66
+            }
+          }
+        },
+        {
+          "id": "393",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 37,
+              "line": 69
+            },
+            "start": {
+              "column": 19,
+              "line": 69
+            }
+          }
+        },
+        {
+          "id": "392",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 28,
+              "line": 68
+            },
+            "start": {
+              "column": 18,
+              "line": 68
+            }
+          }
+        },
+        {
+          "id": "394",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 30,
+              "line": 70
+            },
+            "start": {
+              "column": 26,
+              "line": 70
+            }
+          }
+        },
+        {
+          "id": "395",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 8,
+              "line": 76
+            },
+            "start": {
+              "column": 7,
+              "line": 72
+            }
+          }
+        },
+        {
+          "id": "397",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 38,
+              "line": 74
+            },
+            "start": {
+              "column": 19,
+              "line": 74
+            }
+          }
+        },
+        {
+          "id": "396",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 28,
+              "line": 73
+            },
+            "start": {
+              "column": 18,
+              "line": 73
+            }
+          }
+        },
+        {
+          "id": "398",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 30,
+              "line": 75
+            },
+            "start": {
+              "column": 26,
+              "line": 75
+            }
+          }
+        },
+        {
+          "id": "399",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 82
+            },
+            "start": {
+              "column": 20,
+              "line": 79
+            }
+          }
+        },
+        {
+          "id": "400",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 25,
+              "line": 80
+            },
+            "start": {
+              "column": 16,
+              "line": 80
+            }
+          }
+        },
+        {
+          "id": "402",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 86
+            },
+            "start": {
+              "column": 15,
+              "line": 83
+            }
+          }
+        },
+        {
+          "id": "401",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 35,
+              "line": 81
+            },
+            "start": {
+              "column": 17,
+              "line": 81
+            }
+          }
+        },
+        {
+          "id": "403",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 92
+            },
+            "start": {
+              "column": 18,
+              "line": 87
+            }
+          }
+        },
+        {
+          "id": "404",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 30,
+              "line": 88
+            },
+            "start": {
+              "column": 16,
+              "line": 88
+            }
+          }
+        },
+        {
+          "id": "405",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 64,
+              "line": 89
+            },
+            "start": {
+              "column": 17,
+              "line": 89
+            }
+          }
+        },
+        {
+          "id": "406",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 78,
+              "line": 90
+            },
+            "start": {
+              "column": 24,
+              "line": 90
+            }
+          }
+        },
+        {
+          "id": "407",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 49,
+              "line": 91
+            },
+            "start": {
+              "column": 14,
+              "line": 91
+            }
+          }
+        },
+        {
+          "id": "408",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 99
+            },
+            "start": {
+              "column": 17,
+              "line": 95
+            }
+          }
+        },
+        {
+          "id": "409",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 30,
+              "line": 96
+            },
+            "start": {
+              "column": 16,
+              "line": 96
+            }
+          }
+        },
+        {
+          "id": "410",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 22,
+              "line": 97
+            },
+            "start": {
+              "column": 15,
+              "line": 97
+            }
+          }
+        },
+        {
+          "id": "411",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "147"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "147",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 37,
+              "line": 98
+            },
+            "start": {
+              "column": 14,
+              "line": 98
+            }
+          }
+        },
+        {
+          "id": "412",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "\u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).toHaveBeenCalledExactlyOnceWith(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected mock function to have been called exactly once, but it was called \u001b[31m0\u001b[39m times",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "148"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 107
+            },
+            "start": {
+              "column": 41,
+              "line": 102
+            }
+          }
+        },
+        {
+          "id": "413",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "\u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).toHaveBeenCalledExactlyOnceWith(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected mock function to have been called exactly once with \u001b[32mArray [\n  Array [\n    Object {\n      \"@type\": \"WebSite\",\n      \"_resolver\": \"webSite\",\n      \"description\": \"App.meta.description\",\n      \"inLanguage\": \"fr\",\n      \"name\": \"Antoine ZANARDI - Portfolio Test\",\n    },\n    Object {\n      \"@type\": \"Person\",\n      \"_resolver\": \"person\",\n      \"address\": Object {\n        \"@type\": \"PostalAddress\",\n        \"addressCountry\": \"Countries.france\",\n        \"addressLocality\": \"1234 Elm Street\",\n      },\n      \"alumniOf\": Object {\n        \"@type\": \"CollegeOrUniversity\",\n        \"name\": \"EPITECH\",\n        \"url\": \"https://www.epitech.eu/\",\n      },\n      \"award\": Array [\n        \"Degrees.highSchoolDiploma\",\n        \"Degrees.ITCertification\",\n        \"Degrees.ITMasterDegree\",\n        \"Degrees.CKAD\",\n        \"Degrees.gcpACE\",\n      ],\n      \"birthDate\": \"1996-04-14\",\n      \"description\": \"App.meta.smallDescription\",\n      \"email\": \"john@doe.com\",\n      \"gender\": \"Male\",\n      \"hasOccupation\": Object {\n        \"@type\": \"Occupation\",\n        \"description\": \"MyProfile.fullStackWebExpert\",\n        \"name\": \"MyProfile.itConsultant\",\n      },\n      \"image\": \"https://github.com/antoinezanardi.png\",\n      \"jobTitle\": \"MyProfile.itConsultant\",\n      \"knowsAbout\": Array [\n        \"MySkills.html\",\n        \"MySkills.css\",\n        \"MySkills.javascript\",\n        \"MySkills.typescript\",\n        \"MySkills.vue\",\n        \"MySkills.nuxt\",\n        \"MySkills.mysql\",\n        \"MySkills.mongodb\",\n        \"MySkills.rust\",\n      ],\n      \"knowsLanguage\": Array [\n        Object {\n          \"@type\": \"Language\",\n          \"alternateName\": \"fr\",\n          \"name\": \"Languages.french\",\n        },\n        Object {\n          \"@type\": \"Language\",\n          \"alternateName\": \"en\",\n          \"name\": \"Languages.english\",\n        },\n      ],\n      \"name\": \"Antoine ZANARDI\",\n      \"nationality\": Object {\n        \"@type\": \"Country\",\n        \"name\": \"Countries.france\",\n      },\n      \"sameAs\": Array [\n        \"https://www.linkedin.com/in/antoinezanardi/\",\n        \"https://github.com/antoinezanardi/\",\n      ],\n      \"subjectOf\": Object {\n        \"@type\": \"CreativeWork\",\n        \"description\": \"MyPortfolio.projects.werewolvesAssistant.description\",\n        \"name\": \"MyPortfolio.projects.werewolvesAssistant.name\",\n        \"url\": \"https://werewolves-assistant.com/\",\n      },\n      \"telephone\": \"0123456789\",\n      \"url\": \"https://test.antoinezanardi.fr\",\n      \"worksFor\": Object {\n        \"@type\": \"Organization\",\n        \"name\": \"Daveo\",\n        \"url\": \"https://www.daveo.fr/\",\n      },\n    },\n  ],\n]\u001b[39m, but it was called with \u001b[31mArray []\u001b[39m",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "148"
+          ],
+          "coveredBy": [
+            "131",
+            "132",
+            "133",
+            "134",
+            "148"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 106
+            },
+            "start": {
+              "column": 18,
+              "line": 103
+            }
+          }
+        }
+      ],
+      "source": "import { definePerson, defineWebSite } from \"nuxt-schema-org/schema\";\n\nimport { useI18n, useRuntimeConfig, useSchemaOrg, useSiteConfig } from \"#imports\";\nimport { ANTOINE_ZANARDI_BIRTH_DATE, ANTOINE_ZANARDI_FULL_NAME, ANTOINE_ZANARDI_GITHUB_URL, ANTOINE_ZANARDI_LINKEDIN_URL, ANTOINE_ZANARDI_GITHUB_AVATAR_URL } from \"~/shared/constants/antoine-zanardi.constants\";\n\ntype AppSchemaOrgComposable = {\n  getAppSchemaOrgWebSite: () => ReturnType<typeof defineWebSite>;\n  getAppSchemaOrgPerson: () => ReturnType<typeof definePerson>;\n  setupAppSchemaOrg: () => void;\n};\n\nfunction useAppSchemaOrg(): AppSchemaOrgComposable {\n  const config = useRuntimeConfig();\n  const { t, locale } = useI18n();\n  const siteConfig = useSiteConfig();\n\n  const getAppSchemaOrgWebSite = (): ReturnType<typeof defineWebSite> => defineWebSite({\n    \"@type\": \"WebSite\",\n    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion\n    \"name\": siteConfig.name as string,\n    \"description\": t(\"App.meta.description\"),\n    \"inLanguage\": locale.value,\n  });\n\n  const getAppSchemaOrgPerson = (): ReturnType<typeof definePerson> => definePerson({\n    \"@type\": \"Person\",\n    \"address\": {\n      \"@type\": \"PostalAddress\",\n      \"addressLocality\": config.public.address,\n      \"addressCountry\": t(\"Countries.france\"),\n    },\n    \"alumniOf\": {\n      \"@type\": \"CollegeOrUniversity\",\n      \"name\": \"EPITECH\",\n      \"url\": \"https://www.epitech.eu/\",\n    },\n    \"award\": [\n      t(\"Degrees.highSchoolDiploma\"),\n      t(\"Degrees.ITCertification\"),\n      t(\"Degrees.ITMasterDegree\"),\n      t(\"Degrees.CKAD\"),\n      t(\"Degrees.gcpACE\"),\n    ],\n    \"birthDate\": ANTOINE_ZANARDI_BIRTH_DATE,\n    \"description\": t(\"App.meta.smallDescription\"),\n    \"email\": config.public.email,\n    \"gender\": \"Male\",\n    \"hasOccupation\": {\n      \"@type\": \"Occupation\",\n      \"name\": t(\"MyProfile.itConsultant\"),\n      \"description\": t(\"MyProfile.fullStackWebExpert\"),\n    },\n    \"image\": ANTOINE_ZANARDI_GITHUB_AVATAR_URL,\n    \"jobTitle\": t(\"MyProfile.itConsultant\"),\n    \"knowsAbout\": [\n      t(\"MySkills.html\"),\n      t(\"MySkills.css\"),\n      t(\"MySkills.javascript\"),\n      t(\"MySkills.typescript\"),\n      t(\"MySkills.vue\"),\n      t(\"MySkills.nuxt\"),\n      t(\"MySkills.mysql\"),\n      t(\"MySkills.mongodb\"),\n      t(\"MySkills.rust\"),\n    ],\n    \"knowsLanguage\": [\n      {\n        \"@type\": \"Language\",\n        \"name\": t(\"Languages.french\"),\n        \"alternateName\": \"fr\",\n      },\n      {\n        \"@type\": \"Language\",\n        \"name\": t(\"Languages.english\"),\n        \"alternateName\": \"en\",\n      },\n    ],\n    \"name\": ANTOINE_ZANARDI_FULL_NAME,\n    \"nationality\": {\n      \"@type\": \"Country\",\n      \"name\": t(\"Countries.france\"),\n    },\n    \"sameAs\": [\n      ANTOINE_ZANARDI_LINKEDIN_URL,\n      ANTOINE_ZANARDI_GITHUB_URL,\n    ],\n    \"subjectOf\": {\n      \"@type\": \"CreativeWork\",\n      \"name\": t(\"MyPortfolio.projects.werewolvesAssistant.name\"),\n      \"description\": t(\"MyPortfolio.projects.werewolvesAssistant.description\"),\n      \"url\": \"https://werewolves-assistant.com/\",\n    },\n    \"telephone\": config.public.phoneNumber,\n    \"url\": siteConfig.url,\n    \"worksFor\": {\n      \"@type\": \"Organization\",\n      \"name\": \"Daveo\",\n      \"url\": \"https://www.daveo.fr/\",\n    },\n  });\n\n  const setupAppSchemaOrg = (): void => {\n    useSchemaOrg([\n      getAppSchemaOrgWebSite(),\n      getAppSchemaOrgPerson(),\n    ]);\n  };\n  return {\n    getAppSchemaOrgWebSite,\n    getAppSchemaOrgPerson,\n    setupAppSchemaOrg,\n  };\n}\n\nexport { useAppSchemaOrg };"
+    },
+    "app/models/period/period.class.ts": {
+      "language": "typescript",
+      "mutants": [
+        {
+          "id": "425",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "app/models/period/period.class.ts(14,61): error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "33",
+            "35",
+            "36",
+            "37",
+            "38",
+            "39",
+            "42",
+            "43",
+            "44",
+            "149",
+            "150",
+            "151",
+            "152",
+            "153"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 18
+            },
+            "start": {
+              "column": 68,
+              "line": 14
+            }
+          }
+        },
+        {
+          "id": "422",
+          "mutatorName": "ArithmeticOperator",
+          "replacement": "this.month * monthsInYear",
+          "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 2,
+          "killedBy": [
+            "35"
+          ],
+          "coveredBy": [
+            "33",
+            "35",
+            "36",
+            "37",
+            "38",
+            "39",
+            "42",
+            "43",
+            "44",
+            "149",
+            "150",
+            "151",
+            "152",
+            "153"
+          ],
+          "location": {
+            "end": {
+              "column": 53,
+              "line": 10
+            },
+            "start": {
+              "column": 28,
+              "line": 10
+            }
+          }
+        },
+        {
+          "id": "421",
+          "mutatorName": "ArithmeticOperator",
+          "replacement": "Period.getMonthsDifference(from, to) - firstMonth",
+          "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 2,
+          "killedBy": [
+            "35"
+          ],
+          "coveredBy": [
+            "33",
+            "35",
+            "36",
+            "37",
+            "38",
+            "39",
+            "42",
+            "43",
+            "44",
+            "149",
+            "150",
+            "151",
+            "152",
+            "153"
+          ],
+          "location": {
+            "end": {
+              "column": 67,
+              "line": 9
+            },
+            "start": {
+              "column": 18,
+              "line": 9
+            }
+          }
+        },
+        {
+          "id": "423",
+          "mutatorName": "AssignmentOperator",
+          "replacement": "this.month += this.year * monthsInYear",
+          "statusReason": "expected '( shared.years, {\"yearCount\":2}, 2 sh…' to be '( shared.years, {\"yearCount\":2}, 2 sh…' // Object.is equality",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "38"
+          ],
+          "coveredBy": [
+            "33",
+            "35",
+            "36",
+            "37",
+            "38",
+            "39",
+            "42",
+            "43",
+            "44",
+            "149",
+            "150",
+            "151",
+            "152",
+            "153"
+          ],
+          "location": {
+            "end": {
+              "column": 43,
+              "line": 11
+            },
+            "start": {
+              "column": 5,
+              "line": 11
+            }
+          }
+        },
+        {
+          "id": "420",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 2,
+          "killedBy": [
+            "35"
+          ],
+          "coveredBy": [
+            "33",
+            "35",
+            "36",
+            "37",
+            "38",
+            "39",
+            "42",
+            "43",
+            "44",
+            "149",
+            "150",
+            "151",
+            "152",
+            "153"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 12
+            },
+            "start": {
+              "column": 44,
+              "line": 6
+            }
+          }
+        },
+        {
+          "id": "424",
+          "mutatorName": "ArithmeticOperator",
+          "replacement": "this.year / monthsInYear",
+          "statusReason": "expected '( shared.years, {\"yearCount\":2}, 2 sh…' to be '( shared.years, {\"yearCount\":2}, 2 sh…' // Object.is equality",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "38"
+          ],
+          "coveredBy": [
+            "33",
+            "35",
+            "36",
+            "37",
+            "38",
+            "39",
+            "42",
+            "43",
+            "44",
+            "149",
+            "150",
+            "151",
+            "152",
+            "153"
+          ],
+          "location": {
+            "end": {
+              "column": 43,
+              "line": 11
+            },
+            "start": {
+              "column": 19,
+              "line": 11
+            }
+          }
+        },
+        {
+          "id": "426",
+          "mutatorName": "ArithmeticOperator",
+          "replacement": "to.getMonth() - from.getMonth() - monthCountInYear * (to.getFullYear() - from.getFullYear())",
+          "statusReason": "expected '( shared.years, {\"yearCount\":-2}, -2 …' to be '( shared.years, {\"yearCount\":2}, 2 sh…' // Object.is equality",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "38"
+          ],
+          "coveredBy": [
+            "33",
+            "35",
+            "36",
+            "37",
+            "38",
+            "39",
+            "42",
+            "43",
+            "44",
+            "149",
+            "150",
+            "151",
+            "152",
+            "153"
+          ],
+          "location": {
+            "end": {
+              "column": 104,
+              "line": 17
+            },
+            "start": {
+              "column": 12,
+              "line": 17
+            }
+          }
+        },
+        {
+          "id": "428",
+          "mutatorName": "ArithmeticOperator",
+          "replacement": "monthCountInYear / (to.getFullYear() - from.getFullYear())",
+          "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 2,
+          "killedBy": [
+            "35"
+          ],
+          "coveredBy": [
+            "33",
+            "35",
+            "36",
+            "37",
+            "38",
+            "39",
+            "42",
+            "43",
+            "44",
+            "149",
+            "150",
+            "151",
+            "152",
+            "153"
+          ],
+          "location": {
+            "end": {
+              "column": 104,
+              "line": 17
+            },
+            "start": {
+              "column": 46,
+              "line": 17
+            }
+          }
+        },
+        {
+          "id": "427",
+          "mutatorName": "ArithmeticOperator",
+          "replacement": "to.getMonth() + from.getMonth()",
+          "statusReason": "expected 2 to be 4 // Object.is equality",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 14,
+          "killedBy": [
+            "153"
+          ],
+          "coveredBy": [
+            "33",
+            "35",
+            "36",
+            "37",
+            "38",
+            "39",
+            "42",
+            "43",
+            "44",
+            "149",
+            "150",
+            "151",
+            "152",
+            "153"
+          ],
+          "location": {
+            "end": {
+              "column": 43,
+              "line": 17
+            },
+            "start": {
+              "column": 12,
+              "line": 17
+            }
+          }
+        },
+        {
+          "id": "429",
+          "mutatorName": "ArithmeticOperator",
+          "replacement": "to.getFullYear() + from.getFullYear()",
+          "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 2,
+          "killedBy": [
+            "35"
+          ],
+          "coveredBy": [
+            "33",
+            "35",
+            "36",
+            "37",
+            "38",
+            "39",
+            "42",
+            "43",
+            "44",
+            "149",
+            "150",
+            "151",
+            "152",
+            "153"
+          ],
+          "location": {
+            "end": {
+              "column": 103,
+              "line": 17
+            },
+            "start": {
+              "column": 66,
+              "line": 17
+            }
+          }
+        }
+      ],
+      "source": "class Period {\n  public month: number;\n\n  public year: number;\n\n  public constructor(from: Date, to: Date) {\n    const firstMonth = 1;\n    const monthsInYear = 12;\n    this.month = Period.getMonthsDifference(from, to) + firstMonth;\n    this.year = Math.floor(this.month / monthsInYear);\n    this.month -= this.year * monthsInYear;\n  }\n\n  private static getMonthsDifference(from: Date, to: Date): number {\n    const monthCountInYear = 12;\n\n    return to.getMonth() - from.getMonth() + monthCountInYear * (to.getFullYear() - from.getFullYear());\n  }\n}\n\nexport { Period };"
+    },
+    "app/components/AboutMe/AboutMyPersonalInfo/AboutMyPersonalInfo.vue": {
+      "language": "html",
+      "mutants": [
+        {
+          "id": "12",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "Snapshot `AboutMyPersonalInfo Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "59"
+          ],
+          "coveredBy": [
+            "59",
+            "60",
+            "61",
+            "62",
+            "63"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 199
+            },
+            "start": {
+              "column": 36,
+              "line": 194
+            }
+          }
+        },
+        {
+          "id": "13",
+          "mutatorName": "ArithmeticOperator",
+          "replacement": "new Date(Date.now() - birthday.getTime()).getUTCFullYear() + epochYear",
+          "statusReason": "Snapshot `AboutMyPersonalInfo Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "59"
+          ],
+          "coveredBy": [
+            "59",
+            "60",
+            "61",
+            "62",
+            "63"
+          ],
+          "location": {
+            "end": {
+              "column": 80,
+              "line": 198
+            },
+            "start": {
+              "column": 10,
+              "line": 198
+            }
+          }
+        },
+        {
+          "id": "14",
+          "mutatorName": "ArithmeticOperator",
+          "replacement": "Date.now() + birthday.getTime()",
+          "statusReason": "Snapshot `AboutMyPersonalInfo Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "59"
+          ],
+          "coveredBy": [
+            "59",
+            "60",
+            "61",
+            "62",
+            "63"
+          ],
+          "location": {
+            "end": {
+              "column": 50,
+              "line": 198
+            },
+            "start": {
+              "column": 19,
+              "line": 198
+            }
+          }
+        },
+        {
+          "id": "15",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "Snapshot `AboutMyPersonalInfo Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "59"
+          ],
+          "coveredBy": [
+            "59",
+            "60",
+            "61",
+            "62",
+            "63"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 205
+            },
+            "start": {
+              "column": 53,
+              "line": 201
+            }
+          }
+        },
+        {
+          "id": "16",
+          "mutatorName": "Regex",
+          "replacement": "/./gu",
+          "statusReason": "Snapshot `AboutMyPersonalInfo Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "59"
+          ],
+          "coveredBy": [
+            "59",
+            "60",
+            "61",
+            "62",
+            "63"
+          ],
+          "location": {
+            "end": {
+              "column": 59,
+              "line": 202
+            },
+            "start": {
+              "column": 51,
+              "line": 202
+            }
+          }
+        },
+        {
+          "id": "17",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "Snapshot `AboutMyPersonalInfo Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "59"
+          ],
+          "coveredBy": [
+            "59",
+            "60",
+            "61",
+            "62",
+            "63"
+          ],
+          "location": {
+            "end": {
+              "column": 36,
+              "line": 204
+            },
+            "start": {
+              "column": 33,
+              "line": 204
+            }
+          }
+        },
+        {
+          "id": "18",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected '' to be '?' // Object.is equality",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "62"
+          ],
+          "coveredBy": [
+            "62"
+          ],
+          "location": {
+            "end": {
+              "column": 43,
+              "line": 204
+            },
+            "start": {
+              "column": 40,
+              "line": 204
+            }
+          }
+        }
+      ],
+      "source": "<template>\n  <div>\n    <div class=\"card-body\">\n      <h3 class=\"h3 mb-2 mt-0 title\">\n        <WrappedFontAwesomeIcon\n          classes=\"me-2\"\n          icon=\"fa-id-card\"\n        />\n\n        <span>\n          {{ $t('AboutMyPersonalInfo.personalInfo') }}\n        </span>\n      </h3>\n\n      <hr>\n\n      <div class=\"row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.genre')} :` }}\n          </b>\n        </div>\n\n        <div\n          id=\"genre\"\n          class=\"col-sm-8\"\n        >\n          {{ $t('AboutMyPersonalInfo.male') }}\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.age')} :` }}\n          </b>\n        </div>\n\n        <div\n          id=\"age\"\n          class=\"col-sm-8\"\n        >\n          {{ $t('AboutMyPersonalInfo.yearsOld', { age }) }}\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.email')} :` }}\n          </b>\n        </div>\n\n        <div class=\"col-sm-8\">\n          <b>\n            <a\n              :aria-label=\"$t('AboutMyPersonalInfo.emailLink', { 'email': config.public.email })\"\n              :href=\"`mailto:${config.public.email}`\"\n            >\n              {{ config.public.email }}\n            </a>\n          </b>\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.phone')} :` }}\n          </b>\n        </div>\n\n        <div class=\"col-sm-8\">\n          <b>\n            <a\n              id=\"phone-number\"\n              :aria-label=\"$t('AboutMyPersonalInfo.phoneLink', { 'phone': formattedPhoneNumber })\"\n              :href=\"`tel:${config.public.phoneNumber}`\"\n            >\n              {{ formattedPhoneNumber }}\n            </a>\n          </b>\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.address')} :` }}\n          </b>\n        </div>\n\n        <div\n          id=\"address\"\n          class=\"col-sm-8\"\n        >\n          {{ config.public.address }}\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.languages')} :` }}\n          </b>\n        </div>\n\n        <div\n          class=\"col-sm-8\"\n        >\n          {{ $t('AboutMyPersonalInfo.englishAndFrench') }}\n        </div>\n      </div>\n\n      <div class=\"align-items-center mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.licenses')} :` }}\n          </b>\n        </div>\n\n        <div class=\"col-sm-8 d-flex\">\n          <WrappedFontAwesomeIcon\n            :aria-label=\"$t('AboutMyPersonalInfo.car')\"\n            class=\"me-2\"\n            data-bs-toggle=\"tooltip\"\n            icon=\"fa-car\"\n            role=\"img\"\n            size=\"2x\"\n            :title=\"$t('AboutMyPersonalInfo.car')\"\n          />\n\n          <WrappedFontAwesomeIcon\n            :aria-label=\"$t('AboutMyPersonalInfo.boat')\"\n            class=\"me-2\"\n            data-bs-toggle=\"tooltip\"\n            icon=\"fa-anchor\"\n            role=\"img\"\n            size=\"2x\"\n            :title=\"$t('AboutMyPersonalInfo.boat')\"\n          />\n        </div>\n      </div>\n\n      <div class=\"align-items-center mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.workingAt')} :` }}\n          </b>\n        </div>\n\n        <div class=\"col-sm-8\">\n          <a\n            :aria-label=\"$t('AboutMyPersonalInfo.companyLink', { 'company': 'Daveo' })\"\n            href=\"https://www.daveo.fr/\"\n            rel=\"noopener noreferrer\"\n            target=\"_blank\"\n          >\n            <NuxtImg\n              alt=\"Daveo\"\n              class=\"daveo-logo\"\n              loading=\"lazy\"\n              src=\"/images/logos/daveo-logo.webp\"\n            />\n          </a>\n        </div>\n      </div>\n    </div>\n  </div>\n</template>\n\n<script setup lang=\"ts\">\nimport WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\nimport { ANTOINE_ZANARDI_BIRTH_DATE } from \"~/shared/constants/antoine-zanardi.constants\";\n\nconst config = useRuntimeConfig();\n\nconst age = computed<number>(() => {\n  const birthday = new Date(ANTOINE_ZANARDI_BIRTH_DATE);\n  const epochYear = 1970;\n\n  return new Date(Date.now() - birthday.getTime()).getUTCFullYear() - epochYear;\n});\n\nconst formattedPhoneNumber = computed<string>(() => {\n  const matches = config.public.phoneNumber.match(/.{2}/gu);\n\n  return matches ? matches.join(\" \") : \"?\";\n});\n</script>\n\n<style lang=\"scss\" scoped>\n.daveo-logo {\n  margin-left: -5px;\n  width: 150px;\n}\n</style>"
+    },
+    "app/components/MyEducation/EducationDegreeCard/EducationDegreeCard.vue": {
+      "language": "html",
+      "mutants": [
+        {
+          "id": "19",
+          "mutatorName": "ArrowFunction",
+          "replacement": "() => undefined",
+          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "45"
+          ],
+          "coveredBy": [
+            "45",
+            "46",
+            "47",
+            "48",
+            "49",
+            "50",
+            "51",
+            "52",
+            "53",
+            "54",
+            "55",
+            "56",
+            "57",
+            "58"
+          ],
+          "location": {
+            "end": {
+              "column": 101,
+              "line": 74
+            },
+            "start": {
+              "column": 38,
+              "line": 74
+            }
+          }
+        },
+        {
+          "id": "20",
+          "mutatorName": "LogicalOperator",
+          "replacement": "props.educationDegree.school.image && \"college-icon.webp\"",
+          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "45"
+          ],
+          "coveredBy": [
+            "45",
+            "46",
+            "47",
+            "48",
+            "49",
+            "50",
+            "51",
+            "52",
+            "53",
+            "54",
+            "55",
+            "56",
+            "57",
+            "58"
+          ],
+          "location": {
+            "end": {
+              "column": 101,
+              "line": 74
+            },
+            "start": {
+              "column": 44,
+              "line": 74
+            }
+          }
+        },
+        {
+          "id": "21",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected '' to be 'college-icon.webp' // Object.is equality",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "51"
+          ],
+          "coveredBy": [
+            "51"
+          ],
+          "location": {
+            "end": {
+              "column": 101,
+              "line": 74
+            },
+            "start": {
+              "column": 82,
+              "line": 74
+            }
+          }
+        },
+        {
+          "id": "22",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "45"
+          ],
+          "coveredBy": [
+            "45",
+            "46",
+            "47",
+            "48",
+            "49",
+            "50",
+            "51",
+            "52",
+            "53",
+            "54",
+            "55",
+            "56",
+            "57",
+            "58"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 83
+            },
+            "start": {
+              "column": 44,
+              "line": 76
+            }
+          }
+        },
+        {
+          "id": "23",
+          "mutatorName": "LogicalOperator",
+          "replacement": "school.translatedName && \"?\"",
+          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "45"
+          ],
+          "coveredBy": [
+            "45",
+            "46",
+            "47",
+            "48",
+            "49",
+            "50",
+            "51",
+            "52",
+            "53",
+            "54",
+            "55",
+            "56",
+            "57",
+            "58"
+          ],
+          "location": {
+            "end": {
+              "column": 43,
+              "line": 78
+            },
+            "start": {
+              "column": 15,
+              "line": 78
+            }
+          }
+        },
+        {
+          "id": "24",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected '' to be '?' // Object.is equality",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "56"
+          ],
+          "coveredBy": [
+            "50",
+            "51",
+            "56"
+          ],
+          "location": {
+            "end": {
+              "column": 43,
+              "line": 78
+            },
+            "start": {
+              "column": 40,
+              "line": 78
+            }
+          }
+        },
+        {
+          "id": "25",
+          "mutatorName": "ConditionalExpression",
+          "replacement": "true",
+          "statusReason": "expected 'Schools.epitech, undefined' to be 'Schools.epitech' // Object.is equality",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 11,
+          "killedBy": [
+            "55"
+          ],
+          "coveredBy": [
+            "45",
+            "46",
+            "47",
+            "48",
+            "49",
+            "50",
+            "51",
+            "52",
+            "53",
+            "54",
+            "55",
+            "56",
+            "57",
+            "58"
+          ],
+          "location": {
+            "end": {
+              "column": 32,
+              "line": 79
+            },
+            "start": {
+              "column": 7,
+              "line": 79
+            }
+          }
+        },
+        {
+          "id": "26",
+          "mutatorName": "ConditionalExpression",
+          "replacement": "false",
+          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "45"
+          ],
+          "coveredBy": [
+            "45",
+            "46",
+            "47",
+            "48",
+            "49",
+            "50",
+            "51",
+            "52",
+            "53",
+            "54",
+            "55",
+            "56",
+            "57",
+            "58"
+          ],
+          "location": {
+            "end": {
+              "column": 32,
+              "line": 79
+            },
+            "start": {
+              "column": 7,
+              "line": 79
+            }
+          }
+        },
+        {
+          "id": "27",
+          "mutatorName": "EqualityOperator",
+          "replacement": "school.city === undefined",
+          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "45"
+          ],
+          "coveredBy": [
+            "45",
+            "46",
+            "47",
+            "48",
+            "49",
+            "50",
+            "51",
+            "52",
+            "53",
+            "54",
+            "55",
+            "56",
+            "57",
+            "58"
+          ],
+          "location": {
+            "end": {
+              "column": 32,
+              "line": 79
+            },
+            "start": {
+              "column": 7,
+              "line": 79
+            }
+          }
+        },
+        {
+          "id": "28",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "45"
+          ],
+          "coveredBy": [
+            "45",
+            "46",
+            "47",
+            "48",
+            "49",
+            "50",
+            "51",
+            "52",
+            "53",
+            "54",
+            "55",
+            "56",
+            "57",
+            "58"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 81
+            },
+            "start": {
+              "column": 34,
+              "line": 79
+            }
+          }
+        },
+        {
+          "id": "30",
+          "mutatorName": "ArrowFunction",
+          "replacement": "() => undefined",
+          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "45"
+          ],
+          "coveredBy": [
+            "45",
+            "46",
+            "47",
+            "48",
+            "49",
+            "50",
+            "51",
+            "52",
+            "53",
+            "54",
+            "55",
+            "56",
+            "57",
+            "58"
+          ],
+          "location": {
+            "end": {
+              "column": 97,
+              "line": 85
+            },
+            "start": {
+              "column": 41,
+              "line": 85
+            }
+          }
+        },
+        {
+          "id": "29",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "45"
+          ],
+          "coveredBy": [
+            "45",
+            "46",
+            "47",
+            "48",
+            "49",
+            "50",
+            "51",
+            "52",
+            "53",
+            "54",
+            "55",
+            "56",
+            "57",
+            "58"
+          ],
+          "location": {
+            "end": {
+              "column": 32,
+              "line": 80
+            },
+            "start": {
+              "column": 14,
+              "line": 80
+            }
+          }
+        },
+        {
+          "id": "31",
+          "mutatorName": "LogicalOperator",
+          "replacement": "props.educationDegree.school.translatedName && \"?\"",
+          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "45"
+          ],
+          "coveredBy": [
+            "45",
+            "46",
+            "47",
+            "48",
+            "49",
+            "50",
+            "51",
+            "52",
+            "53",
+            "54",
+            "55",
+            "56",
+            "57",
+            "58"
+          ],
+          "location": {
+            "end": {
+              "column": 97,
+              "line": 85
+            },
+            "start": {
+              "column": 47,
+              "line": 85
+            }
+          }
+        },
+        {
+          "id": "32",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected '' to be '?' // Object.is equality",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "50"
+          ],
+          "coveredBy": [
+            "50",
+            "51",
+            "56"
+          ],
+          "location": {
+            "end": {
+              "column": 97,
+              "line": 85
+            },
+            "start": {
+              "column": 94,
+              "line": 85
+            }
+          }
+        },
+        {
+          "id": "33",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "45"
+          ],
+          "coveredBy": [
+            "45",
+            "46",
+            "47",
+            "48",
+            "49",
+            "50",
+            "51",
+            "52",
+            "53",
+            "54",
+            "55",
+            "56",
+            "57",
+            "58"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 94
+            },
+            "start": {
+              "column": 53,
+              "line": 87
+            }
+          }
+        },
+        {
+          "id": "34",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "45"
+          ],
+          "coveredBy": [
+            "45",
+            "46",
+            "47",
+            "48",
+            "49",
+            "50",
+            "51",
+            "52",
+            "53",
+            "54",
+            "55",
+            "56",
+            "57",
+            "58"
+          ],
+          "location": {
+            "end": {
+              "column": 59,
+              "line": 90
+            },
+            "start": {
+              "column": 12,
+              "line": 90
+            }
+          }
+        },
+        {
+          "id": "35",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Snapshot `Education Degree Card Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "45"
+          ],
+          "coveredBy": [
+            "45",
+            "46",
+            "47",
+            "48",
+            "49",
+            "50",
+            "51",
+            "52",
+            "53",
+            "54",
+            "55",
+            "56",
+            "57",
+            "58"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 93
+            },
+            "start": {
+              "column": 61,
+              "line": 90
+            }
+          }
+        }
+      ],
+      "source": "<template>\n  <div class=\"card\">\n    <div class=\"row\">\n      <div\n        class=\"background-primary col-md-3\"\n        data-aos=\"fade-right\"\n        data-aos-duration=\"500\"\n        data-aos-offset=\"50\"\n      >\n        <div class=\"card-body cc-education-header\">\n          <PeriodTimeline\n            class=\"education-timeline\"\n            does-show-year-only\n            :finished-at=\"educationDegree.degree.obtainedAt\"\n            :image=\"schoolImage\"\n            :image-alt=\"schoolImageAlt\"\n            :period-dates-aria-label=\"periodDatesAriaLabel\"\n            :started-at=\"educationDegree.degree.startedAt\"\n            :url=\"educationDegree.school.url\"\n          />\n        </div>\n      </div>\n\n      <div\n        class=\"col-md-9\"\n        data-aos=\"fade-left\"\n        data-aos-duration=\"500\"\n        data-aos-offset=\"50\"\n      >\n        <div class=\"card-body\">\n          <h3\n            class=\"degree-name font-weight-bold h4 mb-2 mt-0\"\n          >\n            {{ educationDegree.degree.name }}\n          </h3>\n\n          <div class=\"d-flex\">\n            <p\n              class=\"category font-weight-bold mb-0 school-name\"\n            >\n              {{ schoolLabel }}\n            </p>\n\n            <CountryFlag\n              class=\"ms-2 school-flag\"\n              :country=\"educationDegree.school.country\"\n            />\n          </div>\n\n          <hr>\n\n          <p\n            v-for=\"(paragraph, index) in educationDegree.degree.description\"\n            :key=\"index\"\n            class=\"degree-description\"\n          >\n            {{ paragraph }}\n          </p>\n        </div>\n      </div>\n    </div>\n  </div>\n</template>\n\n<script lang=\"ts\" setup>\nimport type { EducationDegreeCardProps } from \"~/components/MyEducation/EducationDegreeCard/education-degree-card.types\";\nimport CountryFlag from \"~/components/shared/Images/CountryFlag/CountryFlag.vue\";\nimport PeriodTimeline from \"~/components/shared/Period/PeriodTimeline.vue\";\n\nconst props = defineProps<EducationDegreeCardProps>();\n\nconst { t } = useI18n();\n\nconst schoolImage = computed<string>(() => props.educationDegree.school.image ?? \"college-icon.webp\");\n\nconst schoolLabel = computed<string>(() => {\n  const { school } = props.educationDegree;\n  let label = school.translatedName ?? \"?\";\n  if (school.city !== undefined) {\n    label += `, ${school.city}`;\n  }\n  return label;\n});\n\nconst schoolImageAlt = computed<string>(() => props.educationDegree.school.translatedName ?? \"?\");\n\nconst periodDatesAriaLabel = computed<string>(() => {\n  const finishedAtYear = props.educationDegree.degree.obtainedAt.getFullYear().toString();\n\n  return t(\"EducationDegreeCard.degreeObtainedAtAriaLabel\", {\n    degreeName: props.educationDegree.degree.name,\n    obtainedAt: finishedAtYear,\n  });\n});\n</script>\n\n<style lang=\"scss\" scoped>\n.cc-education-header {\n  padding-top: 25px !important;\n}\n@media (max-width: 768px) {\n  .cc-education-header {\n    padding-right: 1.25rem !important;\n  }\n}\n</style>"
+    },
+    "app/components/MyEducation/MyEducation.vue": {
+      "language": "html",
+      "mutants": [
+        {
+          "id": "36",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 96
+            },
+            "start": {
+              "column": 45,
+              "line": 35
+            }
+          }
+        },
+        {
+          "id": "38",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 41
+            },
+            "start": {
+              "column": 13,
+              "line": 37
+            }
+          }
+        },
+        {
+          "id": "39",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 31,
+              "line": 38
+            },
+            "start": {
+              "column": 15,
+              "line": 38
+            }
+          }
+        },
+        {
+          "id": "40",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "expected { degree: { …(3) }, school: { …(5) } } to strictly equal { degree: { …(3) }, school: { …(5) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "74"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 58,
+              "line": 39
+            },
+            "start": {
+              "column": 20,
+              "line": 39
+            }
+          }
+        },
+        {
+          "id": "41",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { degree: { …(3) }, school: { …(5) } } to strictly equal { degree: { …(3) }, school: { …(5) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "74"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 56,
+              "line": 39
+            },
+            "start": {
+              "column": 23,
+              "line": 39
+            }
+          }
+        },
+        {
+          "id": "42",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { degree: { …(3) }, school: { …(5) } } to strictly equal { degree: { …(3) }, school: { …(5) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "74"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 40,
+              "line": 40
+            },
+            "start": {
+              "column": 28,
+              "line": 40
+            }
+          }
+        },
+        {
+          "id": "43",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected { degree: { …(3) }, school: {} } to strictly equal { degree: { …(3) }, school: { …(5) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "74"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 45
+            },
+            "start": {
+              "column": 13,
+              "line": 42
+            }
+          }
+        },
+        {
+          "id": "44",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "expected { degree: { …(3) }, school: { …(5) } } to strictly equal { degree: { …(3) }, school: { …(5) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "74"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 57,
+              "line": 44
+            },
+            "start": {
+              "column": 25,
+              "line": 44
+            }
+          }
+        },
+        {
+          "id": "46",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 51
+            },
+            "start": {
+              "column": 13,
+              "line": 47
+            }
+          }
+        },
+        {
+          "id": "47",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 29,
+              "line": 48
+            },
+            "start": {
+              "column": 15,
+              "line": 48
+            }
+          }
+        },
+        {
+          "id": "48",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "expected { degree: { …(3) }, school: { …(5) } } to strictly equal { degree: { …(3) }, school: { …(5) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "75"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 62,
+              "line": 49
+            },
+            "start": {
+              "column": 20,
+              "line": 49
+            }
+          }
+        },
+        {
+          "id": "37",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 46
+            },
+            "start": {
+              "column": 3,
+              "line": 36
+            }
+          }
+        },
+        {
+          "id": "49",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { degree: { …(3) }, school: { …(5) } } to strictly equal { degree: { …(3) }, school: { …(5) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "75"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 60,
+              "line": 49
+            },
+            "start": {
+              "column": 23,
+              "line": 49
+            }
+          }
+        },
+        {
+          "id": "50",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { degree: { …(3) }, school: { …(5) } } to strictly equal { degree: { …(3) }, school: { …(5) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "75"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 40,
+              "line": 50
+            },
+            "start": {
+              "column": 28,
+              "line": 50
+            }
+          }
+        },
+        {
+          "id": "51",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected { degree: { …(3) }, school: {} } to strictly equal { degree: { …(3) }, school: { …(5) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "75"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 55
+            },
+            "start": {
+              "column": 13,
+              "line": 52
+            }
+          }
+        },
+        {
+          "id": "52",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "expected { degree: { …(3) }, school: { …(5) } } to strictly equal { degree: { …(3) }, school: { …(5) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "75"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 81,
+              "line": 54
+            },
+            "start": {
+              "column": 25,
+              "line": 54
+            }
+          }
+        },
+        {
+          "id": "54",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 65
+            },
+            "start": {
+              "column": 13,
+              "line": 57
+            }
+          }
+        },
+        {
+          "id": "55",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 39,
+              "line": 58
+            },
+            "start": {
+              "column": 15,
+              "line": 58
+            }
+          }
+        },
+        {
+          "id": "56",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "76"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 8,
+              "line": 62
+            },
+            "start": {
+              "column": 20,
+              "line": 59
+            }
+          }
+        },
+        {
+          "id": "45",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 56
+            },
+            "start": {
+              "column": 6,
+              "line": 46
+            }
+          }
+        },
+        {
+          "id": "57",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "76"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 49,
+              "line": 60
+            },
+            "start": {
+              "column": 11,
+              "line": 60
+            }
+          }
+        },
+        {
+          "id": "58",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "76"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 43,
+              "line": 61
+            },
+            "start": {
+              "column": 11,
+              "line": 61
+            }
+          }
+        },
+        {
+          "id": "59",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "76"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 39,
+              "line": 63
+            },
+            "start": {
+              "column": 27,
+              "line": 63
+            }
+          }
+        },
+        {
+          "id": "60",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "76"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 40,
+              "line": 64
+            },
+            "start": {
+              "column": 28,
+              "line": 64
+            }
+          }
+        },
+        {
+          "id": "61",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected { degree: { …(4) }, school: {} } to strictly equal { degree: { …(4) }, school: { …(6) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "76"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 69
+            },
+            "start": {
+              "column": 13,
+              "line": 66
+            }
+          }
+        },
+        {
+          "id": "62",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "76"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 58,
+              "line": 68
+            },
+            "start": {
+              "column": 25,
+              "line": 68
+            }
+          }
+        },
+        {
+          "id": "64",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 79
+            },
+            "start": {
+              "column": 13,
+              "line": 71
+            }
+          }
+        },
+        {
+          "id": "53",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 70
+            },
+            "start": {
+              "column": 6,
+              "line": 56
+            }
+          }
+        },
+        {
+          "id": "65",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 40,
+              "line": 72
+            },
+            "start": {
+              "column": 15,
+              "line": 72
+            }
+          }
+        },
+        {
+          "id": "66",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "77"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 8,
+              "line": 76
+            },
+            "start": {
+              "column": 20,
+              "line": 73
+            }
+          }
+        },
+        {
+          "id": "67",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "77"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 61,
+              "line": 74
+            },
+            "start": {
+              "column": 11,
+              "line": 74
+            }
+          }
+        },
+        {
+          "id": "68",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "77"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 45,
+              "line": 75
+            },
+            "start": {
+              "column": 11,
+              "line": 75
+            }
+          }
+        },
+        {
+          "id": "69",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "77"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 39,
+              "line": 77
+            },
+            "start": {
+              "column": 27,
+              "line": 77
+            }
+          }
+        },
+        {
+          "id": "70",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "77"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 40,
+              "line": 78
+            },
+            "start": {
+              "column": 28,
+              "line": 78
+            }
+          }
+        },
+        {
+          "id": "74",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 90
+            },
+            "start": {
+              "column": 13,
+              "line": 85
+            }
+          }
+        },
+        {
+          "id": "75",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 42,
+              "line": 86
+            },
+            "start": {
+              "column": 15,
+              "line": 86
+            }
+          }
+        },
+        {
+          "id": "71",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected { degree: { …(4) }, school: {} } to strictly equal { degree: { …(4) }, school: { …(6) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "77"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 83
+            },
+            "start": {
+              "column": 13,
+              "line": 80
+            }
+          }
+        },
+        {
+          "id": "72",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "expected { degree: { …(4) }, school: { …(6) } } to strictly equal { degree: { …(4) }, school: { …(6) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "77"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 56,
+              "line": 82
+            },
+            "start": {
+              "column": 25,
+              "line": 82
+            }
+          }
+        },
+        {
+          "id": "77",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { degree: { …(4) }, school: { …(5) } } to strictly equal { degree: { …(4) }, school: { …(5) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 7,
+          "killedBy": [
+            "78"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 63,
+              "line": 87
+            },
+            "start": {
+              "column": 23,
+              "line": 87
+            }
+          }
+        },
+        {
+          "id": "79",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { degree: { …(4) }, school: { …(5) } } to strictly equal { degree: { …(4) }, school: { …(5) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 7,
+          "killedBy": [
+            "78"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 40,
+              "line": 89
+            },
+            "start": {
+              "column": 28,
+              "line": 89
+            }
+          }
+        },
+        {
+          "id": "80",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected { degree: { …(4) }, school: {} } to strictly equal { degree: { …(4) }, school: { …(5) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 7,
+          "killedBy": [
+            "78"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 94
+            },
+            "start": {
+              "column": 13,
+              "line": 91
+            }
+          }
+        },
+        {
+          "id": "81",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "expected { degree: { …(4) }, school: { …(5) } } to strictly equal { degree: { …(4) }, school: { …(5) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 7,
+          "killedBy": [
+            "78"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 56,
+              "line": 93
+            },
+            "start": {
+              "column": 25,
+              "line": 93
+            }
+          }
+        },
+        {
+          "id": "82",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 100
+            },
+            "start": {
+              "column": 90,
+              "line": 98
+            }
+          }
+        },
+        {
+          "id": "83",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 49,
+              "line": 99
+            },
+            "start": {
+              "column": 10,
+              "line": 99
+            }
+          }
+        },
+        {
+          "id": "84",
+          "mutatorName": "ArithmeticOperator",
+          "replacement": "index - 1",
+          "statusReason": "Snapshot `MyEducation Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 22,
+              "line": 99
+            },
+            "start": {
+              "column": 13,
+              "line": 99
+            }
+          }
+        },
+        {
+          "id": "76",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "expected { degree: { …(4) }, school: { …(5) } } to strictly equal { degree: { …(4) }, school: { …(5) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 7,
+          "killedBy": [
+            "78"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 65,
+              "line": 87
+            },
+            "start": {
+              "column": 20,
+              "line": 87
+            }
+          }
+        },
+        {
+          "id": "78",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { degree: { …(4) }, school: { …(5) } } to strictly equal { degree: { …(4) }, school: { …(5) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 7,
+          "killedBy": [
+            "78"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 39,
+              "line": 88
+            },
+            "start": {
+              "column": 27,
+              "line": 88
+            }
+          }
+        },
+        {
+          "id": "63",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 84
+            },
+            "start": {
+              "column": 6,
+              "line": 70
+            }
+          }
+        },
+        {
+          "id": "73",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "72"
+          ],
+          "coveredBy": [
+            "72",
+            "73",
+            "74",
+            "75",
+            "76",
+            "77",
+            "78"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 95
+            },
+            "start": {
+              "column": 6,
+              "line": 84
+            }
+          }
+        }
+      ],
+      "source": "<template>\n  <section\n    id=\"education\"\n    aria-labelledby=\"education-title\"\n    class=\"section\"\n  >\n    <div class=\"cc-education container\">\n      <SectionTitle\n        id=\"education-title\"\n        icon=\"fa fa-graduation-cap\"\n        icon-color=\"#F05033\"\n        :title=\"$t('MyEducation.education')\"\n      />\n\n      <EducationDegreeCard\n        v-for=\"(educationDegree, index) in educationDegrees\"\n        :key=\"index\"\n        :aria-label=\"getEducationDegreeAriaLabel(educationDegree.degree.name, index)\"\n        class=\"education-degree-card\"\n        :education-degree=\"educationDegree\"\n        role=\"region\"\n      />\n    </div>\n  </section>\n</template>\n\n<script setup lang=\"ts\">\nimport type { EducationDegree } from \"~/models/education-degree/education-degree.types\";\nimport { SCHOOLS } from \"~/models/school/school.constants\";\nimport EducationDegreeCard from \"~/components/MyEducation/EducationDegreeCard/EducationDegreeCard.vue\";\nimport SectionTitle from \"~/components/shared/Layouts/SectionTitle/SectionTitle.vue\";\n\nconst { t } = useI18n();\n\nconst educationDegrees: EducationDegree[] = [\n  {\n    degree: {\n      name: t(`Degrees.gcpACE`),\n      description: [t(\"MyEducation.gcpACECertification\")],\n      obtainedAt: new Date(\"2022-12-01\"),\n    },\n    school: {\n      ...SCHOOLS.google,\n      translatedName: t(`Schools.${SCHOOLS.google.name}`),\n    },\n  }, {\n    degree: {\n      name: t(`Degrees.CKAD`),\n      description: [t(\"MyEducation.kubernetesCertification\")],\n      obtainedAt: new Date(\"2022-08-01\"),\n    },\n    school: {\n      ...SCHOOLS.cloudNativeComputingFoundation,\n      translatedName: t(`Schools.${SCHOOLS.cloudNativeComputingFoundation.name}`),\n    },\n  }, {\n    degree: {\n      name: t(`Degrees.ITMasterDegree`),\n      description: [\n        t(\"MyEducation.firstThreeYearsInEpitech\"),\n        t(\"MyEducation.lastYearsInEpitech\"),\n      ],\n      startedAt: new Date(\"2014-01-01\"),\n      obtainedAt: new Date(\"2019-01-01\"),\n    },\n    school: {\n      ...SCHOOLS.epitech,\n      translatedName: t(`Schools.${SCHOOLS.epitech.name}`),\n    },\n  }, {\n    degree: {\n      name: t(`Degrees.ITCertification`),\n      description: [\n        t(\"MyEducation.internationalExperienceForManagement\"),\n        t(\"MyEducation.softManagementSkills\"),\n      ],\n      startedAt: new Date(\"2017-01-01\"),\n      obtainedAt: new Date(\"2018-01-01\"),\n    },\n    school: {\n      ...SCHOOLS.laval,\n      translatedName: t(`Schools.${SCHOOLS.laval.name}`),\n    },\n  }, {\n    degree: {\n      name: t(`Degrees.highSchoolDiploma`),\n      description: [t(\"MyEducation.scientistHighSchoolDiploma\")],\n      startedAt: new Date(\"2011-01-01\"),\n      obtainedAt: new Date(\"2014-01-01\"),\n    },\n    school: {\n      ...SCHOOLS.vimeu,\n      translatedName: t(`Schools.${SCHOOLS.vimeu.name}`),\n    },\n  },\n];\n\nfunction getEducationDegreeAriaLabel(educationDegreeName: string, index: number): string {\n  return `${index + 1} - ${educationDegreeName}`;\n}\n</script>"
     },
     "app/composables/useDates.ts": {
       "language": "typescript",
@@ -13158,7 +7256,6 @@
           "statusReason": "app/composables/useDates.ts(7,22): error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.\n",
           "status": "CompileError",
           "static": false,
-          "killedBy": [],
           "coveredBy": [
             "25",
             "26",
@@ -13200,7 +7297,6 @@
           "statusReason": "app/composables/useDates.ts(10,42): error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.\n",
           "status": "CompileError",
           "static": false,
-          "killedBy": [],
           "coveredBy": [
             "30",
             "33",
@@ -13227,49 +7323,12 @@
           }
         },
         {
-          "id": "417",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected '01/01/2022 2022' to be 'janvier 2022' // Object.is equality",
-          "status": "Killed",
-          "testsCompleted": 1,
-          "static": false,
-          "killedBy": [
-            "30"
-          ],
-          "coveredBy": [
-            "30",
-            "33",
-            "35",
-            "36",
-            "37",
-            "38",
-            "39",
-            "41",
-            "42",
-            "43",
-            "44",
-            "154"
-          ],
-          "location": {
-            "end": {
-              "column": 83,
-              "line": 11
-            },
-            "start": {
-              "column": 66,
-              "line": 11
-            }
-          }
-        },
-        {
           "id": "418",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
           "statusReason": "app/composables/useDates.ts(11,68): error TS2769: No overload matches this call.\n  Overload 1 of 2, '(locales?: LocalesArgument, options?: DateTimeFormatOptions | undefined): DateTimeFormat', gave the following error.\n    Type '\"\"' is not assignable to type '\"numeric\" | \"2-digit\" | \"long\" | \"short\" | \"narrow\" | undefined'.\n  Overload 2 of 2, '(locales?: string | string[] | undefined, options?: DateTimeFormatOptions | undefined): DateTimeFormat', gave the following error.\n    Type '\"\"' is not assignable to type '\"numeric\" | \"2-digit\" | \"long\" | \"short\" | \"narrow\" | undefined'.\n",
           "status": "CompileError",
           "static": false,
-          "killedBy": [],
           "coveredBy": [
             "30",
             "33",
@@ -13302,7 +7361,6 @@
           "statusReason": "app/composables/useDates.ts(15,3): error TS2741: Property 'getMonthFullName' is missing in type '{}' but required in type 'DatesComposable'.\n",
           "status": "CompileError",
           "static": false,
-          "killedBy": [],
           "coveredBy": [
             "25",
             "26",
@@ -13336,2938 +7394,1381 @@
               "line": 15
             }
           }
+        },
+        {
+          "id": "417",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected '01/01/2022 2022' to be 'janvier 2022' // Object.is equality",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "30"
+          ],
+          "coveredBy": [
+            "30",
+            "33",
+            "35",
+            "36",
+            "37",
+            "38",
+            "39",
+            "41",
+            "42",
+            "43",
+            "44",
+            "154"
+          ],
+          "location": {
+            "end": {
+              "column": 83,
+              "line": 11
+            },
+            "start": {
+              "column": 66,
+              "line": 11
+            }
+          }
         }
       ],
       "source": "import { useI18n } from \"#imports\";\n\ntype DatesComposable = {\n  getMonthFullName: (date: Date) => string;\n};\n\nfunction useDates(): DatesComposable {\n  const { locale } = useI18n();\n\n  const getMonthFullName = (date: Date): string => {\n    const dateTimeFormat = new Intl.DateTimeFormat(locale.value, { month: \"long\" });\n\n    return dateTimeFormat.format(date);\n  };\n  return {\n    getMonthFullName,\n  };\n}\n\nexport { useDates };"
     },
-    "app/models/period/period.class.ts": {
-      "language": "typescript",
+    "app/components/MyExperience/MyExperience.vue": {
+      "language": "html",
       "mutants": [
         {
-          "id": "420",
-          "mutatorName": "BlockStatement",
-          "replacement": "{}",
-          "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
+          "id": "85",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
-          "testsCompleted": 2,
           "static": false,
+          "testsCompleted": 1,
           "killedBy": [
-            "35"
+            "64"
           ],
           "coveredBy": [
-            "33",
-            "35",
-            "36",
-            "37",
-            "38",
-            "39",
-            "42",
-            "43",
-            "44",
-            "149",
-            "150",
-            "151",
-            "152",
-            "153"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 12
-            },
-            "start": {
-              "column": 44,
-              "line": 6
-            }
-          }
-        },
-        {
-          "id": "421",
-          "mutatorName": "ArithmeticOperator",
-          "replacement": "Period.getMonthsDifference(from, to) - firstMonth",
-          "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 2,
-          "static": false,
-          "killedBy": [
-            "35"
-          ],
-          "coveredBy": [
-            "33",
-            "35",
-            "36",
-            "37",
-            "38",
-            "39",
-            "42",
-            "43",
-            "44",
-            "149",
-            "150",
-            "151",
-            "152",
-            "153"
-          ],
-          "location": {
-            "end": {
-              "column": 67,
-              "line": 9
-            },
-            "start": {
-              "column": 18,
-              "line": 9
-            }
-          }
-        },
-        {
-          "id": "422",
-          "mutatorName": "ArithmeticOperator",
-          "replacement": "this.month * monthsInYear",
-          "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 2,
-          "static": false,
-          "killedBy": [
-            "35"
-          ],
-          "coveredBy": [
-            "33",
-            "35",
-            "36",
-            "37",
-            "38",
-            "39",
-            "42",
-            "43",
-            "44",
-            "149",
-            "150",
-            "151",
-            "152",
-            "153"
-          ],
-          "location": {
-            "end": {
-              "column": 53,
-              "line": 10
-            },
-            "start": {
-              "column": 28,
-              "line": 10
-            }
-          }
-        },
-        {
-          "id": "423",
-          "mutatorName": "AssignmentOperator",
-          "replacement": "this.month += this.year * monthsInYear",
-          "statusReason": "expected '( shared.years, {\"yearCount\":2}, 2 sh…' to be '( shared.years, {\"yearCount\":2}, 2 sh…' // Object.is equality",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "38"
-          ],
-          "coveredBy": [
-            "33",
-            "35",
-            "36",
-            "37",
-            "38",
-            "39",
-            "42",
-            "43",
-            "44",
-            "149",
-            "150",
-            "151",
-            "152",
-            "153"
-          ],
-          "location": {
-            "end": {
-              "column": 43,
-              "line": 11
-            },
-            "start": {
-              "column": 5,
-              "line": 11
-            }
-          }
-        },
-        {
-          "id": "424",
-          "mutatorName": "ArithmeticOperator",
-          "replacement": "this.year / monthsInYear",
-          "statusReason": "expected '( shared.years, {\"yearCount\":2}, 2 sh…' to be '( shared.years, {\"yearCount\":2}, 2 sh…' // Object.is equality",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "38"
-          ],
-          "coveredBy": [
-            "33",
-            "35",
-            "36",
-            "37",
-            "38",
-            "39",
-            "42",
-            "43",
-            "44",
-            "149",
-            "150",
-            "151",
-            "152",
-            "153"
-          ],
-          "location": {
-            "end": {
-              "column": 43,
-              "line": 11
-            },
-            "start": {
-              "column": 19,
-              "line": 11
-            }
-          }
-        },
-        {
-          "id": "425",
-          "mutatorName": "BlockStatement",
-          "replacement": "{}",
-          "statusReason": "app/models/period/period.class.ts(14,61): error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.\n",
-          "status": "CompileError",
-          "static": false,
-          "killedBy": [],
-          "coveredBy": [
-            "33",
-            "35",
-            "36",
-            "37",
-            "38",
-            "39",
-            "42",
-            "43",
-            "44",
-            "149",
-            "150",
-            "151",
-            "152",
-            "153"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 18
-            },
-            "start": {
-              "column": 68,
-              "line": 14
-            }
-          }
-        },
-        {
-          "id": "426",
-          "mutatorName": "ArithmeticOperator",
-          "replacement": "to.getMonth() - from.getMonth() - monthCountInYear * (to.getFullYear() - from.getFullYear())",
-          "statusReason": "expected '( shared.years, {\"yearCount\":-2}, -2 …' to be '( shared.years, {\"yearCount\":2}, 2 sh…' // Object.is equality",
-          "status": "Killed",
-          "testsCompleted": 5,
-          "static": false,
-          "killedBy": [
-            "38"
-          ],
-          "coveredBy": [
-            "33",
-            "35",
-            "36",
-            "37",
-            "38",
-            "39",
-            "42",
-            "43",
-            "44",
-            "149",
-            "150",
-            "151",
-            "152",
-            "153"
-          ],
-          "location": {
-            "end": {
-              "column": 104,
-              "line": 17
-            },
-            "start": {
-              "column": 12,
-              "line": 17
-            }
-          }
-        },
-        {
-          "id": "427",
-          "mutatorName": "ArithmeticOperator",
-          "replacement": "to.getMonth() + from.getMonth()",
-          "statusReason": "expected 2 to be 4 // Object.is equality",
-          "status": "Killed",
-          "testsCompleted": 14,
-          "static": false,
-          "killedBy": [
-            "153"
-          ],
-          "coveredBy": [
-            "33",
-            "35",
-            "36",
-            "37",
-            "38",
-            "39",
-            "42",
-            "43",
-            "44",
-            "149",
-            "150",
-            "151",
-            "152",
-            "153"
-          ],
-          "location": {
-            "end": {
-              "column": 43,
-              "line": 17
-            },
-            "start": {
-              "column": 12,
-              "line": 17
-            }
-          }
-        },
-        {
-          "id": "428",
-          "mutatorName": "ArithmeticOperator",
-          "replacement": "monthCountInYear / (to.getFullYear() - from.getFullYear())",
-          "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 2,
-          "static": false,
-          "killedBy": [
-            "35"
-          ],
-          "coveredBy": [
-            "33",
-            "35",
-            "36",
-            "37",
-            "38",
-            "39",
-            "42",
-            "43",
-            "44",
-            "149",
-            "150",
-            "151",
-            "152",
-            "153"
-          ],
-          "location": {
-            "end": {
-              "column": 104,
-              "line": 17
-            },
-            "start": {
-              "column": 46,
-              "line": 17
-            }
-          }
-        },
-        {
-          "id": "429",
-          "mutatorName": "ArithmeticOperator",
-          "replacement": "to.getFullYear() + from.getFullYear()",
-          "statusReason": "Snapshot `Period Timeline Component > Periods > Started at date > should match snapshot when started at date is provided in props. 1` mismatched",
-          "status": "Killed",
-          "testsCompleted": 2,
-          "static": false,
-          "killedBy": [
-            "35"
-          ],
-          "coveredBy": [
-            "33",
-            "35",
-            "36",
-            "37",
-            "38",
-            "39",
-            "42",
-            "43",
-            "44",
-            "149",
-            "150",
-            "151",
-            "152",
-            "153"
-          ],
-          "location": {
-            "end": {
-              "column": 103,
-              "line": 17
-            },
-            "start": {
-              "column": 66,
-              "line": 17
-            }
-          }
-        }
-      ],
-      "source": "class Period {\n  public month: number;\n\n  public year: number;\n\n  public constructor(from: Date, to: Date) {\n    const firstMonth = 1;\n    const monthsInYear = 12;\n    this.month = Period.getMonthsDifference(from, to) + firstMonth;\n    this.year = Math.floor(this.month / monthsInYear);\n    this.month -= this.year * monthsInYear;\n  }\n\n  private static getMonthsDifference(from: Date, to: Date): number {\n    const monthCountInYear = 12;\n\n    return to.getMonth() - from.getMonth() + monthCountInYear * (to.getFullYear() - from.getFullYear());\n  }\n}\n\nexport { Period };"
-    },
-    "app/models/company/company.constants.ts": {
-      "language": "typescript",
-      "mutants": [
-        {
-          "id": "app/models/company/company.constants.ts@8:62-24:1\nObjectLiteral: {}",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/company/company.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
           "location": {
             "end": {
               "column": 2,
-              "line": 25
-            },
-            "start": {
-              "column": 63,
-              "line": 9
-            }
-          }
-        },
-        {
-          "id": "app/models/company/company.constants.ts@9:12-13:3\nObjectLiteral: {}",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/company/company.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 14
-            },
-            "start": {
-              "column": 13,
-              "line": 10
-            }
-          }
-        },
-        {
-          "id": "app/models/company/company.constants.ts@10:10-10:20\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/company/company.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 11
-            },
-            "start": {
-              "column": 11,
-              "line": 11
-            }
-          }
-        },
-        {
-          "id": "app/models/company/company.constants.ts@11:9-11:44\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/company/company.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 45,
-              "line": 12
-            },
-            "start": {
-              "column": 10,
-              "line": 12
-            }
-          }
-        },
-        {
-          "id": "app/models/company/company.constants.ts@12:11-12:26\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/company/company.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 27,
-              "line": 13
-            },
-            "start": {
-              "column": 12,
-              "line": 13
-            }
-          }
-        },
-        {
-          "id": "app/models/company/company.constants.ts@14:10-18:3\nObjectLiteral: {}",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/company/company.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 19
-            },
-            "start": {
-              "column": 11,
-              "line": 15
-            }
-          }
-        },
-        {
-          "id": "app/models/company/company.constants.ts@15:10-15:18\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/company/company.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 19,
-              "line": 16
-            },
-            "start": {
-              "column": 11,
-              "line": 16
-            }
-          }
-        },
-        {
-          "id": "app/models/company/company.constants.ts@16:9-16:44\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/company/company.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 45,
-              "line": 17
-            },
-            "start": {
-              "column": 10,
-              "line": 17
-            }
-          }
-        },
-        {
-          "id": "app/models/company/company.constants.ts@17:11-17:29\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/company/company.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 30,
-              "line": 18
-            },
-            "start": {
-              "column": 12,
-              "line": 18
-            }
-          }
-        },
-        {
-          "id": "app/models/company/company.constants.ts@19:9-23:3\nObjectLiteral: {}",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/company/company.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 24
-            },
-            "start": {
-              "column": 10,
-              "line": 20
-            }
-          }
-        },
-        {
-          "id": "app/models/company/company.constants.ts@20:10-20:17\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/company/company.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 18,
-              "line": 21
-            },
-            "start": {
-              "column": 11,
-              "line": 21
-            }
-          }
-        },
-        {
-          "id": "app/models/company/company.constants.ts@21:9-21:32\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/company/company.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 33,
-              "line": 22
-            },
-            "start": {
-              "column": 10,
-              "line": 22
-            }
-          }
-        },
-        {
-          "id": "app/models/company/company.constants.ts@22:11-22:28\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/company/company.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 29,
-              "line": 23
-            },
-            "start": {
-              "column": 12,
-              "line": 23
-            }
-          }
-        }
-      ],
-      "source": "import type { CompanyName, Company } from \"~/models/company/company.types\";\n\nconst COMPANY_NAMES = [\n  \"SoBook\",\n  \"OhMyCode\",\n  \"Daveo\",\n] as const;\n\nconst COMPANIES: Record<CompanyName, Company> = Object.freeze({\n  OhMyCode: {\n    name: \"OhMyCode\",\n    url: \"https://www.sobook.fr/oh-my-code/\",\n    image: \"omc-logo.webp\",\n  },\n  SoBook: {\n    name: \"SoBook\",\n    url: \"https://www.sobook.fr/oh-my-code/\",\n    image: \"sobook-logo.webp\",\n  },\n  Daveo: {\n    name: \"Daveo\",\n    url: \"https://www.daveo.fr/\",\n    image: \"daveo-logo.webp\",\n  },\n});\n\nexport {\n  COMPANY_NAMES,\n  COMPANIES,\n};"
-    },
-    "app/models/school/school.constants.ts": {
-      "language": "typescript",
-      "mutants": [
-        {
-          "id": "app/models/school/school.constants.ts@10:58-43:1\nObjectLiteral: {}",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 2,
-              "line": 44
+              "line": 95
             },
             "start": {
               "column": 59,
-              "line": 11
+              "line": 35
             }
           }
         },
         {
-          "id": "app/models/school/school.constants.ts@11:9-16:3\nObjectLiteral: {}",
+          "id": "87",
           "mutatorName": "ObjectLiteral",
           "replacement": "{}",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
+          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
           "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
+          "testsCompleted": 1,
+          "killedBy": [
+            "64"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
           "location": {
             "end": {
-              "column": 4,
-              "line": 17
+              "column": 6,
+              "line": 47
             },
             "start": {
               "column": 10,
-              "line": 12
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@12:10-12:17\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 18,
-              "line": 13
-            },
-            "start": {
-              "column": 11,
-              "line": 13
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@13:10-13:31\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 32,
-              "line": 14
-            },
-            "start": {
-              "column": 11,
-              "line": 14
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@14:13-14:21\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 22,
-              "line": 15
-            },
-            "start": {
-              "column": 14,
-              "line": 15
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@15:9-15:53\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 54,
-              "line": 16
-            },
-            "start": {
-              "column": 10,
-              "line": 16
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@17:11-23:3\nObjectLiteral: {}",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 24
-            },
-            "start": {
-              "column": 12,
-              "line": 18
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@18:10-18:19\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 20,
-              "line": 19
-            },
-            "start": {
-              "column": 11,
-              "line": 19
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@19:10-19:17\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 18,
-              "line": 20
-            },
-            "start": {
-              "column": 11,
-              "line": 20
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@20:13-20:21\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 22,
-              "line": 21
-            },
-            "start": {
-              "column": 14,
-              "line": 21
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@21:9-21:34\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 35,
-              "line": 22
-            },
-            "start": {
-              "column": 10,
-              "line": 22
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@22:11-22:30\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 31,
-              "line": 23
-            },
-            "start": {
-              "column": 12,
-              "line": 23
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@24:9-30:3\nObjectLiteral: {}",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 31
-            },
-            "start": {
-              "column": 10,
-              "line": 25
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@25:10-25:17\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 18,
-              "line": 26
-            },
-            "start": {
-              "column": 11,
-              "line": 26
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@26:10-26:18\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 19,
-              "line": 27
-            },
-            "start": {
-              "column": 11,
-              "line": 27
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@27:13-27:21\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 22,
-              "line": 28
-            },
-            "start": {
-              "column": 14,
-              "line": 28
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@28:9-28:33\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 34,
-              "line": 29
-            },
-            "start": {
-              "column": 10,
-              "line": 29
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@29:11-29:28\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 29,
-              "line": 30
-            },
-            "start": {
-              "column": 12,
-              "line": 30
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@31:34-36:3\nObjectLiteral: {}",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 4,
               "line": 37
-            },
-            "start": {
-              "column": 35,
-              "line": 32
             }
           }
         },
         {
-          "id": "app/models/school/school.constants.ts@32:10-32:42\nStringLiteral: \"\"",
+          "id": "88",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
+          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
           "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
+          "testsCompleted": 1,
+          "killedBy": [
+            "64"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
           "location": {
             "end": {
-              "column": 43,
-              "line": 33
+              "column": 58,
+              "line": 38
             },
             "start": {
-              "column": 11,
-              "line": 33
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@33:13-33:18\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 19,
-              "line": 34
-            },
-            "start": {
-              "column": 14,
-              "line": 34
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@34:9-34:31\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 32,
-              "line": 35
-            },
-            "start": {
-              "column": 10,
-              "line": 35
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@35:11-35:55\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 56,
-              "line": 36
-            },
-            "start": {
-              "column": 12,
-              "line": 36
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@37:10-42:3\nObjectLiteral: {}",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 43
-            },
-            "start": {
-              "column": 11,
+              "column": 15,
               "line": 38
             }
           }
         },
         {
-          "id": "app/models/school/school.constants.ts@38:10-38:18\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
+          "id": "89",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "expected { job: { …(3) }, company: { …(3) } } to strictly equal { …(2) }",
+          "status": "Killed",
           "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
+          "testsCompleted": 3,
+          "killedBy": [
+            "66"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
           "location": {
             "end": {
-              "column": 19,
+              "column": 8,
+              "line": 45
+            },
+            "start": {
+              "column": 20,
               "line": 39
+            }
+          }
+        },
+        {
+          "id": "90",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { job: { …(3) }, company: { …(3) } } to strictly equal { …(2) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "66"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 38,
+              "line": 40
             },
             "start": {
               "column": 11,
-              "line": 39
-            }
-          }
-        },
-        {
-          "id": "app/models/school/school.constants.ts@39:13-39:18\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 19,
-              "line": 40
-            },
-            "start": {
-              "column": 14,
               "line": 40
             }
           }
         },
         {
-          "id": "app/models/school/school.constants.ts@40:9-40:36\nStringLiteral: \"\"",
+          "id": "91",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
+          "statusReason": "expected { job: { …(3) }, company: { …(3) } } to strictly equal { …(2) }",
+          "status": "Killed",
           "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
+          "testsCompleted": 3,
+          "killedBy": [
+            "66"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
           "location": {
             "end": {
-              "column": 37,
+              "column": 42,
               "line": 41
             },
             "start": {
-              "column": 10,
+              "column": 11,
               "line": 41
             }
           }
         },
         {
-          "id": "app/models/school/school.constants.ts@41:11-41:44\nStringLiteral: \"\"",
+          "id": "92",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
+          "statusReason": "expected { job: { …(3) }, company: { …(3) } } to strictly equal { …(2) }",
+          "status": "Killed",
           "static": false,
-          "relativeFileName": "app/models/school/school.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 45,
-              "line": 42
-            },
-            "start": {
-              "column": 12,
-              "line": 42
-            }
-          }
-        }
-      ],
-      "source": "import type { School, SchoolName } from \"~/models/school/school.types\";\n\nconst SCHOOL_NAMES = [\n  \"vimeu\",\n  \"epitech\",\n  \"laval\",\n  \"cloudNativeComputingFoundation\",\n  \"google\",\n] as const;\n\nconst SCHOOLS: Record<SchoolName, School> = Object.freeze({\n  vimeu: {\n    name: \"vimeu\",\n    city: \"Friville-Escarbotin\",\n    country: \"france\",\n    url: \"https://lycee-vimeu-friville.ac-amiens.fr/\",\n  },\n  epitech: {\n    name: \"epitech\",\n    city: \"Lille\",\n    country: \"france\",\n    url: \"https://www.epitech.eu/\",\n    image: \"epitech-logo.webp\",\n  },\n  laval: {\n    name: \"laval\",\n    city: \"Québec\",\n    country: \"canada\",\n    url: \"https://www.ulaval.ca/\",\n    image: \"laval-logo.webp\",\n  },\n  cloudNativeComputingFoundation: {\n    name: \"cloudNativeComputingFoundation\",\n    country: \"usa\",\n    url: \"https://www.cncf.io/\",\n    image: \"cloud-native-computed-foundation-logo.webp\",\n  },\n  google: {\n    name: \"google\",\n    country: \"usa\",\n    url: \"https://cloud.google.com/\",\n    image: \"google-cloud-platform-logo.webp\",\n  },\n});\n\nexport { SCHOOL_NAMES, SCHOOLS };"
-    },
-    "app/shared/constants/antoine-zanardi.constants.ts": {
-      "language": "typescript",
-      "mutants": [
-        {
-          "id": "app/shared/constants/antoine-zanardi.constants.ts@0:34-0:51\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/shared/constants/antoine-zanardi.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 52,
-              "line": 1
-            },
-            "start": {
-              "column": 35,
-              "line": 1
-            }
-          }
-        },
-        {
-          "id": "app/shared/constants/antoine-zanardi.constants.ts@2:35-2:47\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/shared/constants/antoine-zanardi.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
+          "testsCompleted": 3,
+          "killedBy": [
+            "66"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
           "location": {
             "end": {
               "column": 48,
-              "line": 3
+              "line": 42
             },
             "start": {
-              "column": 36,
-              "line": 3
+              "column": 11,
+              "line": 42
             }
           }
         },
         {
-          "id": "app/shared/constants/antoine-zanardi.constants.ts@4:35-4:71\nStringLiteral: \"\"",
+          "id": "93",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
+          "statusReason": "expected { job: { …(3) }, company: { …(3) } } to strictly equal { …(2) }",
+          "status": "Killed",
           "static": false,
-          "relativeFileName": "app/shared/constants/antoine-zanardi.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 72,
-              "line": 5
-            },
-            "start": {
-              "column": 36,
-              "line": 5
-            }
-          }
-        },
-        {
-          "id": "app/shared/constants/antoine-zanardi.constants.ts@6:42-6:81\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/shared/constants/antoine-zanardi.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 82,
-              "line": 7
-            },
-            "start": {
-              "column": 43,
-              "line": 7
-            }
-          }
-        },
-        {
-          "id": "app/shared/constants/antoine-zanardi.constants.ts@8:37-8:82\nStringLiteral: \"\"",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "Static mutant (and \"ignoreStatic\" was enabled)",
-          "status": "Ignored",
-          "static": false,
-          "relativeFileName": "app/shared/constants/antoine-zanardi.constants.ts",
-          "killedBy": [],
-          "coveredBy": [],
-          "location": {
-            "end": {
-              "column": 83,
-              "line": 9
-            },
-            "start": {
-              "column": 38,
-              "line": 9
-            }
-          }
-        }
-      ],
-      "source": "const ANTOINE_ZANARDI_FULL_NAME = \"Antoine ZANARDI\";\n\nconst ANTOINE_ZANARDI_BIRTH_DATE = \"1996-04-14\";\n\nconst ANTOINE_ZANARDI_GITHUB_URL = \"https://github.com/antoinezanardi/\";\n\nconst ANTOINE_ZANARDI_GITHUB_AVATAR_URL = \"https://github.com/antoinezanardi.png\";\n\nconst ANTOINE_ZANARDI_LINKEDIN_URL = \"https://www.linkedin.com/in/antoinezanardi/\";\n\nexport {\n  ANTOINE_ZANARDI_FULL_NAME,\n  ANTOINE_ZANARDI_BIRTH_DATE,\n  ANTOINE_ZANARDI_GITHUB_URL,\n  ANTOINE_ZANARDI_GITHUB_AVATAR_URL,\n  ANTOINE_ZANARDI_LINKEDIN_URL,\n};"
-    },
-    "app/composables/useAppSchemaOrg.ts": {
-      "language": "typescript",
-      "mutants": [
-        {
-          "id": "352",
-          "mutatorName": "BlockStatement",
-          "replacement": "{}",
-          "statusReason": "app/composables/useAppSchemaOrg.ts(12,29): error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.\n",
-          "status": "CompileError",
-          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "66"
+          ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "146",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
-              "column": 2,
-              "line": 113
-            },
-            "start": {
               "column": 52,
-              "line": 12
-            }
-          }
-        },
-        {
-          "id": "354",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "app/composables/useAppSchemaOrg.ts(17,88): error TS2345: Argument of type '{}' is not assignable to parameter of type 'WebSite'.\n  Property 'name' is missing in type '{}' but required in type 'WebSite'.\n",
-          "status": "CompileError",
-          "static": false,
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "146",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 23
-            },
-            "start": {
-              "column": 88,
-              "line": 17
-            }
-          }
-        },
-        {
-          "id": "353",
-          "mutatorName": "ArrowFunction",
-          "replacement": "() => undefined",
-          "statusReason": "app/composables/useAppSchemaOrg.ts(103,5): error TS2322: Type '() => undefined' is not assignable to type '() => WebSite & Record<string, any>'.\n  Type 'undefined' is not assignable to type 'WebSite & Record<string, any>'.\n    Type 'undefined' is not assignable to type 'WebSite'.\n",
-          "status": "CompileError",
-          "static": false,
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "146",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 5,
-              "line": 23
-            },
-            "start": {
-              "column": 34,
-              "line": 17
-            }
-          }
-        },
-        {
-          "id": "357",
-          "mutatorName": "ArrowFunction",
-          "replacement": "() => undefined",
-          "statusReason": "app/composables/useAppSchemaOrg.ts(35,5): error TS2322: Type '() => undefined' is not assignable to type '() => Person & Record<string, any>'.\n  Type 'undefined' is not assignable to type 'Person & Record<string, any>'.\n    Type 'undefined' is not assignable to type 'Person'.\n",
-          "status": "CompileError",
-          "static": false,
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "146",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 5,
-              "line": 100
-            },
-            "start": {
-              "column": 33,
-              "line": 25
-            }
-          }
-        },
-        {
-          "id": "358",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "app/composables/useAppSchemaOrg.ts(25,85): error TS2345: Argument of type '{}' is not assignable to parameter of type 'Person'.\n  Property 'name' is missing in type '{}' but required in type 'Person'.\n",
-          "status": "CompileError",
-          "static": false,
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 100
-            },
-            "start": {
-              "column": 85,
-              "line": 25
-            }
-          }
-        },
-        {
-          "id": "355",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': '', …(4) } to strictly equal { '@type': 'WebSite', …(4) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 5,
-          "killedBy": [
-            "146"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "146",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 23,
-              "line": 18
-            },
-            "start": {
-              "column": 14,
-              "line": 18
-            }
-          }
-        },
-        {
-          "id": "359",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': '', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 5,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 22,
-              "line": 26
-            },
-            "start": {
-              "column": 14,
-              "line": 26
-            }
-          }
-        },
-        {
-          "id": "356",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'WebSite', …(4) } to strictly equal { '@type': 'WebSite', …(4) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "146"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "146",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 44,
-              "line": 21
-            },
-            "start": {
-              "column": 22,
-              "line": 21
-            }
-          }
-        },
-        {
-          "id": "360",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 31
-            },
-            "start": {
-              "column": 16,
-              "line": 27
-            }
-          }
-        },
-        {
-          "id": "362",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 45,
-              "line": 30
-            },
-            "start": {
-              "column": 27,
-              "line": 30
-            }
-          }
-        },
-        {
-          "id": "363",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 36
-            },
-            "start": {
-              "column": 17,
-              "line": 32
-            }
-          }
-        },
-        {
-          "id": "361",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 5,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 31,
-              "line": 28
-            },
-            "start": {
-              "column": 16,
-              "line": 28
-            }
-          }
-        },
-        {
-          "id": "364",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 37,
-              "line": 33
-            },
-            "start": {
-              "column": 16,
-              "line": 33
-            }
-          }
-        },
-        {
-          "id": "365",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 24,
-              "line": 34
-            },
-            "start": {
-              "column": 15,
-              "line": 34
-            }
-          }
-        },
-        {
-          "id": "367",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
               "line": 43
             },
             "start": {
-              "column": 14,
-              "line": 37
+              "column": 11,
+              "line": 43
             }
           }
         },
         {
-          "id": "366",
+          "id": "94",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "statusReason": "expected { job: { …(3) }, company: { …(3) } } to strictly equal { …(2) }",
           "status": "Killed",
           "static": false,
-          "testsCompleted": 1,
+          "testsCompleted": 3,
           "killedBy": [
-            "147"
+            "66"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 48,
+              "line": 44
+            },
+            "start": {
+              "column": 11,
+              "line": 44
+            }
+          }
+        },
+        {
+          "id": "95",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { job: { …(3) }, company: { …(3) } } to strictly equal { …(2) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "66"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
               "column": 39,
-              "line": 35
+              "line": 46
             },
             "start": {
-              "column": 14,
-              "line": 35
+              "column": 27,
+              "line": 46
             }
           }
         },
         {
-          "id": "368",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 36,
-              "line": 38
-            },
-            "start": {
-              "column": 9,
-              "line": 38
-            }
-          }
-        },
-        {
-          "id": "369",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 34,
-              "line": 39
-            },
-            "start": {
-              "column": 9,
-              "line": 39
-            }
-          }
-        },
-        {
-          "id": "370",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 33,
-              "line": 40
-            },
-            "start": {
-              "column": 9,
-              "line": 40
-            }
-          }
-        },
-        {
-          "id": "371",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 23,
-              "line": 41
-            },
-            "start": {
-              "column": 9,
-              "line": 41
-            }
-          }
-        },
-        {
-          "id": "373",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 49,
-              "line": 45
-            },
-            "start": {
-              "column": 22,
-              "line": 45
-            }
-          }
-        },
-        {
-          "id": "372",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 25,
-              "line": 42
-            },
-            "start": {
-              "column": 9,
-              "line": 42
-            }
-          }
-        },
-        {
-          "id": "374",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 47
-            },
-            "start": {
-              "column": 15,
-              "line": 47
-            }
-          }
-        },
-        {
-          "id": "375",
+          "id": "97",
           "mutatorName": "ObjectLiteral",
           "replacement": "{}",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
           "static": false,
           "testsCompleted": 1,
           "killedBy": [
-            "147"
+            "64"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
               "column": 6,
-              "line": 52
+              "line": 60
             },
             "start": {
-              "column": 22,
-              "line": 48
-            }
-          }
-        },
-        {
-          "id": "376",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 28,
-              "line": 49
-            },
-            "start": {
-              "column": 16,
-              "line": 49
-            }
-          }
-        },
-        {
-          "id": "377",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 41,
-              "line": 50
-            },
-            "start": {
-              "column": 17,
+              "column": 10,
               "line": 50
             }
           }
         },
         {
-          "id": "378",
+          "id": "98",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
           "static": false,
           "testsCompleted": 1,
           "killedBy": [
-            "147"
+            "64"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 54,
-              "line": 51
-            },
-            "start": {
-              "column": 24,
-              "line": 51
-            }
-          }
-        },
-        {
-          "id": "379",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
               "column": 43,
+              "line": 51
+            },
+            "start": {
+              "column": 15,
+              "line": 51
+            }
+          }
+        },
+        {
+          "id": "99",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "67"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 8,
+              "line": 57
+            },
+            "start": {
+              "column": 20,
+              "line": 52
+            }
+          }
+        },
+        {
+          "id": "100",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "67"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 48,
+              "line": 53
+            },
+            "start": {
+              "column": 11,
+              "line": 53
+            }
+          }
+        },
+        {
+          "id": "101",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "67"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 42,
               "line": 54
             },
             "start": {
-              "column": 19,
+              "column": 11,
               "line": 54
             }
           }
         },
         {
-          "id": "380",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "id": "102",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
           "status": "Killed",
           "static": false,
-          "testsCompleted": 1,
+          "testsCompleted": 4,
           "killedBy": [
-            "147"
+            "67"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
-              "column": 6,
-              "line": 65
+              "column": 36,
+              "line": 55
             },
             "start": {
-              "column": 19,
+              "column": 11,
               "line": 55
             }
           }
         },
         {
-          "id": "381",
+          "id": "103",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
           "status": "Killed",
           "static": false,
-          "testsCompleted": 1,
+          "testsCompleted": 4,
           "killedBy": [
-            "147"
+            "67"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
-              "column": 24,
+              "column": 53,
               "line": 56
             },
             "start": {
-              "column": 9,
+              "column": 11,
               "line": 56
             }
           }
         },
         {
-          "id": "382",
+          "id": "104",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
           "status": "Killed",
           "static": false,
-          "testsCompleted": 1,
+          "testsCompleted": 4,
           "killedBy": [
-            "147"
+            "67"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
-              "column": 23,
-              "line": 57
-            },
-            "start": {
-              "column": 9,
-              "line": 57
-            }
-          }
-        },
-        {
-          "id": "383",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 30,
+              "column": 39,
               "line": 58
             },
             "start": {
-              "column": 9,
-              "line": 58
-            }
-          }
-        },
-        {
-          "id": "384",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 30,
-              "line": 59
-            },
-            "start": {
-              "column": 9,
-              "line": 59
-            }
-          }
-        },
-        {
-          "id": "385",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 23,
-              "line": 60
-            },
-            "start": {
-              "column": 9,
-              "line": 60
-            }
-          }
-        },
-        {
-          "id": "387",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 25,
-              "line": 62
-            },
-            "start": {
-              "column": 9,
-              "line": 62
-            }
-          }
-        },
-        {
-          "id": "388",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
               "column": 27,
-              "line": 63
-            },
-            "start": {
-              "column": 9,
-              "line": 63
+              "line": 58
             }
           }
         },
         {
-          "id": "386",
+          "id": "105",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
           "status": "Killed",
           "static": false,
-          "testsCompleted": 1,
+          "testsCompleted": 4,
           "killedBy": [
-            "147"
+            "67"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
-              "column": 24,
-              "line": 61
+              "column": 40,
+              "line": 59
             },
             "start": {
-              "column": 9,
-              "line": 61
+              "column": 28,
+              "line": 59
             }
           }
         },
         {
-          "id": "389",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 24,
-              "line": 64
-            },
-            "start": {
-              "column": 9,
-              "line": 64
-            }
-          }
-        },
-        {
-          "id": "391",
+          "id": "107",
           "mutatorName": "ObjectLiteral",
           "replacement": "{}",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
           "static": false,
           "testsCompleted": 1,
           "killedBy": [
-            "147"
+            "64"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 8,
-              "line": 71
-            },
-            "start": {
-              "column": 7,
-              "line": 67
-            }
-          }
-        },
-        {
-          "id": "390",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
               "column": 6,
-              "line": 77
+              "line": 68
             },
             "start": {
-              "column": 22,
+              "column": 10,
+              "line": 63
+            }
+          }
+        },
+        {
+          "id": "108",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "64"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 54,
+              "line": 64
+            },
+            "start": {
+              "column": 15,
+              "line": 64
+            }
+          }
+        },
+        {
+          "id": "109",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "68"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 98,
+              "line": 65
+            },
+            "start": {
+              "column": 20,
+              "line": 65
+            }
+          }
+        },
+        {
+          "id": "110",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "68"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 57,
+              "line": 65
+            },
+            "start": {
+              "column": 23,
+              "line": 65
+            }
+          }
+        },
+        {
+          "id": "111",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "68"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 96,
+              "line": 65
+            },
+            "start": {
+              "column": 62,
+              "line": 65
+            }
+          }
+        },
+        {
+          "id": "112",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "68"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 39,
+              "line": 66
+            },
+            "start": {
+              "column": 27,
               "line": 66
             }
           }
         },
         {
-          "id": "392",
+          "id": "113",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
           "status": "Killed",
           "static": false,
-          "testsCompleted": 1,
+          "testsCompleted": 5,
           "killedBy": [
-            "147"
+            "68"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
-              "column": 28,
-              "line": 68
+              "column": 40,
+              "line": 67
             },
             "start": {
-              "column": 18,
-              "line": 68
+              "column": 28,
+              "line": 67
             }
           }
         },
         {
-          "id": "395",
+          "id": "115",
           "mutatorName": "ObjectLiteral",
           "replacement": "{}",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
           "static": false,
           "testsCompleted": 1,
           "killedBy": [
-            "147"
+            "64"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
-              "column": 8,
+              "column": 6,
               "line": 76
             },
             "start": {
-              "column": 7,
+              "column": 10,
+              "line": 71
+            }
+          }
+        },
+        {
+          "id": "116",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "64"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 54,
+              "line": 72
+            },
+            "start": {
+              "column": 15,
               "line": 72
             }
           }
         },
         {
-          "id": "393",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "id": "117",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
           "status": "Killed",
           "static": false,
-          "testsCompleted": 1,
+          "testsCompleted": 6,
           "killedBy": [
-            "147"
+            "69"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
-              "column": 37,
-              "line": 69
+              "column": 105,
+              "line": 73
             },
             "start": {
-              "column": 19,
-              "line": 69
+              "column": 20,
+              "line": 73
             }
           }
         },
         {
-          "id": "394",
+          "id": "118",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
           "status": "Killed",
           "static": false,
-          "testsCompleted": 1,
+          "testsCompleted": 6,
           "killedBy": [
-            "147"
+            "69"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
-              "column": 30,
-              "line": 70
+              "column": 58,
+              "line": 73
             },
             "start": {
-              "column": 26,
-              "line": 70
+              "column": 23,
+              "line": 73
             }
           }
         },
         {
-          "id": "396",
+          "id": "119",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
           "status": "Killed",
           "static": false,
-          "testsCompleted": 1,
+          "testsCompleted": 6,
           "killedBy": [
-            "147"
+            "69"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
+              "column": 103,
+              "line": 73
+            },
+            "start": {
+              "column": 63,
+              "line": 73
+            }
+          }
+        },
+        {
+          "id": "120",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "69"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 39,
+              "line": 74
+            },
+            "start": {
+              "column": 27,
+              "line": 74
+            }
+          }
+        },
+        {
+          "id": "121",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { company: { …(3) }, job: { …(4) } }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "69"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 40,
+              "line": 75
+            },
+            "start": {
               "column": 28,
-              "line": 73
-            },
-            "start": {
-              "column": 18,
-              "line": 73
-            }
-          }
-        },
-        {
-          "id": "397",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 38,
-              "line": 74
-            },
-            "start": {
-              "column": 19,
-              "line": 74
-            }
-          }
-        },
-        {
-          "id": "398",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 30,
-              "line": 75
-            },
-            "start": {
-              "column": 26,
               "line": 75
             }
           }
         },
         {
-          "id": "414",
+          "id": "123",
           "mutatorName": "ObjectLiteral",
           "replacement": "{}",
-          "statusReason": "app/composables/useAppSchemaOrg.ts(108,3): error TS2739: Type '{}' is missing the following properties from type 'AppSchemaOrgComposable': getAppSchemaOrgWebSite, getAppSchemaOrgPerson, setupAppSchemaOrg\n",
-          "status": "CompileError",
-          "static": false,
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "146",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 4,
-              "line": 112
-            },
-            "start": {
-              "column": 10,
-              "line": 108
-            }
-          }
-        },
-        {
-          "id": "399",
-          "mutatorName": "ObjectLiteral",
-          "replacement": "{}",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
           "static": false,
           "testsCompleted": 1,
           "killedBy": [
-            "147"
+            "64"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
               "column": 6,
-              "line": 82
+              "line": 84
             },
             "start": {
-              "column": 20,
+              "column": 10,
               "line": 79
             }
           }
         },
         {
-          "id": "400",
+          "id": "124",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
           "static": false,
           "testsCompleted": 1,
           "killedBy": [
-            "147"
+            "64"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
-              "column": 25,
+              "column": 57,
               "line": 80
-            },
-            "start": {
-              "column": 16,
-              "line": 80
-            }
-          }
-        },
-        {
-          "id": "401",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 35,
-              "line": 81
-            },
-            "start": {
-              "column": 17,
-              "line": 81
-            }
-          }
-        },
-        {
-          "id": "402",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 6,
-              "line": 86
             },
             "start": {
               "column": 15,
+              "line": 80
+            }
+          }
+        },
+        {
+          "id": "125",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { …(2) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 7,
+          "killedBy": [
+            "70"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 100,
+              "line": 81
+            },
+            "start": {
+              "column": 20,
+              "line": 81
+            }
+          }
+        },
+        {
+          "id": "126",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { …(2) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 7,
+          "killedBy": [
+            "70"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 58,
+              "line": 81
+            },
+            "start": {
+              "column": 23,
+              "line": 81
+            }
+          }
+        },
+        {
+          "id": "127",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { …(2) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 7,
+          "killedBy": [
+            "70"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 98,
+              "line": 81
+            },
+            "start": {
+              "column": 63,
+              "line": 81
+            }
+          }
+        },
+        {
+          "id": "128",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { …(2) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 7,
+          "killedBy": [
+            "70"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 39,
+              "line": 82
+            },
+            "start": {
+              "column": 27,
+              "line": 82
+            }
+          }
+        },
+        {
+          "id": "86",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "64"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 49
+            },
+            "start": {
+              "column": 3,
+              "line": 36
+            }
+          }
+        },
+        {
+          "id": "129",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { …(2) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 7,
+          "killedBy": [
+            "70"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 40,
+              "line": 83
+            },
+            "start": {
+              "column": 28,
               "line": 83
             }
           }
         },
         {
-          "id": "403",
+          "id": "131",
           "mutatorName": "ObjectLiteral",
           "replacement": "{}",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
           "static": false,
           "testsCompleted": 1,
           "killedBy": [
-            "147"
+            "64"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -16275,209 +8776,255 @@
               "line": 92
             },
             "start": {
-              "column": 18,
+              "column": 10,
               "line": 87
             }
           }
         },
         {
-          "id": "404",
+          "id": "132",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
           "static": false,
           "testsCompleted": 1,
           "killedBy": [
-            "147"
+            "64"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
-              "column": 30,
+              "column": 54,
               "line": 88
             },
             "start": {
-              "column": 16,
+              "column": 15,
               "line": 88
             }
           }
         },
         {
-          "id": "405",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "id": "133",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { …(2) }",
           "status": "Killed",
           "static": false,
-          "testsCompleted": 1,
+          "testsCompleted": 8,
           "killedBy": [
-            "147"
+            "71"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
-              "column": 64,
+              "column": 55,
               "line": 89
             },
             "start": {
-              "column": 17,
+              "column": 20,
               "line": 89
             }
           }
         },
         {
-          "id": "406",
+          "id": "134",
           "mutatorName": "StringLiteral",
           "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { …(2) }",
           "status": "Killed",
           "static": false,
-          "testsCompleted": 1,
+          "testsCompleted": 8,
           "killedBy": [
-            "147"
+            "71"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
-              "column": 78,
+              "column": 53,
+              "line": 89
+            },
+            "start": {
+              "column": 23,
+              "line": 89
+            }
+          }
+        },
+        {
+          "id": "135",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { …(2) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 8,
+          "killedBy": [
+            "71"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 39,
               "line": 90
             },
             "start": {
-              "column": 24,
+              "column": 27,
               "line": 90
             }
           }
         },
         {
-          "id": "407",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 49,
-              "line": 91
-            },
-            "start": {
-              "column": 14,
-              "line": 91
-            }
-          }
-        },
-        {
-          "id": "408",
+          "id": "96",
           "mutatorName": "ObjectLiteral",
           "replacement": "{}",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
           "status": "Killed",
           "static": false,
           "testsCompleted": 1,
           "killedBy": [
-            "147"
+            "64"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
+              "column": 4,
+              "line": 62
+            },
+            "start": {
               "column": 6,
+              "line": 49
+            }
+          }
+        },
+        {
+          "id": "136",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { job: { …(4) }, company: { …(3) } } to strictly equal { …(2) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 8,
+          "killedBy": [
+            "71"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 40,
+              "line": 91
+            },
+            "start": {
+              "column": 28,
+              "line": 91
+            }
+          }
+        },
+        {
+          "id": "137",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "64"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
               "line": 99
             },
             "start": {
-              "column": 17,
-              "line": 95
+              "column": 73,
+              "line": 97
             }
           }
         },
         {
-          "id": "409",
+          "id": "138",
           "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "replacement": "``",
+          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
           "static": false,
           "testsCompleted": 1,
           "killedBy": [
-            "147"
+            "64"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
-          ],
-          "location": {
-            "end": {
-              "column": 30,
-              "line": 96
-            },
-            "start": {
-              "column": 16,
-              "line": 96
-            }
-          }
-        },
-        {
-          "id": "411",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "147"
-          ],
-          "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -16485,101 +9032,6382 @@
               "line": 98
             },
             "start": {
-              "column": 14,
+              "column": 10,
               "line": 98
             }
           }
         },
         {
-          "id": "410",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected { '@type': 'Person', …(20) } to strictly equal { '@type': 'Person', …(20) }",
+          "id": "139",
+          "mutatorName": "ArithmeticOperator",
+          "replacement": "index - 1",
+          "statusReason": "Snapshot `My Experience Component > should match snapshot when rendered. 1` mismatched",
           "status": "Killed",
           "static": false,
           "testsCompleted": 1,
           "killedBy": [
-            "147"
+            "64"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "147",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
               "column": 22,
-              "line": 97
+              "line": 98
             },
             "start": {
-              "column": 15,
-              "line": 97
+              "column": 13,
+              "line": 98
             }
           }
         },
         {
-          "id": "412",
-          "mutatorName": "BlockStatement",
+          "id": "106",
+          "mutatorName": "ObjectLiteral",
           "replacement": "{}",
-          "statusReason": "\u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).toHaveBeenCalledExactlyOnceWith(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected mock function to have been called exactly once, but it was called \u001b[31m0\u001b[39m times",
+          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
           "status": "Killed",
           "static": false,
           "testsCompleted": 1,
           "killedBy": [
-            "148"
+            "64"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
               "column": 4,
-              "line": 107
+              "line": 70
             },
             "start": {
-              "column": 41,
-              "line": 102
+              "column": 6,
+              "line": 62
             }
           }
         },
         {
-          "id": "413",
-          "mutatorName": "ArrayDeclaration",
-          "replacement": "[]",
-          "statusReason": "\u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).toHaveBeenCalledExactlyOnceWith(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m)\u001b[22m\n\nExpected mock function to have been called exactly once with \u001b[32mArray [\n  Array [\n    Object {\n      \"@type\": \"WebSite\",\n      \"_resolver\": \"webSite\",\n      \"description\": \"App.meta.description\",\n      \"inLanguage\": \"fr\",\n      \"name\": \"Antoine ZANARDI - Portfolio Test\",\n    },\n    Object {\n      \"@type\": \"Person\",\n      \"_resolver\": \"person\",\n      \"address\": Object {\n        \"@type\": \"PostalAddress\",\n        \"addressCountry\": \"Countries.france\",\n        \"addressLocality\": \"1234 Elm Street\",\n      },\n      \"alumniOf\": Object {\n        \"@type\": \"CollegeOrUniversity\",\n        \"name\": \"EPITECH\",\n        \"url\": \"https://www.epitech.eu/\",\n      },\n      \"award\": Array [\n        \"Degrees.highSchoolDiploma\",\n        \"Degrees.ITCertification\",\n        \"Degrees.ITMasterDegree\",\n        \"Degrees.CKAD\",\n        \"Degrees.gcpACE\",\n      ],\n      \"birthDate\": \"1996-04-14\",\n      \"description\": \"App.meta.smallDescription\",\n      \"email\": \"john@doe.com\",\n      \"gender\": \"Male\",\n      \"hasOccupation\": Object {\n        \"@type\": \"Occupation\",\n        \"description\": \"MyProfile.fullStackWebExpert\",\n        \"name\": \"MyProfile.itConsultant\",\n      },\n      \"image\": \"https://github.com/antoinezanardi.png\",\n      \"jobTitle\": \"MyProfile.itConsultant\",\n      \"knowsAbout\": Array [\n        \"MySkills.html\",\n        \"MySkills.css\",\n        \"MySkills.javascript\",\n        \"MySkills.typescript\",\n        \"MySkills.vue\",\n        \"MySkills.nuxt\",\n        \"MySkills.mysql\",\n        \"MySkills.mongodb\",\n        \"MySkills.rust\",\n      ],\n      \"knowsLanguage\": Array [\n        Object {\n          \"@type\": \"Language\",\n          \"alternateName\": \"fr\",\n          \"name\": \"Languages.french\",\n        },\n        Object {\n          \"@type\": \"Language\",\n          \"alternateName\": \"en\",\n          \"name\": \"Languages.english\",\n        },\n      ],\n      \"name\": \"Antoine ZANARDI\",\n      \"nationality\": Object {\n        \"@type\": \"Country\",\n        \"name\": \"Countries.france\",\n      },\n      \"sameAs\": Array [\n        \"https://www.linkedin.com/in/antoinezanardi/\",\n        \"https://github.com/antoinezanardi/\",\n      ],\n      \"subjectOf\": Object {\n        \"@type\": \"CreativeWork\",\n        \"description\": \"MyPortfolio.projects.werewolvesAssistant.description\",\n        \"name\": \"MyPortfolio.projects.werewolvesAssistant.name\",\n        \"url\": \"https://werewolves-assistant.com/\",\n      },\n      \"telephone\": \"0123456789\",\n      \"url\": \"https://test.antoinezanardi.fr\",\n      \"worksFor\": Object {\n        \"@type\": \"Organization\",\n        \"name\": \"Daveo\",\n        \"url\": \"https://www.daveo.fr/\",\n      },\n    },\n  ],\n]\u001b[39m, but it was called with \u001b[31mArray []\u001b[39m",
+          "id": "114",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
           "status": "Killed",
           "static": false,
           "testsCompleted": 1,
           "killedBy": [
-            "148"
+            "64"
           ],
           "coveredBy": [
-            "106",
-            "107",
-            "108",
-            "109",
-            "148"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
-              "column": 6,
-              "line": 106
+              "column": 4,
+              "line": 78
             },
             "start": {
-              "column": 18,
-              "line": 103
+              "column": 6,
+              "line": 70
+            }
+          }
+        },
+        {
+          "id": "122",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "64"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 86
+            },
+            "start": {
+              "column": 6,
+              "line": 78
+            }
+          }
+        },
+        {
+          "id": "130",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Hook timed out in 10000ms.\nIf this is a long-running hook, pass a timeout value as the last argument or configure it globally with \"hookTimeout\".",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "64"
+          ],
+          "coveredBy": [
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 94
+            },
+            "start": {
+              "column": 6,
+              "line": 86
             }
           }
         }
       ],
-      "source": "import { definePerson, defineWebSite } from \"nuxt-schema-org/schema\";\n\nimport { useI18n, useRuntimeConfig, useSchemaOrg, useSiteConfig } from \"#imports\";\nimport { ANTOINE_ZANARDI_BIRTH_DATE, ANTOINE_ZANARDI_FULL_NAME, ANTOINE_ZANARDI_GITHUB_URL, ANTOINE_ZANARDI_LINKEDIN_URL, ANTOINE_ZANARDI_GITHUB_AVATAR_URL } from \"~/shared/constants/antoine-zanardi.constants\";\n\ntype AppSchemaOrgComposable = {\n  getAppSchemaOrgWebSite: () => ReturnType<typeof defineWebSite>;\n  getAppSchemaOrgPerson: () => ReturnType<typeof definePerson>;\n  setupAppSchemaOrg: () => void;\n};\n\nfunction useAppSchemaOrg(): AppSchemaOrgComposable {\n  const config = useRuntimeConfig();\n  const { t, locale } = useI18n();\n  const siteConfig = useSiteConfig();\n\n  const getAppSchemaOrgWebSite = (): ReturnType<typeof defineWebSite> => defineWebSite({\n    \"@type\": \"WebSite\",\n    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion\n    \"name\": siteConfig.name as string,\n    \"description\": t(\"App.meta.description\"),\n    \"inLanguage\": locale.value,\n  });\n\n  const getAppSchemaOrgPerson = (): ReturnType<typeof definePerson> => definePerson({\n    \"@type\": \"Person\",\n    \"address\": {\n      \"@type\": \"PostalAddress\",\n      \"addressLocality\": config.public.address,\n      \"addressCountry\": t(\"Countries.france\"),\n    },\n    \"alumniOf\": {\n      \"@type\": \"CollegeOrUniversity\",\n      \"name\": \"EPITECH\",\n      \"url\": \"https://www.epitech.eu/\",\n    },\n    \"award\": [\n      t(\"Degrees.highSchoolDiploma\"),\n      t(\"Degrees.ITCertification\"),\n      t(\"Degrees.ITMasterDegree\"),\n      t(\"Degrees.CKAD\"),\n      t(\"Degrees.gcpACE\"),\n    ],\n    \"birthDate\": ANTOINE_ZANARDI_BIRTH_DATE,\n    \"description\": t(\"App.meta.smallDescription\"),\n    \"email\": config.public.email,\n    \"gender\": \"Male\",\n    \"hasOccupation\": {\n      \"@type\": \"Occupation\",\n      \"name\": t(\"MyProfile.itConsultant\"),\n      \"description\": t(\"MyProfile.fullStackWebExpert\"),\n    },\n    \"image\": ANTOINE_ZANARDI_GITHUB_AVATAR_URL,\n    \"jobTitle\": t(\"MyProfile.itConsultant\"),\n    \"knowsAbout\": [\n      t(\"MySkills.html\"),\n      t(\"MySkills.css\"),\n      t(\"MySkills.javascript\"),\n      t(\"MySkills.typescript\"),\n      t(\"MySkills.vue\"),\n      t(\"MySkills.nuxt\"),\n      t(\"MySkills.mysql\"),\n      t(\"MySkills.mongodb\"),\n      t(\"MySkills.rust\"),\n    ],\n    \"knowsLanguage\": [\n      {\n        \"@type\": \"Language\",\n        \"name\": t(\"Languages.french\"),\n        \"alternateName\": \"fr\",\n      },\n      {\n        \"@type\": \"Language\",\n        \"name\": t(\"Languages.english\"),\n        \"alternateName\": \"en\",\n      },\n    ],\n    \"name\": ANTOINE_ZANARDI_FULL_NAME,\n    \"nationality\": {\n      \"@type\": \"Country\",\n      \"name\": t(\"Countries.france\"),\n    },\n    \"sameAs\": [\n      ANTOINE_ZANARDI_LINKEDIN_URL,\n      ANTOINE_ZANARDI_GITHUB_URL,\n    ],\n    \"subjectOf\": {\n      \"@type\": \"CreativeWork\",\n      \"name\": t(\"MyPortfolio.projects.werewolvesAssistant.name\"),\n      \"description\": t(\"MyPortfolio.projects.werewolvesAssistant.description\"),\n      \"url\": \"https://werewolves-assistant.com/\",\n    },\n    \"telephone\": config.public.phoneNumber,\n    \"url\": siteConfig.url,\n    \"worksFor\": {\n      \"@type\": \"Organization\",\n      \"name\": \"Daveo\",\n      \"url\": \"https://www.daveo.fr/\",\n    },\n  });\n\n  const setupAppSchemaOrg = (): void => {\n    useSchemaOrg([\n      getAppSchemaOrgWebSite(),\n      getAppSchemaOrgPerson(),\n    ]);\n  };\n  return {\n    getAppSchemaOrgWebSite,\n    getAppSchemaOrgPerson,\n    setupAppSchemaOrg,\n  };\n}\n\nexport { useAppSchemaOrg };"
+      "source": "<template>\n  <section\n    id=\"experience\"\n    aria-labelledby=\"experience-title\"\n    class=\"section\"\n  >\n    <div class=\"cc-experience container\">\n      <SectionTitle\n        id=\"experience-title\"\n        icon=\"fa fa-briefcase\"\n        icon-color=\"#4D9344\"\n        :title=\"$t('MyExperience.professionalExperience')\"\n      />\n\n      <ProfessionalExperienceCard\n        v-for=\"(professionalExperience, index) in professionalExperiences\"\n        :key=\"index\"\n        :aria-label=\"getExperienceAriaLabel(professionalExperience.job.name, index)\"\n        class=\"professional-experience-card\"\n        :professional-experience=\"professionalExperience\"\n        role=\"region\"\n      />\n    </div>\n  </section>\n</template>\n\n<script setup lang=\"ts\">\nimport ProfessionalExperienceCard from \"~/components/MyExperience/ProfessionalExperienceCard/ProfessionalExperienceCard.vue\";\nimport SectionTitle from \"~/components/shared/Layouts/SectionTitle/SectionTitle.vue\";\nimport { COMPANIES } from \"~/models/company/company.constants\";\nimport type { ProfessionalExperience } from \"~/models/professional-experience/professional-experience.types\";\n\nconst { t } = useI18n();\n\nconst professionalExperiences: ProfessionalExperience[] = [\n  {\n    job: {\n      name: t(\"MyExperience.fullStackDeveloperConsultant\"),\n      description: [\n        t(\"MyExperience.iJoinedDaveo\"),\n        t(\"MyExperience.whatIsConsulting\"),\n        t(\"MyExperience.myMissionsAsConsultant\"),\n        t(\"MyExperience.cloudProductCertifications\"),\n        t(\"MyExperience.conferenceAndWorkshops\"),\n      ],\n      startedAt: new Date(\"2022-04-01\"),\n    },\n    company: COMPANIES.Daveo,\n  }, {\n    job: {\n      name: t(\"MyExperience.itR&DEngineer\"),\n      description: [\n        t(\"MyExperience.firstPermanentContract\"),\n        t(\"MyExperience.asProjectManager\"),\n        t(\"MyExperience.softSkills\"),\n        t(\"MyExperience.expertiseAndTechnicalSkills\"),\n      ],\n      startedAt: new Date(\"2019-09-01\"),\n      finishedAt: new Date(\"2022-03-31\"),\n    },\n    company: COMPANIES.OhMyCode,\n  }, {\n    job: {\n      name: t(\"MyExperience.internFullStackDeveloper\"),\n      description: [t(\"MyExperience.distributionProject\"), t(\"MyExperience.thisFinalInternship\")],\n      startedAt: new Date(\"2018-09-01\"),\n      finishedAt: new Date(\"2019-08-30\"),\n    },\n    company: COMPANIES.OhMyCode,\n  }, {\n    job: {\n      name: t(\"MyExperience.internFullStackDeveloper\"),\n      description: [t(\"MyExperience.firstStepsInOhMyCode\"), t(\"MyExperience.allFunctionalitiesInOnApp\")],\n      startedAt: new Date(\"2016-09-01\"),\n      finishedAt: new Date(\"2017-04-30\"),\n    },\n    company: COMPANIES.OhMyCode,\n  }, {\n    job: {\n      name: t(\"MyExperience.freelanceFullStackDeveloper\"),\n      description: [t(\"MyExperience.reiterateAsFreelance\"), t(\"MyExperience.moreResponsibilities\")],\n      startedAt: new Date(\"2016-02-01\"),\n      finishedAt: new Date(\"2016-08-30\"),\n    },\n    company: COMPANIES.SoBook,\n  }, {\n    job: {\n      name: t(\"MyExperience.internFullStackDeveloper\"),\n      description: [t(\"MyExperience.firstInternship\")],\n      startedAt: new Date(\"2015-07-01\"),\n      finishedAt: new Date(\"2015-12-31\"),\n    },\n    company: COMPANIES.SoBook,\n  },\n];\n\nfunction getExperienceAriaLabel(jobName: string, index: number): string {\n  return `${index + 1} - ${jobName}`;\n}\n</script>"
+    },
+    "app/components/MyPortfolio/MyPortfolio.vue": {
+      "language": "html",
+      "mutants": [
+        {
+          "id": "140",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: '.portfolio.name', …(3) } to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "99"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 47,
+              "line": 50
+            },
+            "start": {
+              "column": 25,
+              "line": 50
+            }
+          }
+        },
+        {
+          "id": "141",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "Snapshot `My Portfolio Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "97"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 76
+            },
+            "start": {
+              "column": 29,
+              "line": 51
+            }
+          }
+        },
+        {
+          "id": "142",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "99"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 57
+            },
+            "start": {
+              "column": 3,
+              "line": 52
+            }
+          }
+        },
+        {
+          "id": "143",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "expected { name: '', …(3) } to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "99"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 48,
+              "line": 53
+            },
+            "start": {
+              "column": 13,
+              "line": 53
+            }
+          }
+        },
+        {
+          "id": "144",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "99"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 62,
+              "line": 54
+            },
+            "start": {
+              "column": 20,
+              "line": 54
+            }
+          }
+        },
+        {
+          "id": "145",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "99"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 38,
+              "line": 55
+            },
+            "start": {
+              "column": 12,
+              "line": 55
+            }
+          }
+        },
+        {
+          "id": "146",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "100"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 63
+            },
+            "start": {
+              "column": 3,
+              "line": 58
+            }
+          }
+        },
+        {
+          "id": "147",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "expected { name: '', …(3) } to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "100"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 58,
+              "line": 59
+            },
+            "start": {
+              "column": 13,
+              "line": 59
+            }
+          }
+        },
+        {
+          "id": "148",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "100"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 72,
+              "line": 60
+            },
+            "start": {
+              "column": 20,
+              "line": 60
+            }
+          }
+        },
+        {
+          "id": "149",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "100"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 49,
+              "line": 61
+            },
+            "start": {
+              "column": 12,
+              "line": 61
+            }
+          }
+        },
+        {
+          "id": "150",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "100"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 44,
+              "line": 62
+            },
+            "start": {
+              "column": 10,
+              "line": 62
+            }
+          }
+        },
+        {
+          "id": "151",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "101"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 69
+            },
+            "start": {
+              "column": 3,
+              "line": 64
+            }
+          }
+        },
+        {
+          "id": "153",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "101"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 65,
+              "line": 66
+            },
+            "start": {
+              "column": 20,
+              "line": 66
+            }
+          }
+        },
+        {
+          "id": "152",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "expected { name: '', …(3) } to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "101"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 51,
+              "line": 65
+            },
+            "start": {
+              "column": 13,
+              "line": 65
+            }
+          }
+        },
+        {
+          "id": "154",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "101"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 41,
+              "line": 67
+            },
+            "start": {
+              "column": 12,
+              "line": 67
+            }
+          }
+        },
+        {
+          "id": "155",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "101"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 42,
+              "line": 68
+            },
+            "start": {
+              "column": 10,
+              "line": 68
+            }
+          }
+        },
+        {
+          "id": "156",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "102"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 75
+            },
+            "start": {
+              "column": 3,
+              "line": 70
+            }
+          }
+        },
+        {
+          "id": "157",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "expected { name: '', …(3) } to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "102"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 45,
+              "line": 71
+            },
+            "start": {
+              "column": 13,
+              "line": 71
+            }
+          }
+        },
+        {
+          "id": "158",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "102"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 59,
+              "line": 72
+            },
+            "start": {
+              "column": 20,
+              "line": 72
+            }
+          }
+        },
+        {
+          "id": "159",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(4) } to strictly equal { …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "102"
+          ],
+          "coveredBy": [
+            "97",
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
+          ],
+          "location": {
+            "end": {
+              "column": 25,
+              "line": 73
+            },
+            "start": {
+              "column": 12,
+              "line": 73
+            }
+          }
+        }
+      ],
+      "source": "<template>\n  <section\n    id=\"portfolio\"\n    aria-labelledby=\"portfolio-title\"\n    class=\"section\"\n  >\n    <div class=\"container\">\n      <SectionTitle\n        id=\"portfolio-title\"\n        icon=\"fa fa-star\"\n        icon-color=\"#EEC624\"\n        :title=\"$t('MyPortfolio.portfolio')\"\n      />\n\n      <div class=\"gallery tab-content\">\n        <div\n          id=\"web-development\"\n          class=\"active tab-pane\"\n        >\n          <div class=\"me-auto ms-auto\">\n            <div class=\"align-items-center row\">\n              <div\n                v-for=\"project in projects\"\n                :key=\"project.name\"\n                class=\"col-md-6\"\n              >\n                <MyProject\n                  class=\"project\"\n                  :project=\"project\"\n                />\n              </div>\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n  </section>\n</template>\n\n<script setup lang=\"ts\">\nimport { useSiteConfig } from \"#imports\";\nimport MyProject from \"~/components/MyPortfolio/MyProject/MyProject.vue\";\nimport SectionTitle from \"~/components/shared/Layouts/SectionTitle/SectionTitle.vue\";\nimport type { Project } from \"~/models/project/project.types\";\nimport { ANTOINE_ZANARDI_GITHUB_URL } from \"~/shared/constants/antoine-zanardi.constants\";\n\nconst { t } = useI18n();\nconst { url: siteUrl } = useSiteConfig();\n\nconst i18nProjectPath = \"MyPortfolio.projects\";\nconst projects: Project[] = [\n  {\n    name: t(`${i18nProjectPath}.portfolio.name`),\n    description: t(`${i18nProjectPath}.portfolio.description`),\n    image: \"portfolio-thumbnail.webp\",\n    url: siteUrl,\n  },\n  {\n    name: t(`${i18nProjectPath}.werewolvesAssistant.name`),\n    description: t(`${i18nProjectPath}.werewolvesAssistant.description`),\n    image: \"werewolves-assistant-thumbnail.webp\",\n    url: \"https://werewolves-assistant.com\",\n  },\n  {\n    name: t(`${i18nProjectPath}.distribution.name`),\n    description: t(`${i18nProjectPath}.distribution.description`),\n    image: \"distribution-thumbnail.webp\",\n    url: \"https://www.airvey-editions.fr\",\n  },\n  {\n    name: t(`${i18nProjectPath}.gitHub.name`),\n    description: t(`${i18nProjectPath}.gitHub.description`),\n    image: \"github.webp\",\n    url: ANTOINE_ZANARDI_GITHUB_URL,\n  },\n];\n</script>"
+    },
+    "app/components/MySkills/MySkills.vue": {
+      "language": "html",
+      "mutants": [
+        {
+          "id": "161",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.css', …(4) } to strictly equal { name: 'MySkills.css', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "3"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 76,
+              "line": 80
+            },
+            "start": {
+              "column": 16,
+              "line": 80
+            }
+          }
+        },
+        {
+          "id": "162",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.javascript', …(4) } to strictly equal { name: 'MySkills.javascript', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "4"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 57,
+              "line": 81
+            },
+            "start": {
+              "column": 15,
+              "line": 81
+            }
+          }
+        },
+        {
+          "id": "160",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.html', …(4) } to strictly equal { name: 'MySkills.html', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "2"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 54,
+              "line": 79
+            },
+            "start": {
+              "column": 17,
+              "line": 79
+            }
+          }
+        },
+        {
+          "id": "163",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.typescript', …(4) } to strictly equal { name: 'MySkills.typescript', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "5"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 48,
+              "line": 82
+            },
+            "start": {
+              "column": 15,
+              "line": 82
+            }
+          }
+        },
+        {
+          "id": "164",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.vue', …(4) } to strictly equal { name: 'MySkills.vue', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 7,
+          "killedBy": [
+            "6"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 36,
+              "line": 83
+            },
+            "start": {
+              "column": 16,
+              "line": 83
+            }
+          }
+        },
+        {
+          "id": "165",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.nuxt', …(4) } to strictly equal { name: 'MySkills.nuxt', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 8,
+          "killedBy": [
+            "7"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 41,
+              "line": 84
+            },
+            "start": {
+              "column": 17,
+              "line": 84
+            }
+          }
+        },
+        {
+          "id": "168",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.rust', …(4) } to strictly equal { name: 'MySkills.rust', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 11,
+          "killedBy": [
+            "10"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 45,
+              "line": 87
+            },
+            "start": {
+              "column": 17,
+              "line": 87
+            }
+          }
+        },
+        {
+          "id": "166",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.mysql', …(4) } to strictly equal { name: 'MySkills.mysql', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 9,
+          "killedBy": [
+            "8"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 45,
+              "line": 85
+            },
+            "start": {
+              "column": 18,
+              "line": 85
+            }
+          }
+        },
+        {
+          "id": "167",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.mongodb', …(4) } to strictly equal { name: 'MySkills.mongodb', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 10,
+          "killedBy": [
+            "9"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 46,
+              "line": 86
+            },
+            "start": {
+              "column": 20,
+              "line": 86
+            }
+          }
+        },
+        {
+          "id": "169",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "Snapshot `My Skills Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "0"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 152
+            },
+            "start": {
+              "column": 25,
+              "line": 88
+            }
+          }
+        },
+        {
+          "id": "170",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { name: 'MySkills.html', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "2"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 95
+            },
+            "start": {
+              "column": 3,
+              "line": 89
+            }
+          }
+        },
+        {
+          "id": "171",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: '', …(4) } to strictly equal { name: 'MySkills.html', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "2"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 28,
+              "line": 90
+            },
+            "start": {
+              "column": 13,
+              "line": 90
+            }
+          }
+        },
+        {
+          "id": "172",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.html', …(4) } to strictly equal { name: 'MySkills.html', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "2"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 32,
+              "line": 91
+            },
+            "start": {
+              "column": 18,
+              "line": 91
+            }
+          }
+        },
+        {
+          "id": "174",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.html', …(4) } to strictly equal { name: 'MySkills.html', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "2"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 19,
+              "line": 93
+            },
+            "start": {
+              "column": 14,
+              "line": 93
+            }
+          }
+        },
+        {
+          "id": "173",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.html', …(4) } to strictly equal { name: 'MySkills.html', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "2"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 92
+            },
+            "start": {
+              "column": 12,
+              "line": 92
+            }
+          }
+        },
+        {
+          "id": "175",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { name: 'MySkills.css', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "3"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 102
+            },
+            "start": {
+              "column": 3,
+              "line": 96
+            }
+          }
+        },
+        {
+          "id": "176",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: '', …(4) } to strictly equal { name: 'MySkills.css', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "3"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 27,
+              "line": 97
+            },
+            "start": {
+              "column": 13,
+              "line": 97
+            }
+          }
+        },
+        {
+          "id": "177",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.css', …(4) } to strictly equal { name: 'MySkills.css', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "3"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 35,
+              "line": 98
+            },
+            "start": {
+              "column": 18,
+              "line": 98
+            }
+          }
+        },
+        {
+          "id": "178",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.css', …(4) } to strictly equal { name: 'MySkills.css', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "3"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 99
+            },
+            "start": {
+              "column": 12,
+              "line": 99
+            }
+          }
+        },
+        {
+          "id": "179",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.css', …(4) } to strictly equal { name: 'MySkills.css', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "3"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 19,
+              "line": 100
+            },
+            "start": {
+              "column": 14,
+              "line": 100
+            }
+          }
+        },
+        {
+          "id": "181",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: '', …(4) } to strictly equal { name: 'MySkills.javascript', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "4"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 34,
+              "line": 104
+            },
+            "start": {
+              "column": 13,
+              "line": 104
+            }
+          }
+        },
+        {
+          "id": "180",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { name: 'MySkills.javascript', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "4"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 109
+            },
+            "start": {
+              "column": 3,
+              "line": 103
+            }
+          }
+        },
+        {
+          "id": "182",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.javascript', …(4) } to strictly equal { name: 'MySkills.javascript', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "4"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 29,
+              "line": 105
+            },
+            "start": {
+              "column": 18,
+              "line": 105
+            }
+          }
+        },
+        {
+          "id": "183",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.javascript', …(4) } to strictly equal { name: 'MySkills.javascript', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "4"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 106
+            },
+            "start": {
+              "column": 12,
+              "line": 106
+            }
+          }
+        },
+        {
+          "id": "184",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.javascript', …(4) } to strictly equal { name: 'MySkills.javascript', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "4"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 19,
+              "line": 107
+            },
+            "start": {
+              "column": 14,
+              "line": 107
+            }
+          }
+        },
+        {
+          "id": "185",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { name: 'MySkills.typescript', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "5"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 116
+            },
+            "start": {
+              "column": 3,
+              "line": 110
+            }
+          }
+        },
+        {
+          "id": "186",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: '', …(4) } to strictly equal { name: 'MySkills.typescript', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "5"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 34,
+              "line": 111
+            },
+            "start": {
+              "column": 13,
+              "line": 111
+            }
+          }
+        },
+        {
+          "id": "188",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.typescript', …(4) } to strictly equal { name: 'MySkills.typescript', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "5"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 113
+            },
+            "start": {
+              "column": 12,
+              "line": 113
+            }
+          }
+        },
+        {
+          "id": "187",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.typescript', …(4) } to strictly equal { name: 'MySkills.typescript', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "5"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 33,
+              "line": 112
+            },
+            "start": {
+              "column": 18,
+              "line": 112
+            }
+          }
+        },
+        {
+          "id": "189",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.typescript', …(4) } to strictly equal { name: 'MySkills.typescript', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 6,
+          "killedBy": [
+            "5"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 19,
+              "line": 114
+            },
+            "start": {
+              "column": 14,
+              "line": 114
+            }
+          }
+        },
+        {
+          "id": "190",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { name: 'MySkills.vue', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 7,
+          "killedBy": [
+            "6"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 123
+            },
+            "start": {
+              "column": 3,
+              "line": 117
+            }
+          }
+        },
+        {
+          "id": "191",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: '', …(4) } to strictly equal { name: 'MySkills.vue', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 7,
+          "killedBy": [
+            "6"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 27,
+              "line": 118
+            },
+            "start": {
+              "column": 13,
+              "line": 118
+            }
+          }
+        },
+        {
+          "id": "192",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.vue', …(4) } to strictly equal { name: 'MySkills.vue', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 7,
+          "killedBy": [
+            "6"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 32,
+              "line": 119
+            },
+            "start": {
+              "column": 18,
+              "line": 119
+            }
+          }
+        },
+        {
+          "id": "193",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.vue', …(4) } to strictly equal { name: 'MySkills.vue', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 7,
+          "killedBy": [
+            "6"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 120
+            },
+            "start": {
+              "column": 12,
+              "line": 120
+            }
+          }
+        },
+        {
+          "id": "194",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.vue', …(4) } to strictly equal { name: 'MySkills.vue', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 7,
+          "killedBy": [
+            "6"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 19,
+              "line": 121
+            },
+            "start": {
+              "column": 14,
+              "line": 121
+            }
+          }
+        },
+        {
+          "id": "195",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { name: 'MySkills.nuxt', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 8,
+          "killedBy": [
+            "7"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 130
+            },
+            "start": {
+              "column": 3,
+              "line": 124
+            }
+          }
+        },
+        {
+          "id": "196",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: '', …(4) } to strictly equal { name: 'MySkills.nuxt', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 8,
+          "killedBy": [
+            "7"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 28,
+              "line": 125
+            },
+            "start": {
+              "column": 13,
+              "line": 125
+            }
+          }
+        },
+        {
+          "id": "197",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.nuxt', …(4) } to strictly equal { name: 'MySkills.nuxt', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 8,
+          "killedBy": [
+            "7"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 39,
+              "line": 126
+            },
+            "start": {
+              "column": 18,
+              "line": 126
+            }
+          }
+        },
+        {
+          "id": "198",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.nuxt', …(4) } to strictly equal { name: 'MySkills.nuxt', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 8,
+          "killedBy": [
+            "7"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 127
+            },
+            "start": {
+              "column": 12,
+              "line": 127
+            }
+          }
+        },
+        {
+          "id": "199",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.nuxt', …(4) } to strictly equal { name: 'MySkills.nuxt', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 8,
+          "killedBy": [
+            "7"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 19,
+              "line": 128
+            },
+            "start": {
+              "column": 14,
+              "line": 128
+            }
+          }
+        },
+        {
+          "id": "200",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { name: 'MySkills.mysql', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 9,
+          "killedBy": [
+            "8"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 137
+            },
+            "start": {
+              "column": 3,
+              "line": 131
+            }
+          }
+        },
+        {
+          "id": "201",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: '', …(4) } to strictly equal { name: 'MySkills.mysql', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 9,
+          "killedBy": [
+            "8"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 29,
+              "line": 132
+            },
+            "start": {
+              "column": 13,
+              "line": 132
+            }
+          }
+        },
+        {
+          "id": "202",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.mysql', …(4) } to strictly equal { name: 'MySkills.mysql', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 9,
+          "killedBy": [
+            "8"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 35,
+              "line": 133
+            },
+            "start": {
+              "column": 18,
+              "line": 133
+            }
+          }
+        },
+        {
+          "id": "203",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.mysql', …(4) } to strictly equal { name: 'MySkills.mysql', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 9,
+          "killedBy": [
+            "8"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 134
+            },
+            "start": {
+              "column": 12,
+              "line": 134
+            }
+          }
+        },
+        {
+          "id": "204",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.mysql', …(4) } to strictly equal { name: 'MySkills.mysql', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 9,
+          "killedBy": [
+            "8"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 19,
+              "line": 135
+            },
+            "start": {
+              "column": 14,
+              "line": 135
+            }
+          }
+        },
+        {
+          "id": "205",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { name: 'MySkills.mongodb', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 10,
+          "killedBy": [
+            "9"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 144
+            },
+            "start": {
+              "column": 3,
+              "line": 138
+            }
+          }
+        },
+        {
+          "id": "206",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: '', …(4) } to strictly equal { name: 'MySkills.mongodb', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 10,
+          "killedBy": [
+            "9"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 31,
+              "line": 139
+            },
+            "start": {
+              "column": 13,
+              "line": 139
+            }
+          }
+        },
+        {
+          "id": "207",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.mongodb', …(4) } to strictly equal { name: 'MySkills.mongodb', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 10,
+          "killedBy": [
+            "9"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 31,
+              "line": 140
+            },
+            "start": {
+              "column": 18,
+              "line": 140
+            }
+          }
+        },
+        {
+          "id": "208",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.mongodb', …(4) } to strictly equal { name: 'MySkills.mongodb', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 10,
+          "killedBy": [
+            "9"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 141
+            },
+            "start": {
+              "column": 12,
+              "line": 141
+            }
+          }
+        },
+        {
+          "id": "209",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.mongodb', …(4) } to strictly equal { name: 'MySkills.mongodb', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 10,
+          "killedBy": [
+            "9"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 19,
+              "line": 142
+            },
+            "start": {
+              "column": 14,
+              "line": 142
+            }
+          }
+        },
+        {
+          "id": "210",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { name: 'MySkills.rust', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 11,
+          "killedBy": [
+            "10"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 151
+            },
+            "start": {
+              "column": 3,
+              "line": 145
+            }
+          }
+        },
+        {
+          "id": "211",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: '', …(4) } to strictly equal { name: 'MySkills.rust', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 11,
+          "killedBy": [
+            "10"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 28,
+              "line": 146
+            },
+            "start": {
+              "column": 13,
+              "line": 146
+            }
+          }
+        },
+        {
+          "id": "213",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.rust', …(4) } to strictly equal { name: 'MySkills.rust', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 11,
+          "killedBy": [
+            "10"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 148
+            },
+            "start": {
+              "column": 12,
+              "line": 148
+            }
+          }
+        },
+        {
+          "id": "212",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.rust', …(4) } to strictly equal { name: 'MySkills.rust', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 11,
+          "killedBy": [
+            "10"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 31,
+              "line": 147
+            },
+            "start": {
+              "column": 18,
+              "line": 147
+            }
+          }
+        },
+        {
+          "id": "215",
+          "mutatorName": "ArrayDeclaration",
+          "replacement": "[]",
+          "statusReason": "Snapshot `My Skills Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "0"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 220
+            },
+            "start": {
+              "column": 23,
+              "line": 154
+            }
+          }
+        },
+        {
+          "id": "214",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { name: 'MySkills.rust', …(4) } to strictly equal { name: 'MySkills.rust', …(4) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 11,
+          "killedBy": [
+            "10"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 19,
+              "line": 149
+            },
+            "start": {
+              "column": 14,
+              "line": 149
+            }
+          }
+        },
+        {
+          "id": "216",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 13,
+          "killedBy": [
+            "12"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 159
+            },
+            "start": {
+              "column": 3,
+              "line": 155
+            }
+          }
+        },
+        {
+          "id": "217",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 13,
+          "killedBy": [
+            "12"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 46,
+              "line": 156
+            },
+            "start": {
+              "column": 20,
+              "line": 156
+            }
+          }
+        },
+        {
+          "id": "218",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 13,
+          "killedBy": [
+            "12"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 32,
+              "line": 157
+            },
+            "start": {
+              "column": 18,
+              "line": 157
+            }
+          }
+        },
+        {
+          "id": "219",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 13,
+          "killedBy": [
+            "12"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 158
+            },
+            "start": {
+              "column": 12,
+              "line": 158
+            }
+          }
+        },
+        {
+          "id": "220",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 14,
+          "killedBy": [
+            "13"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 164
+            },
+            "start": {
+              "column": 3,
+              "line": 160
+            }
+          }
+        },
+        {
+          "id": "222",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 14,
+          "killedBy": [
+            "13"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 34,
+              "line": 162
+            },
+            "start": {
+              "column": 18,
+              "line": 162
+            }
+          }
+        },
+        {
+          "id": "221",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 14,
+          "killedBy": [
+            "13"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 56,
+              "line": 161
+            },
+            "start": {
+              "column": 20,
+              "line": 161
+            }
+          }
+        },
+        {
+          "id": "223",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 14,
+          "killedBy": [
+            "13"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 163
+            },
+            "start": {
+              "column": 12,
+              "line": 163
+            }
+          }
+        },
+        {
+          "id": "224",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 15,
+          "killedBy": [
+            "14"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 169
+            },
+            "start": {
+              "column": 3,
+              "line": 165
+            }
+          }
+        },
+        {
+          "id": "225",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 15,
+          "killedBy": [
+            "14"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 51,
+              "line": 166
+            },
+            "start": {
+              "column": 20,
+              "line": 166
+            }
+          }
+        },
+        {
+          "id": "226",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 15,
+          "killedBy": [
+            "14"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 30,
+              "line": 167
+            },
+            "start": {
+              "column": 18,
+              "line": 167
+            }
+          }
+        },
+        {
+          "id": "227",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 15,
+          "killedBy": [
+            "14"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 168
+            },
+            "start": {
+              "column": 12,
+              "line": 168
+            }
+          }
+        },
+        {
+          "id": "228",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 16,
+          "killedBy": [
+            "15"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 174
+            },
+            "start": {
+              "column": 3,
+              "line": 170
+            }
+          }
+        },
+        {
+          "id": "229",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 16,
+          "killedBy": [
+            "15"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 43,
+              "line": 171
+            },
+            "start": {
+              "column": 20,
+              "line": 171
+            }
+          }
+        },
+        {
+          "id": "230",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 16,
+          "killedBy": [
+            "15"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 38,
+              "line": 172
+            },
+            "start": {
+              "column": 18,
+              "line": 172
+            }
+          }
+        },
+        {
+          "id": "231",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 16,
+          "killedBy": [
+            "15"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 173
+            },
+            "start": {
+              "column": 12,
+              "line": 173
+            }
+          }
+        },
+        {
+          "id": "232",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 17,
+          "killedBy": [
+            "16"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 179
+            },
+            "start": {
+              "column": 3,
+              "line": 175
+            }
+          }
+        },
+        {
+          "id": "233",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 17,
+          "killedBy": [
+            "16"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 47,
+              "line": 176
+            },
+            "start": {
+              "column": 20,
+              "line": 176
+            }
+          }
+        },
+        {
+          "id": "234",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 17,
+          "killedBy": [
+            "16"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 34,
+              "line": 177
+            },
+            "start": {
+              "column": 18,
+              "line": 177
+            }
+          }
+        },
+        {
+          "id": "235",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 17,
+          "killedBy": [
+            "16"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 178
+            },
+            "start": {
+              "column": 12,
+              "line": 178
+            }
+          }
+        },
+        {
+          "id": "236",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 18,
+          "killedBy": [
+            "17"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 184
+            },
+            "start": {
+              "column": 3,
+              "line": 180
+            }
+          }
+        },
+        {
+          "id": "237",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 18,
+          "killedBy": [
+            "17"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 48,
+              "line": 181
+            },
+            "start": {
+              "column": 20,
+              "line": 181
+            }
+          }
+        },
+        {
+          "id": "238",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 18,
+          "killedBy": [
+            "17"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 35,
+              "line": 182
+            },
+            "start": {
+              "column": 18,
+              "line": 182
+            }
+          }
+        },
+        {
+          "id": "239",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 18,
+          "killedBy": [
+            "17"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 183
+            },
+            "start": {
+              "column": 12,
+              "line": 183
+            }
+          }
+        },
+        {
+          "id": "240",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 19,
+          "killedBy": [
+            "18"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 189
+            },
+            "start": {
+              "column": 3,
+              "line": 185
+            }
+          }
+        },
+        {
+          "id": "241",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 19,
+          "killedBy": [
+            "18"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 44,
+              "line": 186
+            },
+            "start": {
+              "column": 20,
+              "line": 186
+            }
+          }
+        },
+        {
+          "id": "243",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 19,
+          "killedBy": [
+            "18"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 188
+            },
+            "start": {
+              "column": 12,
+              "line": 188
+            }
+          }
+        },
+        {
+          "id": "242",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 19,
+          "killedBy": [
+            "18"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 36,
+              "line": 187
+            },
+            "start": {
+              "column": 18,
+              "line": 187
+            }
+          }
+        },
+        {
+          "id": "244",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 20,
+          "killedBy": [
+            "19"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 194
+            },
+            "start": {
+              "column": 3,
+              "line": 190
+            }
+          }
+        },
+        {
+          "id": "245",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 20,
+          "killedBy": [
+            "19"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 44,
+              "line": 191
+            },
+            "start": {
+              "column": 20,
+              "line": 191
+            }
+          }
+        },
+        {
+          "id": "246",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 20,
+          "killedBy": [
+            "19"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 32,
+              "line": 192
+            },
+            "start": {
+              "column": 18,
+              "line": 192
+            }
+          }
+        },
+        {
+          "id": "247",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 20,
+          "killedBy": [
+            "19"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 193
+            },
+            "start": {
+              "column": 12,
+              "line": 193
+            }
+          }
+        },
+        {
+          "id": "248",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 21,
+          "killedBy": [
+            "20"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 199
+            },
+            "start": {
+              "column": 3,
+              "line": 195
+            }
+          }
+        },
+        {
+          "id": "250",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 21,
+          "killedBy": [
+            "20"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 30,
+              "line": 197
+            },
+            "start": {
+              "column": 18,
+              "line": 197
+            }
+          }
+        },
+        {
+          "id": "249",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 21,
+          "killedBy": [
+            "20"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 44,
+              "line": 196
+            },
+            "start": {
+              "column": 20,
+              "line": 196
+            }
+          }
+        },
+        {
+          "id": "251",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 21,
+          "killedBy": [
+            "20"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 198
+            },
+            "start": {
+              "column": 12,
+              "line": 198
+            }
+          }
+        },
+        {
+          "id": "252",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 22,
+          "killedBy": [
+            "21"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 204
+            },
+            "start": {
+              "column": 3,
+              "line": 200
+            }
+          }
+        },
+        {
+          "id": "253",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 22,
+          "killedBy": [
+            "21"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 53,
+              "line": 201
+            },
+            "start": {
+              "column": 20,
+              "line": 201
+            }
+          }
+        },
+        {
+          "id": "254",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 22,
+          "killedBy": [
+            "21"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 38,
+              "line": 202
+            },
+            "start": {
+              "column": 18,
+              "line": 202
+            }
+          }
+        },
+        {
+          "id": "255",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 22,
+          "killedBy": [
+            "21"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 203
+            },
+            "start": {
+              "column": 12,
+              "line": 203
+            }
+          }
+        },
+        {
+          "id": "257",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 23,
+          "killedBy": [
+            "22"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 40,
+              "line": 206
+            },
+            "start": {
+              "column": 20,
+              "line": 206
+            }
+          }
+        },
+        {
+          "id": "256",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 23,
+          "killedBy": [
+            "22"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 209
+            },
+            "start": {
+              "column": 3,
+              "line": 205
+            }
+          }
+        },
+        {
+          "id": "258",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 23,
+          "killedBy": [
+            "22"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 32,
+              "line": 207
+            },
+            "start": {
+              "column": 18,
+              "line": 207
+            }
+          }
+        },
+        {
+          "id": "259",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 23,
+          "killedBy": [
+            "22"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 208
+            },
+            "start": {
+              "column": 12,
+              "line": 208
+            }
+          }
+        },
+        {
+          "id": "260",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 24,
+          "killedBy": [
+            "23"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 214
+            },
+            "start": {
+              "column": 3,
+              "line": 210
+            }
+          }
+        },
+        {
+          "id": "261",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { description: '', …(2) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 24,
+          "killedBy": [
+            "23"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 41,
+              "line": 211
+            },
+            "start": {
+              "column": 20,
+              "line": 211
+            }
+          }
+        },
+        {
+          "id": "262",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 24,
+          "killedBy": [
+            "23"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 45,
+              "line": 212
+            },
+            "start": {
+              "column": 18,
+              "line": 212
+            }
+          }
+        },
+        {
+          "id": "263",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { …(3) } to strictly equal { …(3) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 24,
+          "killedBy": [
+            "23"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 213
+            },
+            "start": {
+              "column": 12,
+              "line": 213
+            }
+          }
+        },
+        {
+          "id": "264",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "expected {} to strictly equal { Object (description, iconClasses, ...) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 25,
+          "killedBy": [
+            "24"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 219
+            },
+            "start": {
+              "column": 3,
+              "line": 215
+            }
+          }
+        },
+        {
+          "id": "265",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { description: '', …(2) } to strictly equal { Object (description, iconClasses, ...) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 25,
+          "killedBy": [
+            "24"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 37,
+              "line": 216
+            },
+            "start": {
+              "column": 20,
+              "line": 216
+            }
+          }
+        },
+        {
+          "id": "266",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { Object (description, iconClasses, ...) } to strictly equal { Object (description, iconClasses, ...) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 25,
+          "killedBy": [
+            "24"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 33,
+              "line": 217
+            },
+            "start": {
+              "column": 18,
+              "line": 217
+            }
+          }
+        },
+        {
+          "id": "267",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected { Object (description, iconClasses, ...) } to strictly equal { Object (description, iconClasses, ...) }",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 25,
+          "killedBy": [
+            "24"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+            "19",
+            "20",
+            "21",
+            "22",
+            "23",
+            "24"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 218
+            },
+            "start": {
+              "column": 12,
+              "line": 218
+            }
+          }
+        }
+      ],
+      "source": "<template>\n  <section\n    id=\"skills\"\n    aria-labelledby=\"skills-title\"\n    class=\"section\"\n  >\n    <div class=\"container\">\n      <SectionTitle\n        id=\"skills-title\"\n        icon=\"fa fa-code\"\n        icon-color=\"#007EB8\"\n        :title=\"$t('MySkills.itSkills')\"\n      />\n\n      <div\n        class=\"card\"\n        data-aos=\"fade-up\"\n        data-aos-anchor-placement=\"top-bottom\"\n      >\n        <div class=\"card-body\">\n          <div class=\"row\">\n            <div\n              v-for=\"skill in skills\"\n              :key=\"skill.name\"\n              class=\"col-md-6\"\n            >\n              <SkillProgressBar\n                class=\"skill\"\n                :skill=\"skill\"\n              />\n            </div>\n          </div>\n\n          <hr>\n\n          <div class=\"row\">\n            <div class=\"col-md-12 text-center\">\n              <h3\n                class=\"mb-0\"\n              >\n                {{ $t('MySkills.myTools') }}\n              </h3>\n            </div>\n          </div>\n\n          <div class=\"mb-2 row\">\n            <div\n              class=\"col-12 font-italic my-1 small text-center text-muted\"\n            >\n              {{ `(${$t('MySkills.hoverIconsForDetails')})` }}\n            </div>\n          </div>\n\n          <div class=\"row\">\n            <div class=\"col-md-12 d-flex flex-wrap gap-1 justify-content-center text-center\">\n              <MyTool\n                v-for=\"tool in tools\"\n                :key=\"tool.iconClasses\"\n                class=\"tool\"\n                :tool=\"tool\"\n              />\n            </div>\n          </div>\n        </div>\n      </div>\n    </div>\n  </section>\n</template>\n\n<script lang=\"ts\" setup>\nimport MyTool from \"~/components/MySkills/MyTool/MyTool.vue\";\nimport SkillProgressBar from \"~/components/MySkills/SkillProgressBar/SkillProgressBar.vue\";\nimport SectionTitle from \"~/components/shared/Layouts/SectionTitle/SectionTitle.vue\";\nimport type { Skill } from \"~/models/skill/skill.types\";\nimport type { Tool } from \"~/models/tool/tool.types\";\n\nconst { t } = useI18n();\n\nconst htmlUrl = \"https://fr.wikipedia.org/wiki/HTML5\";\nconst cssUrl = \"https://fr.wikipedia.org/wiki/Feuilles_de_style_en_cascade\";\nconst jsUrl = \"https://fr.wikipedia.org/wiki/JavaScript\";\nconst tsUrl = \"https://www.typescriptlang.org/\";\nconst vueUrl = \"https://vuejs.org/\";\nconst nuxtUrl = \"https://v3.nuxtjs.org/\";\nconst mysqlUrl = \"https://www.mysql.com/fr/\";\nconst mongodbUrl = \"https://www.mongodb.com/\";\nconst rustUrl = \"https://www.rust-lang.org/\";\nconst skills: Skill[] = [\n  {\n    name: t(\"MySkills.html\"),\n    iconClasses: \"fab fa-html5\",\n    color: \"#E44D27\",\n    percent: \"95%\",\n    url: htmlUrl,\n  },\n  {\n    name: t(\"MySkills.css\"),\n    iconClasses: \"fab fa-css3-alt\",\n    color: \"#0162B0\",\n    percent: \"90%\",\n    url: cssUrl,\n  },\n  {\n    name: t(\"MySkills.javascript\"),\n    iconClasses: \"fab fa-js\",\n    color: \"#EFC624\",\n    percent: \"95%\",\n    url: jsUrl,\n  },\n  {\n    name: t(\"MySkills.typescript\"),\n    iconClasses: \"fas fa-rocket\",\n    color: \"#3077C6\",\n    percent: \"85%\",\n    url: tsUrl,\n  },\n  {\n    name: t(\"MySkills.vue\"),\n    iconClasses: \"fab fa-vuejs\",\n    color: \"#38956A\",\n    percent: \"95%\",\n    url: vueUrl,\n  },\n  {\n    name: t(\"MySkills.nuxt\"),\n    iconClasses: \"fas fa-mountain-sun\",\n    color: \"#00DC81\",\n    percent: \"90%\",\n    url: nuxtUrl,\n  },\n  {\n    name: t(\"MySkills.mysql\"),\n    iconClasses: \"fas fa-database\",\n    color: \"#017395\",\n    percent: \"85%\",\n    url: mysqlUrl,\n  },\n  {\n    name: t(\"MySkills.mongodb\"),\n    iconClasses: \"fas fa-leaf\",\n    color: \"#4E9445\",\n    percent: \"90%\",\n    url: mongodbUrl,\n  },\n  {\n    name: t(\"MySkills.rust\"),\n    iconClasses: \"fab fa-rust\",\n    color: \"#E3884F\",\n    percent: \"60%\",\n    url: rustUrl,\n  },\n];\n\nconst tools: Tool[] = [\n  {\n    description: t(\"MySkills.linuxForServers\"),\n    iconClasses: \"fab fa-linux\",\n    color: \"#2C2C2C\",\n  },\n  {\n    description: t(\"MySkills.microServicesArchitecture\"),\n    iconClasses: \"fas fa-sitemap\",\n    color: \"#007EB8\",\n  },\n  {\n    description: t(\"MySkills.gitForVersionControl\"),\n    iconClasses: \"fab fa-git\",\n    color: \"#F05033\",\n  },\n  {\n    description: t(\"MySkills.multipleEnvs\"),\n    iconClasses: \"fas fa-code-branch\",\n    color: \"#6C757D\",\n  },\n  {\n    description: t(\"MySkills.gitHubAndActions\"),\n    iconClasses: \"fab fa-github \",\n    color: \"#000000\",\n  },\n  {\n    description: t(\"MySkills.nodeJsForProjects\"),\n    iconClasses: \"fab fa-node-js \",\n    color: \"#539E43\",\n  },\n  {\n    description: t(\"MySkills.cssFrameworks\"),\n    iconClasses: \"fab fa-css3-alt \",\n    color: \"#0162B0\",\n  },\n  {\n    description: t(\"MySkills.vueJsWithNuxt\"),\n    iconClasses: \"fab fa-vuejs\",\n    color: \"#38956A\",\n  },\n  {\n    description: t(\"MySkills.openSourceNpm\"),\n    iconClasses: \"fab fa-npm\",\n    color: \"#C63635\",\n  },\n  {\n    description: t(\"MySkills.esLintForGoodPractises\"),\n    iconClasses: \"fas fa-spell-check\",\n    color: \"#00B819\",\n  },\n  {\n    description: t(\"MySkills.unitTests\"),\n    iconClasses: \"fas fa-tasks\",\n    color: \"#35485E\",\n  },\n  {\n    description: t(\"MySkills.openSource\"),\n    iconClasses: \"fas fa-hand-holding-heart\",\n    color: \"#C41B1B\",\n  },\n  {\n    description: t(\"MySkills.docker\"),\n    iconClasses: \"fab fa-docker\",\n    color: \"#2F87E3\",\n  },\n];\n</script>"
+    },
+    "app/components/MySkills/SkillProgressBar/SkillProgressBar.vue": {
+      "language": "html",
+      "mutants": [
+        {
+          "id": "269",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Snapshot `Skill Progress Bar Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "103"
+          ],
+          "coveredBy": [
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108",
+            "109",
+            "110"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 59
+            },
+            "start": {
+              "column": 66,
+              "line": 56
+            }
+          }
+        },
+        {
+          "id": "268",
+          "mutatorName": "ArrowFunction",
+          "replacement": "() => undefined",
+          "statusReason": "Snapshot `Skill Progress Bar Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "103"
+          ],
+          "coveredBy": [
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108",
+            "109",
+            "110"
+          ],
+          "location": {
+            "end": {
+              "column": 3,
+              "line": 59
+            },
+            "start": {
+              "column": 59,
+              "line": 56
+            }
+          }
+        },
+        {
+          "id": "271",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "Snapshot `Skill Progress Bar Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "103"
+          ],
+          "coveredBy": [
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108",
+            "109",
+            "110"
+          ],
+          "location": {
+            "end": {
+              "column": 87,
+              "line": 61
+            },
+            "start": {
+              "column": 55,
+              "line": 61
+            }
+          }
+        },
+        {
+          "id": "270",
+          "mutatorName": "ArrowFunction",
+          "replacement": "() => undefined",
+          "statusReason": "Snapshot `Skill Progress Bar Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "103"
+          ],
+          "coveredBy": [
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108",
+            "109",
+            "110"
+          ],
+          "location": {
+            "end": {
+              "column": 3,
+              "line": 64
+            },
+            "start": {
+              "column": 47,
+              "line": 61
+            }
+          }
+        },
+        {
+          "id": "272",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Snapshot `Skill Progress Bar Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "103"
+          ],
+          "coveredBy": [
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108",
+            "109",
+            "110"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 64
+            },
+            "start": {
+              "column": 89,
+              "line": 61
+            }
+          }
+        }
+      ],
+      "source": "<template>\n  <div class=\"progress-container\">\n    <span\n      id=\"badge-html\"\n      class=\"progress-badge\"\n    >\n      <WrappedFontAwesomeIcon\n        class=\"skill-icon\"\n        classes=\"me-2\"\n        :icon=\"skill.iconClasses\"\n        :icon-color=\"skill.color\"\n      />\n\n      <b>\n        <a\n          class=\"skill-name text-muted\"\n          :href=\"skill.url\"\n          rel=\"noopener noreferrer\"\n          target=\"_blank\"\n        >\n          {{ skill.name }}\n        </a>\n      </b>\n    </span>\n\n    <div class=\"progress\">\n      <div\n        :aria-label=\"progressBarAriaLabel\"\n        aria-valuemax=\"100\"\n        aria-valuemin=\"0\"\n        class=\"progress-bar progress-bar-primary\"\n        data-aos=\"progress-full\"\n        data-aos-duration=\"2000\"\n        data-aos-offset=\"10\"\n        role=\"progressbar\"\n        :style=\"progressBarStyle\"\n      />\n\n      <span\n        class=\"font-weight-bold progress-value\"\n      >\n        {{ skill.percent }}\n      </span>\n    </div>\n  </div>\n</template>\n\n<script setup lang=\"ts\">\nimport type { SkillProgressBarProps } from \"~/components/MySkills/SkillProgressBar/skill-progress-bar.types\";\nimport WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\n\nconst props = defineProps<SkillProgressBarProps>();\n\nconst { t } = useI18n();\n\nconst progressBarStyle = computed<Record<string, string>>(() => ({\n  width: props.skill.percent,\n  backgroundColor: props.skill.color,\n}));\n\nconst progressBarAriaLabel = computed<string>(() => t(\"SkillProgressBar.skillProgress\", {\n  skillName: props.skill.name,\n  skillPercent: props.skill.percent,\n}));\n</script>"
+    },
+    "app/components/NavBar/NavBar.vue": {
+      "language": "html",
+      "mutants": [
+        {
+          "id": "273",
+          "mutatorName": "BooleanLiteral",
+          "replacement": "false",
+          "statusReason": "Snapshot `NavBar Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "92"
+          ],
+          "coveredBy": [
+            "92",
+            "93",
+            "94",
+            "95",
+            "96"
+          ],
+          "location": {
+            "end": {
+              "column": 50,
+              "line": 101
+            },
+            "start": {
+              "column": 46,
+              "line": 101
+            }
+          }
+        },
+        {
+          "id": "274",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "expected [ 'collapse', …(2) ] to include 'show'",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "94"
+          ],
+          "coveredBy": [
+            "94",
+            "95",
+            "96"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 105
+            },
+            "start": {
+              "column": 43,
+              "line": 103
+            }
+          }
+        },
+        {
+          "id": "276",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "expected [ 'collapse', …(3) ] to not include 'show'",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "96"
+          ],
+          "coveredBy": [
+            "96"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 109
+            },
+            "start": {
+              "column": 40,
+              "line": 107
+            }
+          }
+        },
+        {
+          "id": "275",
+          "mutatorName": "BooleanLiteral",
+          "replacement": "isMobileNavBarCollapsed.value",
+          "statusReason": "expected [ 'collapse', …(2) ] to include 'show'",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "94"
+          ],
+          "coveredBy": [
+            "94",
+            "95",
+            "96"
+          ],
+          "location": {
+            "end": {
+              "column": 65,
+              "line": 104
+            },
+            "start": {
+              "column": 35,
+              "line": 104
+            }
+          }
+        },
+        {
+          "id": "277",
+          "mutatorName": "BooleanLiteral",
+          "replacement": "false",
+          "statusReason": "expected [ 'collapse', …(3) ] to not include 'show'",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "96"
+          ],
+          "coveredBy": [
+            "96"
+          ],
+          "location": {
+            "end": {
+              "column": 39,
+              "line": 108
+            },
+            "start": {
+              "column": 35,
+              "line": 108
+            }
+          }
+        }
+      ],
+      "source": "<template>\n  <header>\n    <div class=\"profile-page sidebar-collapse\">\n      <nav\n        class=\"background-primary fixed-top navbar navbar-expand-lg\"\n        data-color-on-scroll=\"100\"\n      >\n        <div class=\"container\">\n          <div class=\"navbar-translate\">\n            <a\n              class=\"navbar-brand text-uppercase\"\n              href=\"#\"\n            >\n              {{ ANTOINE_ZANARDI_FULL_NAME }}\n            </a>\n\n            <button\n              aria-controls=\"navigation\"\n              :aria-expanded=\"false\"\n              :aria-label=\"$t('NavBar.openNavigation')\"\n              class=\"navbar-toggler\"\n              data-target=\"#navigation\"\n              data-toggle=\"collapse\"\n              type=\"button\"\n              @click=\"onClickFromNavBarToggler\"\n            >\n              <span class=\"bar1 navbar-toggler-bar\"/>\n\n              <span class=\"bar2 navbar-toggler-bar\"/>\n\n              <span class=\"bar3 navbar-toggler-bar\"/>\n            </button>\n          </div>\n\n          <div\n            id=\"navigation\"\n            class=\"collapse justify-content-end navbar-collapse\"\n            :class=\"{ 'show': !isMobileNavBarCollapsed }\"\n          >\n            <ul class=\"navbar-nav w-100\">\n              <li class=\"nav-item\">\n                <a\n                  class=\"nav-link smooth-scroll\"\n                  href=\"#about\"\n                  @click=\"onClickFromNavBarLink\"\n                >\n                  {{ $t('AboutMyProfile.whoAmI') }}\n                </a>\n              </li>\n\n              <li class=\"nav-item\">\n                <a\n                  class=\"nav-link smooth-scroll\"\n                  href=\"#skills\"\n                  @click=\"onClickFromNavBarLink\"\n                >\n                  {{ $t('MySkills.itSkills') }}\n                </a>\n              </li>\n\n              <li class=\"nav-item\">\n                <a\n                  class=\"nav-link smooth-scroll\"\n                  href=\"#portfolio\"\n                  @click=\"onClickFromNavBarLink\"\n                >\n                  {{ $t('MyPortfolio.portfolio') }}\n                </a>\n              </li>\n\n              <li class=\"nav-item\">\n                <a\n                  class=\"nav-link smooth-scroll\"\n                  href=\"#experience\"\n                  @click=\"onClickFromNavBarLink\"\n                >\n                  {{ $t('MyExperience.professionalExperience') }}\n                </a>\n              </li>\n\n              <li class=\"nav-item\">\n                <a\n                  class=\"nav-link smooth-scroll\"\n                  href=\"#education\"\n                  @click=\"onClickFromNavBarLink\"\n                >\n                  {{ $t('MyEducation.education') }}\n                </a>\n              </li>\n            </ul>\n          </div>\n        </div>\n      </nav>\n    </div>\n  </header>\n</template>\n\n<script lang=\"ts\" setup>\nimport { ANTOINE_ZANARDI_FULL_NAME } from \"~/shared/constants/antoine-zanardi.constants\";\n\nconst isMobileNavBarCollapsed = ref<boolean>(true);\n\nfunction onClickFromNavBarToggler(): void {\n  isMobileNavBarCollapsed.value = !isMobileNavBarCollapsed.value;\n}\n\nfunction onClickFromNavBarLink(): void {\n  isMobileNavBarCollapsed.value = true;\n}\n</script>\n\n<style lang=\"scss\" scoped>\n.navbar {\n  box-shadow: 0px -5px 20px 5px black;\n\n  #navigation.show {\n    transform: unset;\n  }\n\n  .nav-item {\n    display: flex;\n    align-items: center;\n    justify-content: center;\n    text-align: center;\n  }\n\n  .navbar-toggler {\n    border: 0;\n  }\n}\n</style>"
     },
     "app/components/OgImage/DefaultOgImage.vue": {
       "language": "html",
@@ -16593,12 +15421,12 @@
           "static": false,
           "testsCompleted": 1,
           "killedBy": [
-            "136"
+            "128"
           ],
           "coveredBy": [
-            "136",
-            "137",
-            "138"
+            "128",
+            "129",
+            "130"
           ],
           "location": {
             "end": {
@@ -16620,12 +15448,12 @@
           "static": false,
           "testsCompleted": 1,
           "killedBy": [
-            "136"
+            "128"
           ],
           "coveredBy": [
-            "136",
-            "137",
-            "138"
+            "128",
+            "129",
+            "130"
           ],
           "location": {
             "end": {
@@ -16640,6 +15468,189 @@
         }
       ],
       "source": "<template>\n  <div\n    id=\"og-image\"\n    class=\"flex h-full w-full\"\n    :style=\"{ background: 'linear-gradient(0deg,rgba(0, 15, 9, 1) 65%, rgba(13, 79, 22, 1) 100%)' }\"\n  >\n    <div class=\"flex flex-col gap-2 h-full items-center justify-center\">\n      <img\n        :alt=\"ANTOINE_ZANARDI_FULL_NAME\"\n        height=\"180\"\n        src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAAA9zQYyAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAtKADAAQAAAABAAAAtAAAAABW1ZZ5AABAAElEQVR4Aey9d7RnR3Xnu3/p5nxv305qtRq1WhJKSIAQyICwkbEwGBDJ2PiZ9xzWvOVh+Zl54388fsPMG8+seZ7wPJ41Y/BzwAGbYJDJSIBaQiiBhNQop+5W53xz/IX3/ew6+3fP/fW96iCJ6Or+3XNOnapdVbu+tWvXrnAK9k/ujDmw8ep3DC8UikNWKnaXisULGg3bWLTGqFljc9Vsm65la1hJhF9aLBS5Wr1R93SKPDYaB/R80ApWKzQajxUKNl+v2/fqVnjICqWJRrlwcHFufmby3s8e80j/9Oe0OVA47ZA/gQE3vPWtXbWjHefXSo3NAuEFBStcITRuFVjXmBWGxbzuQrHcEUxs6EVdyFxyDROg/bEJ6OZzIwXLIqtRWEHItka9phcHG43GjJ6OiNq3le6xRsF26P1j1criobHtN40tpfFPd3kORF3k/X5i79e88t3riu2FS61Yv8YWC1dbsbG53rCXFIrFHsEt44tg61jUH0AoX4AcLgAcz3E9GdB54Eeo7Aqw3QnKzXulUa8f19/DSvVhvf5uo1C7s1EvPXHsrk/tyyL8xF+Ccz+xjBh+zY2vLBbbflqS8VpB89KiFbYUSgVhRywRciUpuTlt/rwggF4tNQf3EsizvO1R8HsF8vuV2S+NbrRHHv7UpxZWI/Hj7v8TB+jRV71vbaGycFmt3rhW4u8GYfWqYqlcKTakBVtduNavIFVB/3AhWU8XCC8qoFfMhKpQQHdw12sz6jIes0Lxa/Va/bNDQ7PfferLX55fMdqPqedPDKBdEhfK11uj9huqy/OkRujSsAIA1l3RNI4TNwAw1wAmAD8TF/Fa40TDiPfx3BruTJ+TlKYzoRQFK1IuAbxeq9Z1eVDgvqVYrH18zYnyow8//OMvuX+sAT3y2hvXF+rFD6iu366CXimDQ6WBtaGpRggAksq4QgugC4Wy+1tddovncAHQCNIK1Hgf/q3PES+AGTpz63OEiyuDT8K2hlv2rAGoh0Fym0nvLv6/gv1tP846948loNe9+t1XW6nwTukP764XSlu8kjOzWQAirj8qgM4Dlfu8NQXQrtYQCnQ31DJh1DjXdRzb87+/vf/z73jDxv+57oo/eSj48ONy/bEC9LpXvecN9VLjt1WHby4Vy5W6KlDV6GpESMaTKy4GfJJ2aNEuwan/pEMXBYQX04XkzgOW9PLPcZ/PRyuA8+/ivliXhPYHyjVjPZUx+/U3Ddgv/ex69UcLk3PF6c836n1/ecGrLr+jUPjQbMT7Ub6+uLX1feLMumsF5IaAbIU3F4qFSjLlpsRXB/LJmVsO6MSaM4l/MsVT+5wuoAPUAeS4hv9KKSGdNb6VUjVjQ+0H7Zd+eqP94uvXWV9pxurlRav2Nmz3iS0zf/KJo1/+4p37Pz3Uv+6mXdv/cm4lWj8qfj/SgF537Y0CcjEDcnEZkKMCzhSQAbCzjR/xTvca6QUwW4Ha+hx0V/OP91w1C6nfjA10HLR3XTdov3rDS6wTdXqxbovtbXagusb+/PPj9sU79tlisdNK1fb71Df8/pHJ+tftR3QA+SMJ6JFr3/kKmdX+lepLEnllIEfF/iQD2qxmXXbA3v+Gbnv3DeutvXvGigtVWUI6baKw2T7yiXH7wm2HrMZcZ7VmlUabLVhpRsPkT6mB/T/H7/nUI8HHH5XrjxSgR14uq0Vb8fdkU/tl6bgDqBbouGjBSLhWKXemYI5KQ/UIWvidFZ3CKcx9snvjTiWhPdAKf0JCr/DKvSSbrVSbsBtebvY7791ivaVjVq/My4rXYQfnR+1jX5mwm247bo1qlwAuS46mRJHotYbWmiST5pj8/rZRbfzB0fs+c2C1dH7Y/BNXf9hydXJ+CiOvedcvWlvhNjH7t/TawZyCPf82CYBfCHcmdLzRnEa6+YZ6xnls1Gz9mnZr79BEkYpYbHTZRHWzffZLs/alrx+yRT0XSnrBAFiCAcN1o1GVDVsTjY3agLx/q1Au3Db6qne+f+vWG9rPOP0fQARfCfYDSPe0k1wv9aLnvMv+pyL8nmTIMKMcBjrhVpJU4RfXCNt6RToGCANgxOFf+J+OdPa4km44j5e1sZp6EMxrbmKDrn4eRmHrkoiANfz8hf60Pq/mv1q4ZnhuCiWbn1u0rRcM2cCabjs2t97+5mvH7IvfGLOphQ5NIAFkrYUi78pPOGg7j/Evloal1t041106t2Pjtidm9z1+JML9MF6fv3h7kUp13nUf6KguzPz2bKnjd8X3oWJ1dpkaEMkCuABUqAlR2acCY767b40T705Fg3yQftiFMffB1JGRQRsdHbGO9g7bu3evHTx0SJhpWLlc8azXaxmYwYwAVBMNXOQjyhLX8PdAuXDxvNJVi5dkzRizC9eU7NrLN9vBoxW7+YE9VqtLMlfblNiC0mNxn24zQDfTy/DtoNd7LWmVSl4/pPf/5+DQ/Kd+WKfUfygBve66t59XqRX/SErfL8xrxq6urrOgH9B5sV0rgPO9AZVbF8eQ34XaoiYR561eTF0165xZAVLXUuhKY8F+/Zfeab/x/hutU++f3r3PvnHHHXb73XfbI08dsJqKUiq3WTWbVhdZzQFBJwGauZCmy0nOpp9uWgGefxf3NfGspmFeYbFhFQpSqMiaUVZc+FiSClLjrwcPIEdcjH3kI89xOpiSpH6xUfqrRr3xHw/+EA4af+hUjuv/+Bu/sH/3zk/Y4sKrmJWW7NOfJEWWmP3i3bUCJY+thmq0DqhrdU1M1K2/p9OG+3v8OtTXbetGhmzN0KCVFmX37TC74brX2Nr+btu0dsiuuPwSe83VL7eNktpHDh+2ExPTVlVjhb4rOaCFH25Zosmr9W9rPlvf80zjLFpFWoN6hRISOfUenl4G1Zh6aY1fz7dkvSS9ekkNpLSgoUzhis7akXdde83mR554dPeTrXF/kM951v0g82Ef+IudHfOj6/51pVL9F4/celPliW9+xYSJTDKvbjEI1eCFynxeQiOdGPlT90kPFi4k0DasHbGfeuXL7HXXvNzWDQ3ovSSgQNPT2yUUFW3vnt127OB+e+1PvVph17h6qhWpjlOa5n2P7LT/8bFP2NfvvM8W5OHgFI0koZmMR7/mr8jxZwX3nIDO8kzlNqU+fuG4R4fXc8yEog7hms85Kw1psQKxoMzUqydsbfukvemqAXvr68+Z3bSu/KdPHT/4u29+8w/Hqr4fCkC/+3OzW0rtlf+qxUNvW1BXXh7fbXd+8s9t8sCz1lZE3VgZ0KE7e02c9R+63KAviSaOAN4ATEclLVKqVhclfYfs9a+40N52wxvtypdeaIPduYE/eHBuQguaDc1fAAIWQMnHOxnpyuoTCXrwyJj9ycf+3j598512dGzCo9IDoIM31CjomQhX8jcQToDTjbvIXzwvu2aAxa9BgVpdDtDQCeqh6iCcGxmgSdVNo4WqtdWn7LK1k3bjm9bZ668Yth4VqiKpMz7f8VdznVd8+IorPrizNanv9/MPXOV41+dnryu3FW8qViqvqi3MWUmWgbbOdk0ALNjeZx6V7idwtXDlhQEyRKEs8KgGAVBBtmFUiS2bNuKrGbVZ+8A7rreff/3V9vqXX2rvf/ub7D2/cL29dMsm62wD6ICX2odUlkuBBdMXjyWBM73MXoMU+ePb391pV11+sZ2zaZP1dVVs07oBSfxXWFel02anpqyq8tMGatJZ0c3VNJxUJLMM0ACUPEA+JeENkjABUiSyv9P7kMI1Gq7+EdX93LYnMqhCilsQYOtFlbE6ZRs7DtiNr2mz33rPRXbJFrO2xryVZfar1SrW6Dn3is9+c+bt9+3veWDu4BO7RO4H5sSlH5x755en31yy8p9pff262mJah16UNC6UZeA/8Izd+smPWH3ssJWjFrOsBqAZyCyr2DMuCiChSuest7dXarvZ2q6a/cav/oo98eRjNtTXb7/y3hslmQd8rqGSSbuGdPpIFyzN0xBLSfRWKiG1gQmOppJA7I/+B0gnV1WwqZl5WxCAe7p77NjxaXv4iafsu498zx547HF7ctchO3T0hM0uLMoKV26CMdJ3KmQiGzzm/eFPlXf6AdgAMmF4V9NYgHZSkB7lPYEATSOqN1QGTbYUbNK6q+N21bl1+8Wf32CXXVCybpXdl+CWFKbcZ0fmh+wLd8za5+6ctGePLx4sVxd/7cg9n/xSVrzv++UHA+hGo/CeL89/SCLg3xZLpa56NXYMYb4SxCWVi9MH7duf+5gde3KHnpEgSyCASy+U7tyoVe2cwS5761veYrfeda+97sJ19i9/+5/J6mBWaWuzzq5Ol6hRM0sMA7AJSA8/8rAdPXLEuru77ejRo3bppZe45FX5ItrJ12ymMInH7DUkswQWJD0nZ2ftiWf22fY7v2Of//rt9vSeg86fPGg9psCJ9MXFOwesaHDlVy6nAWgKlf6iN3t4NdTUVetvvV20NLlSP2xrRybtba8csLe9dr2tG5jR7HhV4/M2q4svc/V1tuOpsn32zv129wP7babaI6NUB6vK57RM9Q+72nv+/Q9iodP3XeW47tadHS9/vPO/lcvtv6fKrDSkM4cTe9XFwnhJjFLVju58zCYO7lHXDXTSv2aFORIi5plclyBJo+hQb/Cb732H3fDG6+ypXTvtfW97k11w3mbr7OiwtkrF8UUMjyUAzApkC4tzVl9kRk3NT3blHQ8+aH/6px/1dzfffLM9/vhjLsVGR9dYe3tnxF6eSXod/U8yEWARLEOlbpGmHW1SRUYH7OUvu8yuuPJltlCt2+5n99qcpLlvTEm5AsX5qJ4OIGZXjo5Z8J/nf3kORENymUYntYJ+CptIoTZnXY29dvW2Wftn79xiP/fqQWvrOKEGPqVgJZtrX2MHptfb52+r2p9/erft2DUh86NMlW7OExV2SpRKr6/W5tdPnz96s+3a9dw7JFry9HwfVyrn86W5avzr/qLRMTw6/9/LHe2/VlcXCtMZ04dLgE4g0iSt7fjcX9nu+78pC0KEeL5XdFFVoHqAumRdvT5jv/i6q+3f/csPWXdPl+3ef8A2b1wrIMnElbmZ6Rl77NFHbfttt9kxSd+pqQmpB/OSxj2SeiVrQ1rNzdlXv3qzKrMuALe7ZF8zMmJXXnml/dzP3WCXX3GFdXR2e9d/stT20aJSoyqWJHpSq/ARyDNJPza7aJ/8wlfsI3//adu154h02HZriDk0A7eGiJ9I3WgW3kZoKfofVgwHv/wI72BW3LrUi5LUj676uK3pO2bv/Jl19rOvGbW+DjWcBenzUknq1mPzhXX2zWcr9oWvHrbvPjRh85Lsoa6o6GpUyi1p6QF7daNe/bPO9mP/fNf27d+3JamU+fviPiAwTwLm9vZfqy1KKovxuDyg4bw6Rzc1dRcmbcdNHxOg7xBwCJ7Ch4Q+20w7nQbpz9vVV15sf/S7/8K2nnuO0lVzoivI4HD82GG74/Zv2jdv/5Yk8Pdszz5Jxvl5q1Q0cFSG0JnRQefmZv2+ImleU2/DQAvJznO1WrXztmyxn7r2Wnvve95nW7ZecHK2A328Wak2mu9BTFHdft0+e9u37D/96d/ak1JHyuiySGh06BygXULLHwmNa52JTIBO5cXyUtZCpgvW7rEPvn+rvWxDt3Vqc0RVPRh8WWgbsj1ja+2Wuyfsi3fJJHmiy9QENHs4LcoIIP1r5tOTSw1MPYA2WfxZd3uvQP2X3xdQZxvnUiZerL8fkJoxNbf4x+XKcjBnRc+SXZLUcAcz2eyM1u5mlfx8gUwiDGaGBzusX9Ly/A1r7bd/89ft3I3rXB8vSgrd+vVvSAc+LAk8a9/4xjfsO/fdZ3PTUi+kWqBPt5WLytOsS+U2JLFA29k/KCCjc0rvV77LWBN0xdRYkgTbtWuX7dbvgQd22Fukp//sm26wGdEY6O+3/oF+BwOAPMm1AET2NxVAEzpqdG//6dfaiekF+8OPfsyOHBz3BuYSWkTgE9S0k91J+gAu83eP7N6tH0rDZw31UBTdi7ZttMu2jlhxUgvtJFgWy502VVxvd+1o2Ge+8bQ98My4YvcJwiq7IN2oqxGrrJgbV3SyWGkg+2vTi1MNLWX44PcD1C86oF0yzyCZK8sk8xIDckCWJ2oHxoS56Wk7fvyY65LI7Xz9pipLFJa/WaK60h3LTS/eeq69/8a32BUv2WKbNelxy81ftbWjo7Zv/z77yEf+xA4ePiiA12xybDzTMZW68jPveivqSsEWJXnL0m9rAnpVvQ07rVE9sBov6hlJXc1MdzouQWUo2qNSW55++mm75ZavWW9Pj61bt97eeP31ds45G627q0sr4jqtq0dqSdNlIKEvd0faSNpFganN3v3G19qBQ8ftI5qgUXacQ8RwQAPqDGSsoMOFhSN6OvwSECWeZWOuLrTZvt01O36i10Z7pUY1Ou3ZsR77+1v3263fOmBj850aDPapR9VsYW3aKhLr6NQN6d+RQ2iGY0LHHaAuln59enGyIFC/6JL6BdNOoyD563I1Q7qiJIw7r6RUYsAajqHJotYbdNfn7cgjd9szD95jFTEMgEdFRIW5GAqmBYEVrj5BgMTXO8xt119+vl1z8VY7R1PQE2Mn7N/8239jN99yi33ta7doAdFBm5mdtnn1DoB2cmpS64OT2W1eNj1Wz1UBsX7zc/OuashK48BekDqCTt2hwWRd4ZSaN4hKpc0BP60GOj09qR7gmO3avVvgftIeeeQhNdqjzpfD6hmYEh8eHnSJ63qzl48/WUEdnExWF6xTuvNLt2y2ualx+97jT1ut2EZbU37ThIzPcJKLLKpuV3CiRACJ95LiHz2xqAatnrG93x7cWbO/+cwuu+3BMZvXNgHWniSdmx5IOaLD8PwgoZ1EMy2e9b9ZZ/QShULpqoXq3PrRra+6eWzXAy/aQPFFA/SrP9nobB8OnRkwA9wMvAKYK110zcvYXNAAUK3+2B578Bv/aPMTRzW4UAWpOw8HsOMXfiGN4nnpCiOVhvRBZhzP14DvTa+43O7a/g3buGGD3X///faVr3zZJicnHcgSP65+eKakgjDL5nZlVdysdGVaFpYD9GYk8awGg0jpsmYT2wTcBdmjyVu3JG1J4K5pFwiWFIpOGOIQF3Vqcnrcpmem1DPstT1799iYGhfWkj37nrVBrQehYaSVeYlDjh0VDDC7E83uzja76MKt9uyBo/b4Uzvd4hINnzAOrCxi+J/EK+pCAQFrrVix3QfnpGIctLu/d8wOjQke2hDgAzwaaEYUe4g70U7NJwNwVCZX/UTZc5vS1lOxdNX84uzw7K+/98u2fTuvX3D34gH6l/+P3y91df9OTVt+AsfNG5iYueABjwxgOuYn7Im7v2p7Hv6OFsGou1qKLKan0DCoKakVL/wTScC/RLWhZafdWlTz9ut/yj74gffa3qeesNu232ZPPvmEeLrdB3rovyXpkEg3Bl3ulEUWIQFKBoGYuABkh1SDHqkMAGBRUnteZryapDn6dEWgrQJiSWgmSdoFynnFWZhfENiJC0gTsGdmZ2weqa6GM6EGtU+Dzv0HDtiOHQ/aEzL7sey0Vw2jt7cvV5qUNf+bFbFXdvJzNm60hx562A4cGxMP02Q5ao6DPwuX51eOSvOW96zNq6nRLmhpqUSAGrSAG6wM3nvvo2jiT17dIxgNyF0uTcI160f1Jj6+suvpQxMzex69Kwv9gl5eFEDfcWD6zeNz0//9xNR8qa59at4/KduAk7K61PTnVBb80fE0Jrad990mQN+iFWuTelZopKLeNZni8Zee8/5NSaB4+GuJo0xPRfvf3vcO+81ffoftfPg++8TH/94O7j/kkvHI0SMuMZGgVU3uzM7PycYs/VcARTdG+rIQ31fXCbCAZUYABpRdnZ0O0E7ZmZG+qBzM9gHsRUlgBplDgwOy0ara1WCwX5OnsnogbyB6P6/0aCTd3doGJQCisjA589BDD9n+fQfssFSQbRde5H6JUyv/XauZzHmtr/729x4TPe0ZdDDD7xzIVo7a9EXG+PSKBp8IFl+Fp+1YYdoDvKgOIemXAVVUlqXFQzjRXeb0TrVzbfe5Fz8oUL/gK/VecEA3GrOvX9vT+Vejo90Dh8enbWJWTBFj0rrbDNAwj+asKzbQzjbpybNH7eG7vmJP3P5lK80KzBQcUOaZI87gxy9c3FMhSEavGCEUW3FFwX7nV2+0X3nbDfadu75lH/kff2LP7tlrRVkrcOjJswIiriCgIZ2xOzMAZAF+UbZUTHBIZSoZSQw456VqtMmKgBRt12AQELe3ySasCkdKC09qEFUHa39vv8epSkIvOl1tXJVUJW5ne5fnU2eIeIOYVdo0bt7NSEdHapeVzrYLtmrQKfNc3mUsYH2+2pmNaID70KOP2DOaTURvD+C18i9PIn+fwgVvqSDdo1o4r/VMr0gE3ebBHPzPp0O45i+rr6g3p1GQwm6Fn+4655LvzOx9ZDdkXyj3ggJaTDxX/dQ/au3FpgHNV09Nn7Bbvr7d2jWAaW+XvVKMLov7ZdU4Epkp7fLsYTv+zAP23e1fsF0P3GVt87LrOhMBHYBO6sVqBQ6GwkFf4ilQsXC9UF+wl249z/4XLSb67t3fsr/+67+xPXv2eWNYkKowJ+nIhAhqxuzsnPLX4cBksJcks9QNSWgAjM3ZrRjeaJJKAriRYhGWBtquowHIM9knX/NSNVBVumTF4HlWagaDQ8JVNMOIdQSp3Nvb4z0DtGgsWD28Z5B0f/rpZ6TidNvFF10sGqkhOi+UhiMLJMm7S4udJqbn7c7vPORqT/AlDzSPt8ofGoCzXWhFwrs6gXTgTu+igUT0oB/X8D+9q+gWS70yc15X2XTRTXN7HsUe+IK4FwzQKjBzvH8krrxO0HJ14VP/cJN9/pOftENPPW5Hdz1j8yeOWvXYbps5+ISd2CWd77Hv2NP3fsOe+PbtNnVwr1ZwYf10SHjhnFlecQkgPLf+ggvOcFUEtt+CJk56y3V72/Wvtaqk/cf/5q/s4MEDCqrRvMCp+pH0nHcJOjU9pYGbrCCyJSNlUQlQdZDIDXRoSVrUD9Y70yixcKAm0DABJPczspfTmJLNFxAkF+87pZ6gZvT29HoDQT3hvl2mPxpWv2zSqDmoLOSHxoV8RFJP6/nAvv0a/F1oI2tGkvbmQCMNgEF6hNYKuLZeu/P+h7XA6YQPXgmBP7/nAnYerPDXwUzkzHk96D7P+9Z38XzaVxpQqTxQbDS2brh082eOP/UUpqHn7V4wQH/4wx/+z8rNb7hRUkx59uiY/Yc//nM7Pj5hDS3DnDq+347tecz2P/5d2//Yg3Zk16M2vu8pmz6u87sBjCslqhgBEvkQ0gKrwopM9kqkIjPES/eLOGuH+uxNr32l/cLPvNbuu+dOu/eee5LJTQM2HGpBquY0CASUDNAAVKfUC4BCF18kL0ofqwSTJ1gdaBCAf3F+0e9Z88ECpvm5GdeTkawpHwBAZjSpLqFbU7aerh6fPocGkpnGRPoD0rePnzgutUSr6hRxXvRJm7xihRkXHzeec45APer5y2AKp/yH7O7s6rZHtTrvkceeEB/Rfymm7MSRIT22ujyYeRfgXQqXGgzPcZdx3IOcHB5vTzhdiURMj5SPibesUMXStrn5Unnm19576wth+XhBAC2mvFnZ+0P9NG+NUle0z3zlDvu7L35ZaoZWbyHNNAgqSbIkkGQwpPIVKQYxrjfLJzHJOQGHFSIxGv/45Xmmpq4ASNmGtRcW7Vfe+Ra77urL7NH77rInn3hc9uXDPrDzgZ7yx5Q1XX1RuivSCMAhjdFxkaRuhtMVtYDUGQzCfHRrxLurJ9LDq5pAQX/u6Gh3NUGnTNu01jKjOkAnVA7UK1QJZvkAEIPAsbExt6AMa9PA8ePHbXBwyOak+qAGVSS5F9Ht6bHQyRX/4MGDNiVgX6GFSqQHQpbAzL0aqnS4fUeO2d33P6idMKgO2NBbQKRweZd4ndQ18hbPXFmTUdWRYSWNgXTopW9OaFOd0Xh80CjSRYl+0lYH5b2AFD5/q0qXp3ishUuFgsyZmrzxz85Qh/kMeDUXXtP71OH7pvc+8kT+1dncP29AiwkXKuHP6Ke9SHKSQmNTi/ZfPvLX9qwqocBeNqQnBVVhqAiceJe59Awb3PpBgf0B5hIEhilwM3yKhn0X4KjeVO86cEZ6c6cq9C1vuMbOWz9oO+79lj3wnXs0CNwjyanNrEoQMxvgRSJSeT7QUiJYMZCGsBp/dPikUkjfF2CxjbteqfxglnMrhsqJ9GRanKwBnjbpxujLpAGg3Vqi8O0CII0JywjSHtWFBgWoWeSEejMj+3S/1l9jDWEmkTz6lLvCJnWm4UtT161ba5u3bFHvoIX1pKs8JwfQCnZkctq2332fTWkskN7E+yzYChfAS/n4hcOP2Xb4z/igVNcEkW+3kT1evEat5CeVQT+pW0I0NeUjDJKEr/pXK6ocjFxJA6uJA17v846uq1B4dWXThc9bn35egFbld6kA/0n5f03kD6nxtbt32F/87U2yarLQCJBkb3XjEkB+FJ77+KWKyd4ntngkolKhaYIiDU4Anf80vwoDS5pmbtfs4sWbR+36a66wXY/tsLvu2G4nTkgKCqwzknwuhb0RiJYagA8I1e17TqAn4CFJ2zVw7ZS6AcgcCorToXUb7QI26x1QOVCDaGGub6OCCHz0PNibaRiAGZMh9/zgCT1AWYNjGgdrVAAy+RiTKjE0OGjTGjA6iBSvTfFpUOMnTig+vQO9hCS+Jm6Oye9lV15lAwND8oZyAmy6CtATM3bz7XdL1dOxX0xKORdP/ccbtMqP8zpKd0qb5byaAZVluqt2zDYNzVtf+6x1lbX4v6x1LXX1UvVp6yjNCqo6akINu1HjXpaihRk1BHXbhS7lQw1Q76j3SIM6dCcei7mDOvNm68Do+f84eeAJrR47O/d813K8Q1X7y85xT79gx6UD/t3nvmST81qPJZOWn5AvPgFImM6ULAVJrDt1pgkbEmqJ0SkeAoVPSSAhuip1u3zbOfbId+7wTarTk+Np0kSVgR6bBmwuKLzCUCfQd9GNuzu7NMWutb7q7t2+LAAzpU0ekcLou6TNIE3r21WBkjj6Ib1pBFgvPLDyCrhRUUqKB0hYLw2Iw+RHb6JllTY1Maa0OjzNaS1JbVe4GVlAopLJBzR9hlLXTi2oonfY+cwzWuh0v527aXPWsJbzsEs6vS9/BSuMBCnEWTrhz+UpQ/xS8ai99boOe9cbN2ndx6yPOao1Zk3LKj/29AWZaPUTg+ak/zNxtDjfsMmJDnvwyQnbP6MVeiqjH2zT0szENg02xONi6S3Vtrbf0hPq61m5swa0GI+qkSVMBUu/LHbZrfc+and852Er0h0r46lV6lUwFpPaCln13cm8gYu6en1gOcjCtoIZb+gwNV6sz9mmjWvswm2b7I5bHrb92nHNzBw25pLWhnhDIi8oegITRGlYrN+FCLptZ1+vdUk1gCaCCn2fe6QooPUGgSRRI5CdBALekKDdrT2QmCBLmdmOsiKXAXRZkrVNvGgrq0JlMYEoa5iZyMEi063B4LRW32liToPjlNbszLSVNGBkrfGUdPIYiM7Jtl5Q3Pu+e7+95jWvtdHmAFFxPbcCvgDNNDxZjLUWvD2VQ+C0umRAkZVHOjDb1K66dJ0WdM1YbV4NGP6Jt+qCdcUqIygV1ehU8ip6dX1Q5NRr1Xvszocb9t8+vccOTZACvduSowFHIxazFaX4uzqM89aj3/qH7yyFOv27swK0MqD9+vb7+q2HDVSeyVaOVP74p78ge+iMBjZ0VdQeBU+Qyh69ACsBVEVzFYHsx/tmYZWEO5EMh6SraI3GG697tV19xVbrahdb1V1PTE27bk042Add1AM1OwlWdEXeyDkzNdgT8FlPXFHc6HqhjdrQ0C4RQIy6oTGfteuaAE/5yKdTEqDRuyXFmYSRX7toobaguEAX8FakN+MoWwjPeYH0xETZjk7SPUt6M4MoPRt7NTmnF1E2vbeZUdj+4SE7pLHJnmefzQDtJJt/KBtpJp1YKpnUsbN1aec34xPMi312/44pu2bbeZpUYlocXVq9LkJBV8I2GE8gCMiDvDVNbL3Soa+9YrPd8eSCfeXWgypf6nlWypMLjUJ5pF5tfNjsw7+g38mtbKWIOb+zArTiv10/qRrhkFlFu+nWO+zb9z/gEkUeqrklYLJSDXAGUImZv+fZdWXpmowRWsM6sKEnJGjlljOxJKBsWddlL7tok5Vlx3360Wfs6OFjNj2h7UICMKh2A4jikR8u7g/49GOiArBjqRCUHbi1kODqX+QjEEvlkJ6ItOpolw6s8D1SFboklbulFrBOGldCuugdC3lIhw212JnbfJUarzSLiBojf2YgvYwiOilp3NHGdHjJjo5P2ZRAUZUuzhoSZhfbRINGxgCYhjEroD/1xFN2YP9+a1xJb5caiZdOGSbNHu2+cRFCHTwPl3a5qDRavlCVwPrS3UdsanGvXXihjubtarPutoYN0LuJLyWtl+EU044O2evhp9Suouqck6MmtIZ6VksZrNStcpOh5RkDB4EFBInGDTesueZ77zpyt33yTLN/xoAWsNYpkX+zPKGi7M7j9ucf/6xNZ/bTyODycMufADDOwasqiOfloWjt4oL+Q5PBVfBjrc6Pu+7abTbUK6l85ITtfPJp6abTLqXdEqHwyaUG4tJSzMbFWW4AjunrmqSi+wtsQJIF+q6WiEQHAJY60iWLw2hPmw1KHegVaFikxDQzGfLd6qon1Bof8esKuCq+0F4NiwZC/j20eiIBFitAj9aadOl8DyZfMG0WZpjF1IImNUYsOO0CBmqP501/TmhQuCDV5bBMkfQgCSB6kRW1x/Mps573Pkv+xD8bV8vGKBob2olGjzbFTlhJO1dKMlv64FWZbFdvDBvKAnVFyxjQ/xlHUPZBjU/G58ft27tOWJXdPrWok6XcUP+UhTIk3LDOsfAH+hDq7Ue+/amDSyFPfXfGgBbJf6Xf1iCNyssJ2R/565vsocee8UpxAEaA07mKBpWL1ArnElkP0TBc4vBSQKPsmsKz9gVNI2sQ9pB2loxppdmhQwdsfExnHotBSNx0LkaS/OQTm25UBN1hQZURZ2cwiAPYrLpz8Al6JENZ2vQb0jEHG7Xpdf1Qp/UJ4KgVNBBCqbcF0xRCV0lgVSaSk0pttimZrFynlQcjg7oAwXYt1JgOAblXaXdo8UnjkPbw6Sy6Y5Pozm06rEZE1dgKMgXCCwZg2jTv1hGSS41EechY1yZlfrAf1YnDLdWf+DhBIQELf87A0RP6eEHKmsfE4lHq82LWBUx9CCB9JGwh8ayhb7okNYUFUoyr5tTQp5SwNtpJ92cJTdRrPhvQxh9+cu/NvlDcqqMUwNo/z4c91f0ZAVqJMhB8f54ojPzKbffaJ/7hc67/llwi5UMs3Qc4l3yyO9HIM5tw8QsGOLwAjUsePdEFY3uWaNh97IQdPqjTPTO1hq4ZxlLZCpYkmdKgvXASEofEVATmoqQ9IGatBNYBNrnWAY82FWCBQGIyHQ6g1w4M2Eh/n3Rj9ZxIbypZ+fH1FS5hdC9/SuKlycqQSoif6tcvAl8uTDp7TtKsXSBXBsc1n8KEzIwsLosq29i0NqNqehzSNBSsCf19Aw6ANEEkwspHpIyevm7dGoVlLXbS3ZVj3RPiLB0F9TyTh1QWKFE3VHfTgkRPSlcqR/0VxUfKykjCU1d4Pycke+8BU2CFT3HCL+nTxfePXP3Ovzx67+kPEE8b0Mo8R83RYvpJlMKQ6W8/tc/+60f/xsY0qClrKSWSFikVjjA4rhGHa1O9WOJVREmMolULcB7HGZXIwi4o9sgq8frrXqfF8LIRy8zGsk7su0hcVqjNaSSu05gkFQQZ+TG5waL7TgGnXwvje2RC6hBABrTeuE/rKhjQcaQCu1raJE16dBAjqoZPdyuPnaLTpjBIfg58cTmL9FRZvDyee0mojC9R7mahuKGs7qLQqmqpwNCkwfZq6nrjiAAtME9rYMtgFVVnVoNBloVKVHv5mDHcqUVL07pSdud3xnK1QZn0NqrhttnMPDCKtFLKZ/p3xXJkRPJ1uhpdyqXRkwOb++eil6eBSqgVkP1SxP+1vfvdb7dPfSrpXflAK9yfNqDFy9eL8++EhrNIAOVEn3/3nz9ij+3cb2XpSklaAelUc62ZX/acgniWXGJlFQIgWl348cq7JaXdqfSGhtdIh53XtqURbX49ZHu1fYrFQ9iWMXUxRe3T1pLcSNx+AbdTkwGDWpnWJ2tEX1unjuTqdsADUCQZEq5D5rc26QJF3WMtAL5IaRqGCuk/H8AK4FwbjBj5D7izfygduGVny2VlROBh98ZhRPFjbRVXRhqpM+22ZqDHxicmbUq23IWCGqIaJoDG4oHDln0gM026R/aHtzT4DdqvSK8zN49dG+lN2V48F/WzrH5XSS7CrvJ6mXcymZZ+dt2ztddJkb512ctVHk4L0MqEzHT1/yB2dfo0scTAM0en7f/6j/+f3XH/91wS+gBFiaAnUm/UsVdyVCJAyJwXHM7LOQjE9ab+JCAy5es1offBJMJxj/Cn4YxLOv3D1263N1xyvk0cGrMFrUpb1EzagrpnQNzepZ3JGvAhsZDSg/0dNtrXbuf2DOgsOWy1WhIqSVuWnkheU66ZDmcNB3BUdyqwysghqSj9T/jj9E3Ps4NWIPFHJSCAkX/gBIDCeX5zYALIrvNKAU+dmDRtqT6cDY1eTOPoVN67JV37NODs0XLQmRnZgOGH007rTqCL1WMhOz7NdR9yDB/1blSzkD1q8EdNpj/4ns9UZO4UV2idjotwnrb4nHeNjLfup3dJ60mNK+K5NpNFwqri/NE1JuK0HKRNvPkdSenbT0dKnxagld5bxJkryQp20h3PHrQ/+C8ftdvueVDdeFrg4/UpHlCtp8eKrBS6UEHpH9jA/JO6btiTTEeJKNIPxziHKfWdew/Yopakbh3UoiANlmS/dMncJnWCAZdCiUFSTyT1Rvp0lnNvu9SNduthKlvAxU4criSigNhnCBWH9RzN6W8oifM0pJRXGmAa1DUHwEhqxUuWkQQuDwsw5B88SX7kDJd8KTsV6XZs9QxMvWMp6GQ3uABfk+rRJksIy1RxAJ8lqKzMyzto44YHBjU1riWpu/YrvwzrsnSy9/k4L8R9gPO5aEUenissPAhHD4vLTIdvGjnQeK22E293z+f4s1SjqwRq7NypT87Ye6mVCdXCP9x6n33wd/9vu/Wbd7lEoFIikz7oUaa80rLM8e65fs1ks3A8Oz26V/0Qiv6TP3STpYB36kgVZ7/WQszKRtrTO6JuXIv0BWb8AaRPiWtovaa304a6OySZk4mOyZcAIjS9dxAvATOM5MeUNzo3kpGwSH0Gie4c2FgxEh3ex0QG4YhPGnEPYJUlz1crL5LUpgGlPDMBg+2ZnoK1H1hlmBRyXigdwMyip+My3x3VFrKVHBsEOJoBe3c0GsI5X1eK0OKXz2PLqxUfvb71JuLlA4EJfv4ua1i8p9yp7KkxB5ih1RRiTsiFTJsExYckpRPK8wm03J9aQp+36Q0LdXvzo88esI9+/PP2j1+8RbqZtjdJ/yRhMkqF8T/vvBCZhxcm0/8wzTkwqWE57nGEwcVzPj4hODiFoIRDujHQ4F9N0qwuXXm4a4PMdocFDM6YYOkljNJSzY6yTG6dNtjTbr0aYLUJcKQBzUjLsy+QOjABp36KTABJTd1mfh5ezw5QvSfLAAxJ7rnXH/IUdL3c0KFRqL8lfLwjZDgGsik/WhGIZUD5xsbb4eqPKrhN08kLoiweBp8YGC4BGlpQSFQ7VOYNWpUnsrSDeOXvX6w/qX9bnbrzIupYwQLA+RjwJrhC+OBVWslXPC0p/ZyAFtHyR//x1l996IlnOm7+2m12xHdCSCq5FBSfBBp+OCrWQaB7vJLUo9KzjIm5eReZDb8YPEWBvAWD4KZLQM6SS4VVbV227WJ76cWb7Kn7b9MpRhVbGEtdP5whyeHOsn6aDFED7NA2ffLlu1pEO5jKle4esxjg5Ugwn+SgHKJDXhmQCZa6TwVJa0Hkp2e+ZQKoOcODZxoc78mAl1OF4TFf5hg01rIyInp4TyfQrp6B2cN+AZqj0KcUtyY1aVqzioCdvLGu48CBdCgO+VeQphP+bYPMjCWFq0kyZEk035/qJp/PCEs94uJdTEwFD2lP1BlONZBucn89vGhAh7cILFwzvu6bafib7Jmyuc1SRvla/UN23XV32PbtmHxWdM8J6Evf/J5tExOLN0xqPXFZAyxMWN7iRcor1jlF9elZv2ZXQSayDEfZghEe+DT+RIGXgooN+p+nA/j279lr4/uf1tLRPutp22CHjxxSFy3oKX26cbb598jGzGo2JCGAQxWA7UsugRk1w+tNkSkaaVEm7rPxoEfBX2S85YZ9Vz5qDKnQwAs+UXHuCO8RwiNdqaiYTPKGo2ypSem0T+0qn6tYH9YYGb7Z8FtTI2MgS14YXbG46dlnd6mhaRKDNec5h6bU1SFLjWzsC1pfk2onF+AHeJuvv1WzoULCu3xYX1hWKL5peGHtlcfMvr1a3OcE9JGx6gcbjVIfh60EcSrORY+uyS9VIgk4s3X1zERthicBXgQ3qRm1rn42nWqCRVv/2YWCFEZOYino0wwftlomfFAMyI4MewJOYpoP/rKyuBTOQEkhQmJ4gRQGF3xIPCAQcGGaRbSzMEx4RFyECyHiOQ9s7mlaOE2yeRhSQc1hYzF6NBtqOwTKOTUs1kf4ZgOBm8Nz9u3dI5u1NhNowEj7wgXbBySh0eO10im9OIO/5HUpv/n6TffNd6LZFGK65y38wRIWDTWSjXci7HlsCogl8p4m+Yc+dFx65/CjdehquY13KciqgA4+RLrN68hrb1yvh7eFYIlCECDtLGkGfdFu8mmulIjbZQXAXs2cHTx0xCZku13qOdjq1KkFRLIzywyW9GAaYWJ6nl5iIiDMgJhVaKRPFYQeHfGQ9KRF988gEDCjdkWcCJeuAbP05JWl3sXVG2Wo2Ui8EtPEEGuaOyRle1QGFkLRSFmGCsBpoPSWc7JTu+TKJRbd/uBgnx8R7Cjz917KXMizv82XkXt+OVwmZGfkPazeh2sCNTzyV3iRfz7pXuk07N2jr3rf2pNeZR6rArpULVxXLLStFdtd9ngXKj2CDPHDWM+eMyQTv7yKAPNxVHq4KHj+Oe7z4Rwoiu+MUACfMUJ/FU/yP/yhjvH9kBbLT7Hynq4X3kkqsjWoW6pGpSzprEPU/QURMtHQ8E8CIz4pCSVIkkEXpa78UyD/KYqLT8rkBPzqKpUaE7bWBiqMyiojoegAdOSu7kU0lVuPUBXf0l5GvRO5/M8tEvBWQEcSsxqwUzR9JZ6SrUgqs9gJc57TEbjHx8c1Q8oy01QOLyMFkRvQvsXuNk3usqdPftqf7j8Pk4Ks+jfqOK4RMOoQf887vVn8FIhxECzjfTiaOnhAkud/+XgRlljEDb066iSw4IPDYmlLoVL/XyNO65UaOsltePlbNZFS+JDaXtEPJ9TKMF8NpZBBnEj5+5OInMIjX+jUCaUI+ftTkPDXSMUTkswHtGy0vaNb1oG0i4RlnX4WiDjvg1cPnWo7nzbe/iyGUx6kPj/u4znunUTuT4adNBGU+RNWFH2QiJrD0lR02fSTpBVgSa/1F2R5zyIqgIvu7ztQtMqPyR4kNKvyWF8C3RPak3jk8CEqIqKTtLtuzYR2onII6xwOsagB8aIadlr0vxT8hbgLIAatVv6G/+lcgy8O6ny58pEbjRvt5b+Zlk3m/XW/IqCrneULROtCplhhFl0qjMYxYUGlrZTpyAzhXBBi+VDYCM/7PDjiPrpqnv0+yTnXc/M0oethFG7JMWsm/VI6tJ8DJ+kIkPq01gOn1JtB0wAOn1hYpPyoXEibcEntQOIloLeWE0bjh7SJ/PtVfl4JflX5AaYAlY4+4PgD1jVjepQujwRXoswOhvMFk5lkh067g7rD11x3CZwAGukuQa3GwZpjgVQr8Pbs3kVGRY/lqFr8k5FkGemwpvs7dPRtp0yZdS2NoydZSjHxclkZMr62+uWfY31N+Dl/lH7K/+oNNcqZv0IDPuZ57HzNB8rdi7r3yIpw2Uhl/LLcq+btyoPCaumXxP1ePqhDYnkm8ExGlvs26TVvQgXJeNT0b8bP6PDC6ek57rny5EzT1Qdreo8VAXg2GeHh5IMUBjySXHT9rJojHe/iiAHtKIQrmQrj3qmR5svi5XUaKQLPPnsogHqelCYu5UMg0QAoHOGQh65CkaTikldC8xfHY9zzvNqZGVhkOmVuXFPQeR3qgTolpWcZbEVBRIjGf1CrDEmTAkI3coOF5C0/8zq79qqLTPv07Fs7HrG7HvieLcKroOExUI0SqJb8RWgV1zrYywcj/lJJ82/QTKIClvxp9OQZIRnvE78S75ZCpjsEki+xKJU7Clb9Ofne3xqGGljm1l7+K92FcvUPGqXCOs+cg8Frh1RShpsVlaJ6xZFfD8vV/y+jm3+ITIefg0jdvOt6ouGkIKN7Cs1z+gMgEhxgQPbGw9RkxlqUBCrpgz5aM6/VZjpiS4OpfpntWLGGhqtVIimLAgvxPV2R5t4nN9xPVKGdvY+rh5VfMyu6995KGfOZRwaHNCrygCSluyfv8qeb993vShfAzQuYnKPHp9p8sYhoIKwJh6iIwmLbpnekEqd1PEFVU/szsm7MaQ04GwQozPlbt9qrrrnGGx38SP84UqFsl12y1a65+gp71VWX2lVXXmqHDuy1x3fuUbRU7ZSJtJplIw/ib/CYsuJan5vh9S7ufezj9JbTIIWTHOWUcOIYNm8gBEIXJz73unJxl9FMeV3Ki/h1ft+5r/i76T07GEQ03ckSumvmUvXgl7DeOKPVDMxNK+F4XhZID1SQu0wcBVOCAfnnLGTz4lFgLD6oLcoI4aN7AmThUtEbquSa7zoeUiQaAaeI8mMRj3MnywfxUnQaS2owgJmtVvjn80U69DRMxMBwypSms5NkdxCKXhwGQ0IMohnY+ZhDaaIGuFXI86+vrs5oql7LQzlawY/TVVhWxnH4TFn2upR+yizx2MDLF2yPHp+wKX1HuTgn+p5wEgAMDOnBQjKlJuOlpD0lHurxfK2R/sD73mP36mzE/Yd07rbKm1yS6fXoUjPfuAQ/4nnV+vamKAZljnjpKfub1RnxKV1ekq9GM2jlr44fPArFTVacv1x3X8u/j1Ll/Arv0AxTxffWLbWT5vvWxPPPUfi8HxG9cFmB8mG49x/SOVKQXypxxuhUt96SoRtgdqZwYCImMxft2mWuivZTQCX52Gg6ryWXDGq9IQiQPjhUQkgTpBnA9x5Az75uI8sP5jiy63Zi4rlpTrqvroCVOOQbnLNJFGkMQNg3KeraPqWVcFovMKnFRA5cNTa6S/IzNjPps3z+rRbpwazdbtOKup7Oaen9ArZ6FWzj3l0hwVRQlrOODA/bsSmtJNQGZNKV0PGF/5OT2gCgiRcGwcFbWAkJOBjTKgD+kgsusEsvuVSfZb6NIO7gqbNcf1rrjQCtfqs9U76cXPV45AfesxbF65k0UrJNQOfznL1advG6y/lE+prV1Ye7atfq1eqAxrqhvc7Xp0STVAwCOZrNWzLzXO+bAZ/jxgtEghlwCUrrpSJx0PepzyYrwo9QqUFkAYmlSmQKWqY4gZqDX9KqO6fo75GtzMYl+7GkskdW5QuEnLPhNmUAzT9lAjWgIBUCqwLAJj8AWsSE3aQOyFM9QVIj6BUO6jiuaX1saI/020Nz0/qWt5a3aoID4HF8GAM6TkcaGRr2DQfz0pHpifq0gGrT6LAN6wR/4dzLzbkj5HFQEyW9x/XdFx2eQ4/C1iwG7RwfVtfgEPgmQKmxeQwKJkDpHjBT7l5tZt229Xz72m3fdBATLM9nYpy1Ez8ANXq950O0Q11DqKA+haM2cKlul+7jfXrpIfSHZrkci4E5ibI3y9rx7+2+jzaXHS6T0IX2jm0iv9WV7yzR1hYUxJR7+OEtj6Sz4J7JxC33zcy+CpnyTTR3vhYi3Xkr5ta7eDUSB4wipAYjfwEHR9qRvqet59Sly1905+YWbZyF/LrngJs5bVfy4wj0DNABIGmgv5F77JpIAPLGOSLOOIUryxLBAnzCFtn0lwGZPCDb+Ud8JCVfpQdUUwLwvCTxpHZlH9MHh2Z06MqMPnl8bHxMS1t1FBkDOgHRN5Aqnn+WQtK1UtFXtJQPPz5MkuyotpOxwm6gX0eEaXCbLCGyqctcx4E4/nkIAYedNZwrd1Q68b2f/YLGCxXrHRmwC1/xeivpsMr0nk22ZBKnYxRUngvWDbsJcY4vK4hpmON516wgHnMu+B1erc/hH9fovXiGNJSbOVD6YoLXlR9ARKB4yX3eKRxV4wPsnH+kn6bCC5ePdI1fpmWlzcHhMkBLOr9FYkjcoKNShp5DAvs75ea5wuTy4be0XvQ9CkHGHFx6Q5mcr7rih8vURH9HWLwpYLjkF62el8qLAKNqFkgZ5GV5I48ZPQ4crEtSaNegb5Al7zRenISXDnoRUDiXTsdYdQjUGLk4gLGgjadptjHlm0U/LMrnwHSO5Z3TOXIcFgNIsA1TRvJXku1ytKPLNvQO+icqeqVSdHSl8gHiqhqAtDtfvciZdujn+EOrU8cBdGpgl+Ve77SRlml8qRY1GqoaSEUbb4tjE/btz3/BNq8bsvahXpufWrBLr3+DVbS1DJ6k1CghXCjYBoG+UzOQs2r82l0gv9SQ03vCnZ2jvHmX5i1CKC29g+f8TuVc0BBIQVtpp7i8KHZos/Ob9LwioAuqoyuh4P9UKZ6wMNNKEGCSEIeKwKS8a81sPu90ywSHzcQi0xG+NQ26fv33tEmPcISJcDzHYiBykcY0WmapLh+hhGSbl9rBGo+ybMCshMMCof1MDiCXigIkH5dEOs7MHfe4fqyBGsVAp6aOpbtWq5NKR5+20PR6X1+f8qRGo3iwgPxjAwfANe2lYp0yFo9F7ZqpSMr2S8oO9LGepE97H4e0YF+n/EurpeyoMhyZu6iBHptip9s0je1vmNFTvkSLVgagffOtTKiY7tj/6OtS/MsHbbZ+sNfW9esos9q8HX32sCaZjtnApkHb8sqfUiqANRq9buVGdVBNv/JxQj0BGyUYTqoYK9ZD8DquicLp/fWGqDoIFwCN+g7/U11PlbbU0VflaTQl9PCr371BNXM1/YHDDSA7g/PBNRhBHxLSHEziBEA6VSYBHGYmH1TpnmchU0mFeoHHknOaKZR3ia2FSu8VHklJbeA42VL3/tEfSVeWgAIsFxyZzlsQmCfU/R/St0uQggB+Qtu2jmqx/KwGZnx+YlASdVBbmAa6Z2xUhyhqL4ykvXgipRYd2k10gAz5rZaTeITpTvo3pjQ591P6HZp2R6ISbmJ2ygeE3kOJKroxEyXo093aHMt2MG/g6j/qOrA9QUF/VQC0aJaodmoVHpK7Q8BGpejSc58+JNozpCl+mfM0krfSwoTtefQh23LVNcIyx+Jk/NYVaHNITqfKif6dTj3yJERPLzMHv5t8Dc/cNd5x9XvFZVAd8ehlOUIZlw8bPXIO5zmqZ37r6Zu9bPRn3rf28Nf/DoO8N2GnVKjXtikTG9xcJ5/o+v1l7o/bG7NqzPEgF2L5bbTMMMjn4yB50yAsVd9KjSPPEN57SBEJ/0gtQF9QJVbLvdYmiVVscC6xqlGAxvY6qZVpz+zb5+u65zlYULtdxiZ0ILsqoEs71jlckoHkhM6SwKSmT5BpE622QWlmrixp2pAtuFcTFkxjs36aNMkPvGIVHHpdFZVF9xVtOuDtAvq1VItZnQM3qd5jSpaPqvLRrkY3QlOQCAAAQABJREFUKOldadOJpZLIayTNB3WSP6efLlaVXzUIvg3o+jqiVLTa1Zu067xmhA6910hvxV6irVbdamjd6j1QuBZFu35kXF8ukEVEh+GIUZ7H4A8mxu6OHuVV+y11LBrdGe/SuCW4CchTncR16U16B/95l+pBFaLGlGgkP/yj7okLj5qCSM95uoR1OoAjJevvI0xcobPMpTycU5hZvFT+LYAuNDgSF849pyNNXySSheI57/KJk0ny5/nMGERYEgHI6ajdJQoAQEXzgqcqDFVC5VwKJgDKH0J5p/ekxRG+C6p4PiGhr64juJWgNtXKkrD/0CFJY31IUjrvrDagIvk2rd/g+nGvTtbv7dXOdVkhmFJuyOzHF2VnJMFZulSclvSX2Q3LR5+kT4/0YYaGKR9ahD81642BAWxFqopElAaK09KrdU6d+LBHvcCDTz/lEyGHtGO7KH19WJYLghZrC3awq2LnrB22c7V1Cpu0mwIFergF6+h9mBgalM2a3S+8GZFO3SNpPSHabaURSd5OW5zWyZ/6WNOMltX29aQjd7MaSLQAsPKoEqn0lADMi+uomPh64w+g6mWLI6wP1JQnr9+sXvP1ThTexTXexbUJbAVZBjjKmcOJE3jOPzQqme+KNbD7dYI2VQ7ZaF+WZm1UGBFG58RRbD02XV5yo4cSKp+JKEhESFTSU8Ql/ErMIF1SE89RUJ120CEuZSWu54dK0C/SpivneU7XBXX/Pe36EM/8pAY/0ndFcEyWh0mBWbMtko6SaDo0Bp14dGTEddxOzSaif0/paNvZaakjOoAccyH6K8fpTukQ92oFnVy0u2RXFuDTuXbKrwZX/jlkARM9l1pCL69K5ZnSLpOhjZts7daL7Gk1KCT0otQ21JqLLrrIxrTJd+/uJ21xVh+9V2MZkjWDBUkcx8RBi6wBgRHwBMk/IPVkVN8XP37suBYf8QUu2Z81GAWQHNvQ3qVBqs4kmVO6GhaKP8sg489pr2HibNRXntvhF7zPX+F3mOfwd/5TMXJRH35VnvHNT+0HXVZKOi70x+tc8SNu1KcT1J/W5/CPqzeuRuMV8eyA7r/s5weV+uWiGv4nXVsTjMy1Bmz1T0VtDUUPJdlGehlAiUfh3GUMOjlWYtpK/pF3aYaSqNrC1NVnUyf2SUIKWJKs7JKmcfZLEqP/9/cPyDSmgZ6kHDtcOKhmUkfX+texpHYAboyC3Zo6ZzDJDhGmnPns2yJfrWrTZAYr8aXipNpJDY2G1yUb84JAtl/qDSc7DWlN9sDgsF190UvtqZ1P22bZnwe79RF4WSvOGeqybeuutILUGyQvsnNOoGcg6UNC8SVRlp4uQPfJdLdZ+wWn9IllTF/o9f1qmJ0Csx+lqwa1Z2JO32WZsFHPWDA1cW1eg9cFDTgTUOhfBCb+Ug85vufviRn16gYBjyW6OdLxniuqxvJmBIUWpzBZwv6iNf2g15qPFipkjGy8hCUbh3b89bQDuq2rY0TFGXF56+JR0RQQogFx7oN4JEblOQhzjGhNsLVgQQNe+NoFbvSLdPx9VlZoZcuX9V7py5/3dFm4oBX3KV/qmqU/l92iIruwJBVmPD5oWZWqwUyifyNFwEB67NW+vAkBeVqTHse0rnpSqghd+7rBfg0MOzVY1ME0Aky3rBxz+pQxe/n4QCdbnDgdVPLbLRxMjwMqeJi+962jb6Xf9qlhNUTj+JOP2cUjPXbh6OXKrjbDig5nZwyyeN95i7eo6R6GRNlQcVJxBWg1rE7pwP29+lRch6wgUo+efuppnYvXqUmaQfn3Wr8+wtmpL4DNHTqR9LKWCkAN4jBylCVPitRa6i//HHWtYG5LT7OhqhepJklpySqDAHKhN0cdJd/0N+qyKbWzqIGtuEacyEfeFh1m1giT5W9zobd6nvwedkCrc3upmvpQK0GVGt6u6kiwKVVXDbX8RaRBXEhHwSPzy0Of/ER8snWS83xKOmpR0mWb11nP3FGbOZQ+9MP0eI/MXYuyZDB4A9Azkth7dc7yMa2FmBDgntVBj52SisNDI/qM2rO2YeOobTjvXNv/xFOaONGpozpcnIHgrMDPx4P41uGCuMdhiLQdmO4DXOWOiRYmQc5/yfms6vTewdeUqEbL2vyKOtHQSjq+18iKRpdo4geqAFYPGIOf8wrUIWR0gWMMGjmydnh4QIv/tcdTZsMpHRvGgevQ6tQ4gFM/59WTrOQOaWfPcale8Jtd8Uw26UHkl3OV8gAer+PIi/LhYxM9e/6UQMQir6u5fN2uHirFXomOCzNHy0opqMHrm4c6x3uL3iZAy+IrsUEHixqQIywm4Rx62T3P0QrdS8zArZQRf9HypxlO0RKkWwKcxmO09OVBU6VwxNdG7bEbqHTYie5eP3mIdQ90xxKZPriaErA55f+wdrHXVaEvveQSq8nsdEIDqbGjxyXdGXDJ4qAcMrPnB7pI70sbBbLySjoK16rwtIZEAsvNe2CvyglOyhz6LXZuZyqoxwoi0LG81ccTSpuD1B1XisjJp81pftFBuMZgzWkINMTl3I1BfWOlIiHN2XwFDTBRP8gnEzTt3cNKSoVwkIkQdUq+lIfvPrjDB8gh9QLIzXpRUJxjQdfwD57HM3nGRfz0tPyvlzHzIh5RPJr+KDveWGisTTUmwxJRIp3mNcVU8JYuh8By+p7MNq4uoUV/iASWUlPrpYbkoiB58JE1MkbL83geMmUi3xoz7+bFw5Np0abiqOpTuaDvjDhVYOWmJv13RtJ2Y19NoOyxffr234JA1COg12WDRnefnDpi+3Vg+JQk84U6BmGDwFHadqHt+N7DtrZfayl6u21Q+zFLMoFt2bTJy7lY1UlF0qNhCJMrDLYccA4apIT0RoSdfKsAVzOINDGfBFGv4Zu84BfFlz/Hk7kUVFgmqNy6ADdVUHq9BBjRVZm9Uql457oap0yMfNh+sKhzRnRWVrsmYGZ1TgeOgx77dJxulwadnpj7pj+HdIb37Xfdo95Fjaqk80xUB9kUsgc4qe5yTI/bAFiQDTAGXvCPMMQ5mSaNklJlglGCgp4t4viLs/hTKxR9wX/ZrruurEW2V9d92khA9VwoI2KgA1DEIzFXDwhAxbQkShif7swaUGQ6HyzUC5GWSzSCdlzz4bmP3iAY2vo+LwU8vOh2SC/tLk5r4NeuAZJmtGWRKArQDBerUhX4hgm66LpN50gfmLX9Mqfx/e03XHmZ25mx9DVU6Rxr0CYrA6xZkP7NupB0pgcpUQiVQe/4pgnAoBdoqDsoIx15i74hqchionadD8JglFiSy7KS8EVaNRDxramPeiEFXF25BdTUg+SvN35W+lWE9i7tcRwo63AdWTsa+upVQ3buqtJc1I949AIVnd+XWpz8ZLtkJ8sdarAPPrlf/pRJPQJLAbwuFKnVeSagllzUQwT3+uI1P3nyHHUeV3DiFPSO+I6nDMw+/lJUGulqdZ9SPr2/SukCsFzum1+jPqu2hpx5gsQX47hPcng5QfzyTAC/FNILoQe/Lo9y0pMzp8mZFGelQuX98gw7iWB4iCZ5W5C0bNeMWPeilnRqRM9aC+sGFpqi1oBuSJJ7w+ilkmysi6hpd3SPZt80OFOZsWYsSGWoyxrAWowagBJIazLJEV/CBPZ42CJ2Yu7148iBOkZvAbum7/lhN8ax8g/9uQZABCD0ZqqRT645zxVOyaSeUHmHLT7YYoNAVgMusZUPRRJBNQiF79TREuwvnNOS0glfkjqn3e86pFFbzxa1/qSiiRrVqP6JmpI8ouOOv3rr7Roka9Drx1KQD+o85TPPa73Qqxb/7FkR/DV/uA3JnEKnVxGCK/6Bq8AG/vn706rbRHrlv8qbSrrmnPnz+8rl6kJ3vVDsCknXTMgDpfjRrcBQ3sPXjA/NBCJeeMRzFA5/Ckfmo0slTP7XylR/FwRP8zqnrn4cu2xRx39VuiRh+cyYBoOStu0ysxW1jqFf0quZP1krCpw2L7PZooDL8s8y52Fo4MU0N5DAhIdpryK9XGpu6omUH6QnU76xGAmIMLGCRI6ysMINIUDv5Xx0FSOVm6nvgk7Cj7w4ZkQfkGCiQyVIMldpqRHQJmgMrFVnSSZT9WNMEsnMN6hp+tE1a7RTRQNeme46NWh03iv9afHjlu132j337Uhlgu9ZJUQ+40oKuNZnGh0u6pO8km+aJdjBnzgIqyyo+0XZ8stHoYMjTryPq7/I/oRfXm9utXLwjhTF5WGrzA5rcFxap250xJkZ1HKZCq9TXUmcH4WKH3GSlFgee4kpqaKXv13+1GQsXIqIWZBohPkYc1IvJjRIKlb69PmIIXXLfTo8XPqlWiBAA6TkirUlQRvIIcaKQky3AN4uuzHro3nPBAmTKRyc6KN+qRGAOu9QBRTYQRs0xYxU0Vx5L+c6q3oEBmzo4NixfTKLd/JzRUXh0buppAAG+RV5z0/M0nozkefR40f8uIbNWzYrX/r4mhrMkL5h2L1mnY1p4dPe3Qftczd/3T7xxa/YQenQpbI+3EP+l4g7XfKXd15E/SHdU7lQR/Lh4AM0ApQ+75AFoN7gSSJ9GgnkCbfce514SsWuhUZDil2p0C+u6qxt2poXw6Pk1Qr0rabzjKbnyGzznW7yoOY+BjKEoR17HJUhwoWkR7JRqSsxh7hevVnZ863d6RFAjlxhtTixoFVtAmWvvp24Xh/5WdBXrCg4ZqoELeUjYyiqAdKQwyA5MpeZOcCCdQLQc2o/O6759h46KjXsX7oiL/qlWTe0c14plyoz0hjQoORw/jSfYEZnRkI3kOhqLEya8E83TqimwR06OjqNay7OOdWJ0qDsfL/EH0SDaCxrbWgmcWhk2G3s3UP9XoPHpSwfnqnY3Z+43XY8+rQ98OjjsrXv1zhCjUh6Nw0XxyCWRkUDYeIJHuR5SQGicfo1w0CEUVHJmoeJunTC+GU3XMGR/utPVvd+qzxAgHL5lQAnO95FevEWnsGPvHMahUZHo7F4YVk63SW8zAdxRotYa8Q8kdO5jwydlClqO3P+TokDZpZMpjhJckU8QoeU88zn4wah7Eq4mhDhYJLfcHuXDjwUP1VxaRo4VZwKngZ4njajfQJhUwa0fFpMAzn0al0ZcPHaKwEmpyrCx/lGcVhJCKrJHxYcvvrqPJV0ZzETO178G+MKjITiYLIoH3SK5E+jT3GgSdNVDK8H8Uc0sYbo0eORDlP0W84/XwPAdlsQIKvqfaq9A3bT9nts+wNP8x1PLWehR1JZNU2Og5eRrjcwpeu8zdUJtNNMrsLmhZlTOPmPl5lGnIX1tejwQ460/JePRiZQeZRO5CVeQ8v5S5jMednlj1spfPIX+xq2UWKpfnleAnsEj7syAacKUyEuCvm4vCND4ZxR8aBra2Z4RfiQys4YaIsX0M+rFK1xW5+hhXOdSgBkfTLSZ0hfcG3wlVtJRZaPNvTxaZeOYn6SkoAxcQ8IopsCNrZj+dJPvWroq1Q0NkHQwebWCgAQlaVrVAQNk5V6WFZoJFP6Ph/PwwNS8QQqPh/nn7ogr+pNSNm3KJGOnvicBvxgIMmaD+9J9M6xoiuCmt3fSOxpzWq2lzRrKd1+gckaWWrm+9fb40fvsWk9t2uDQJt6CLgJeINnnlfyzxvKoKvz3n3SHw+rFxEn6iJfV4R0y5augDnCprhLz4kiuVA+aJgqn8M9ZcFfE4ddPfAtxi745fMadOLKO5znXfdq76NlNZTUdCOUrp4oz7kE47W3atGJSl0hSLNgEScKGs9cm5nQPTSiGdAICN/aGIgTzruxLOEYrMQ75cylM2ZIhlQVSQ4N5XyHiq/H1uwaVgLAHon6oEN+jPh98CiJCugAE0oT37TGWoLUZXDISjin5e9TRjzPbuRA6ngCWSVrp7cWRsm+ITOipsGVUZfBigtK/VlZYfIH4cA6aT70SQNaxPwmk6CDmgpTXL7Qpb7Mu3J9SttOTMsq06VjCzQ9v2HbJXZ8ut0OaztYXT0Di7L4eDwcXqoD93C/JgMI8gK6ppqR0YxBXQAQ72YuVNfh4Gmb7P9grNUt5b/1TXp2nlpjMzOmF2dA9zcONO7whNsKEEn6wJgMiFG8zGcwEowrJHCtzwHkiEs1RRhUAu5DRw7/RElMIFm9j/yEf/4qmWaTyvtxLR1dq+/+zaKXCiQF6ZYlTUAASkCKhACuiRFSXQVgP1MDfVoDQFLxXlFXprnZboWLhez5QY6/4B0AV9yylnFWFgREEahWanZcM5ITGpiWZX2AMt9GweTGmg9vwDQepK6gynmB3OFfkgUECwuVXNUAj48TFfVhy0U1mEWtTelff571jay3jee9xLZsfYkNjG60ez7zdWtoQoiUUFloW3QVCTcABe7JYqKXqYpP5qbXESqEIpEXrq2SWUTchZrhdeW4SHWerzsEJIIn8ONX8iXnPaoyQhji5H+8D7xw3+oIGzhSNinahZLQIk8KqzhaizOd9ySYLhQz8SbL2CrRV/WGZjCOK1LIpZ7SiHerRc4zxEGugMEw3o1LQu3XF1k3DWowpuMFpiemjRPvBzuGBBky7Ll38pSHmSq+bejn4ikfQZMi0gBQGeAD65wxiyVdnMrOeCAaXoGoECLPm7SrRHdaKEWDwsG9sqQ/sJphokYNmMVSburToj3UJMDHOmyX0AIzy3idduqklQ8NTjVGWLP5fPu5d/+yDnkfEd+UrsBUU+HHtMewrDyUFI8JFV2cZqJBLmgwdPtwAZf+0rzDEZaNujivo+wFvIrQmVeWt3hKV6+f5V4nPa0UxtNqljelfVLEnAfhW5yPGPSp45NeeLiwnVJAB1kWm4qhcO6aN+GReSvOSg5aS8xVCAXz1p9lLv/Ogb4KnZVo41cVsnWUmz11fMy2qrLPXX+OFiZNClNMfJAeFSVZiNSQzuZqhfwZyLi0ybJNUKQwumzkg10vTLJgIfAvPEknZ/sUIJnVDhgkuYJr+lmbBFBRBMiGJO+c3nXJ6uLxhVkHoAKyko8fKwE56YiloCoANekNiEYEb7i2aVET+ZdBQrlvt8GNm61rRB/YlCx2Rzi9H9MuHHRyk3RHhXEJncR0Cqe/zlLKq/uVJC91QPkDMFxDh87XD37Ej3dYeNwR35lNWplferPsL2kgmd0RTrTy4aGBkFvNRf5IgfGc2nqprM2kGyCUdwRY7pMVLpe5qOR8vLO5pwDNxkI+9CNt6EceVmfJySnSLWO6e+b4pO1e02+bh3ttZLRdgzMtGNIMIOALRlAB0KZCmiwgP/oBotZKwUrBDwndrgFeG9PpYjjP2tuiw20W7JhsvY899qTPNDKoHOjv1aRHv3UKtDQmVuphBVlg6SmVLtAV5YdmjMqh3GeIU8Y8L7nHlFvZ7LQEVoun2J+u0/zcl7BMu89K8kNbug9oySLDyeVcdN42C63XmWsCCv5n77mysIl3+cEfUeAV/hE26JzWVZloxtM9OIj03dq0PMurkqRREVTKxkuzbzCkltpsaVlBCBUJQM3Palbm6bRwZCb/3j1P8w9x+XmlKo7IeuXSXrknC0DaM+ovl/KCX0v9NLWmNgknNVRtfi3avYcW7aKRom0b1smfmmyZnWEanDXMgFbCUNYN5Bs2Z3amYA9AUuPo8l33VD44fHxeO1Ympye1H/G4WysGNcBTYA3Pqv6BH3asHNP+xGe087p7cFRl0RS8dOUFxZ1U4ygJtFKAdN4HlgypEjQYAZxGVdPaaA7a5yzo5vpn6dJI5aJPBHmWnBu+llgqRl9fv0bzCs8rqkM39ApzWpzlMo8XogEzUcd4TN/hTqoJvHX+hjqUlVvBFCU19PzAeZmu7LSEGU/ck8j+pLjkh/EJzvPCNQvrACa/mSNvjgVFSpt2U4w4/9vDK2wrznzXCyDhnf8Vlqp1SWh/SH+i+/HIEZial8t3LTyTEOHiit9ZuaygMB4XGfc9h9EdnQFhGEQRGfbt0Xlwj4536XPDI9ah717L1OFAwiaNbkyrqXBiqVyoF5iMKBMzhEhpCQ2fGGnv0Co9TaE3BKZpvaupa6cn0MepXP8GpMe1ibZN60Q4tvb4pPYuKry+5aoVcTUbV/E4QJINray0o8FIG3G1gG+HVxRmlDXOfhYHn3YjX0COv2RVf0WDJs5qv14tjW3tjCnDlGzTBFTNILGaDZ34+WMn6H0c0Aqdd6tJ3KiXfFjuV/NvDdf67LiRJ8XyvHkA5QiPzKVSxNPSNcJ4T5oLD6OwcrgLMk0pLd98ZsOfwAEaCLTaoZ3Yaf6Bfj4NosWzMztrMKdJblkwKptlkvfuPmLrtD56mw54wVqgyWGXGuwMOarjDNqkh5ZZJadn9GVAzLpi9F9c+sprqno+ZdeoTNmEdn2c0KL6GQ3iZmSjjq6SddZT7PLWlXPt4OmALBgiZuNap1zW56lQTmC626u1xoKGw/kffVpr0q2Pg/b2den4hYVkMaELFnjZPgZYlXk50ZBk79AeSFy0eeTBnHam8+VZUIzajETmdCXKRq9KWUifRsFCQI+vgEhfwoR1iXt+Xheim38O/6inRGXlv5Sf8HkXz36l/vUSWlyDdj485cJFeoShnugBmN1UJH/vmERYIClSxk8Gl4fM/hAto+0+SxlbSiwffqX7iBOZWylM3i/C5/3O5J4ufefhCbu9ss8WNw7ZZvRYuthGWjnHgGNOujWzhiw8Ah0cH8aub7pILAx0u6yUmxfAZwT0Qzpf7rjsyjVUGInYcQGoSwvue7UjZkr664SATqfZpllGqqkqMMJznd0ok5tUjKImVsR9NsBy3h3HHNQWtdx1eNBVGBoHjEa6emUqsg9clQ83tSkuh7Snl8u5QUVPslOFiAJpvr7iPuCV6iD5wmeeW+u4WU8K5hJdfAjVg5Sb75dnw59CxXCiK7z3ckIje0ceWtNfIZp7UbJIG0EbOMHP+2HRSnNloh6qBQlF4aGC5CICo0muoZ5EoEjAU1zlTyQcDFwlWNM7T9MLrLRx+AetfJhmRN0AGFiE6WrH/mk7OF/W4v26vWK0ZufVprSuuGJDWv+go6QcrJjT0C/qAsyMDnqZFbgnJGWrknI0+lltDhib0mmisgcXBX5Ooy1q0mNS+/OIN6rjB9hoyyImJKifRqpGwMAQsxw2Z6QqSl6trplEre5raAKFxkP4tWvXaLOr8sNsps4TUREdRBJFig89qSnMIkpV8k8ma3lsq5sSmKfnZrKB6hKPCMe4AqkNvwCb69OAiPpUIlzVZPx9a907gDIpTnwHERnMObW/5LKrG1Zy71tvPd0cDU7VQsDkMUecqN+wV1On8IMrfQ3/lHkPx4hCSzkKjyjDl/mL1lRXeCZB8gxRrl6QXMZWiPK8vZzZKjAJUsAo5CkJU4HKJ3ruHlkfDmjrf0+tU2dx6DslktQau6tyqUTdq8J8Wll9MZMx+44dlVox5QM7zqDzo75UWMHVT0RipRw7R9h4izLMaac1pK0kdi8nhWp3OQ1hUBtlMdM1z6XTNPzcvLZ66fgCwNu9dkTSRI1L28M6JdXhp/OUvHOvQnqZnd8wQP9V8aqBk4rPoidUC34uAYmsBotr5Vnio+pQ9HBNAaX7FMO9/Q8A5j1xuOcaYYJuK368DMSOgEvklu5E0wsUPjyL9qmc9xI5uvADlUP83q8xUMmP4HAzVZbpKBxACheFaT43b06dAYK20mptoUGu9RrxoqtzZmb5bA3b+kzYJJVSvaq+7ciUPjIkDLZxbpzAhXmoKHBSUlSFYzqX44COCNh94IDUBMksqSCcd9fRrs/DaUF/RYDnoJpumc56dGxYp0Q1aZRlPx7q6bcR7Q4f1Mfj2YyLY5CJqW/2xISNy+oxvzCtPX3HrVufa16vQ8h7OD1JtAAzblF6v8sdyugiI4HRASIM+2mkkvj+hQCFV1tsOvTsRenlvvRVDQDnXX/GhwhI5Uu/8UeXyrprAnOVOgfI4bxOcs/hv9I16K70zv0yiFG/K4WN+iefuAhDGXjnVh9d4ZYsRge1kbngmykITAAiBJHw4ypS/h+wU7jWsJFQCrsE4Lx/3Af91rSIG3SDTlwJG/HD70yuHldAmNSU+ORiwdZ2SsaJJiCnYA4i/T2kQwwP6wTReWYIZU7jHLhBSc+hgREBVztgBBg+djmgXS5JtQBlAq5+nOTBGpe58UkNGNMAc1YH1mAX5vhc0tA+dFszOmQv2bpFW8W0VFXhJXL1SzwF/M38wGsBk4kS1A0/7VQ00oRQAmQrD+AfVR9CqfV9POd5mWHKX+X982GjzkSerKZ6UoBmOpTjebh8g1mJTKQf+YtnwpJ/Upf1qFHWQONxPb7cA5DZLECEgkAC8FLm86D20hGHkq7gWv15Dj8kEJWMa/plFRvp0xKjECloyqHHWiVN6CnXXJpOnaY8tVZaKu9x0ihigpO5rKD9gFIZWOWGpGaD6+I866B1KHkv25za/ZMQa4ZG/XuF0xoUNkodNi+dmtVwbsKTVCU1JDWaHea6OakeqBx0/yNrRrTRoN9Vie5enRi6aZ319jMpQ/ayxiSVCh4gUTlHhJ9XlbLth6nLosJqNCQSJj0WLeGaVg5lgK9jsdaEgWyen4RrDtJ0D+X0h6s/4eOuGU9lCZCFH1f4Dttd4SRuM3rWnxAg5yIudejxszqLOm3mK8tHS/QmJZfIenLbOL5ZXshQlEckHi1rNL1bOU8mm8AAgbOEnWKW8QTsVKgAdZOwB4Q/KePZ4xIYwyOuq+Q8Cu2zdMopXQkDIh8IKE+YuwgTDIlrTFGjr0ZFRFIehnypGvgWy76JWbtEBx12C8DtksDM0tHVMzAcGRzQF2llY5Yk5xxlJic4O252bNYXOAHUAlu1pC8DMNjJVioOSPdJGaGa8zK6dCIoW6TYr8g3VAA2Bpa+QX0QU1vA2JUC7TTYppzUEaVNLpUx2ceR0JRPTIDBuvLNQuUtz0PdM/DkywC44FFcE9X019Vqgd7rSkgJHvI27gMK+XjcBz2ujodcnNawqz1HGqu9X8mf9MCc81wsgEaeDuMgwVhHpRTtMATiZWSYrpBuEue7Gfwu8TAPGMLn+Qod95N/0CRq3MeVmotwvOe+1QEc30WS6YMeLgsEnaDFNcYAgD9Pt0lTEo9wpHJ8Wh8YqvVYF6dnCIAsFcUezF69tTp5qE00xifHpdtq/YQqfkKHH06emJLk1nSe0MBo2hf/A2aBlrPoBmWh6NGkCstLhTfxTlPcikslxDqNiiZNOqU7I0XhJHnhfGnAiqrBJgBlMg0Ks4xXlR5rlvixnHRRDZZ4DHaXOfGzU1PxXTJN8t0W1o0os6nMACDHXiXhNIgfPFxGK/dA/vOO8Pn6b42/Uj0SPzXcpTrL0zyT+5ReqgMKERKeMkl33oGNf5/8ybVuk3MDOyH0PzIS71rYCEc8YhQsf4174lJQnqPAft9k63LGEsaZhjExY6hL4IwO9HimVZI4YaGHdA76VESkGdPZFJOp5uPTVTs0vmgjWl66qNlD/yKU0lrQzu7Bti7r37Req9a0WF6qgx8jpuNnh/u0/oLvpGjqPE3LAmstE9KEyLA+6NOlSRe2eKkJ+npmVA+G3hWZ8QByRUtH2zSBUvKpLCR76km44zMW9Dwcl8ssIA6NgzKkA9VRIRIP2cQLnTxvPYL+EJfvEzIj6KxxtSXeLr+m3d4K56XQu2UIWB42ngLIMZl2GlEi6rJrHgfLXpziQSzJGrsEGA/LHH6Nh5MOrXGMMtdJmCaj9OCL3NVPwvSmEyBw6DQ4l3mZH8/5BhAZD5oBNsKFi3dBL4VRGikZTxu/iAtTSZrKBgTED2kVDM/TzueBOKzfGJeVY+ehBXtJz6Ak7Zx6cjUgSTVAMyu7MsdtDeicuAUtFWUxUZvOZK51SdoJIMK4DnWZ9XPtkHq+31ANYUrrRDj5iHOdvVeR2lHJ1mbM6uyPBdmeqw0taNKKjhLnfXDIo3rBmiZ5fHZR66VZyNSjKe0ENn06Q9PpDAZROXxSRd0pO17882+oDDnpgi7dqfTWSkdnKh0ewSnqjnI1pwYz5vjHiMS7WEsDf+mJqT+CR53jH3UUIMqqpumfkfRLhM37td7n6/NU4aPePVckTH3rkozGQVklrWmdbmNxnMH5rB41VDKN+5NzEMTDqa5KABdAbs1gU/dl0KN/nh1FaQ2Xf84zMeos/5704jmu+OEwXQUTeJdyl94lRuqTa6qZZ3VAy7MzAlAnlmXp5QpIoxob01JTLb3k8PEOffzd46h6i9rEmgDMXkMtRZUuzsCTNNg0SzfPxIBXugICxGmt7gOAjNwGdGgj66l9rQjqHNYMXTled2J6yk5o0VO7Jl46dVSvT1eLV4vi2ayms2NwSa/EqjdOZWLiqFiQqQ/0ZY41zGukMtFrzDWlMxzIBYrADlneJWi0hggeNoPrpslr5RtHHHhyNq5J6ywik2Q0rhCE+sKBvh1UPFieLxaPtddrOpu1OBwFJ/BKBVoxbbVgEmAQh3Rqjdd8Fk1fLKPQLHMMu3Lw2iVC0NI1fZ1JhBPvVkwapoS60QyQgZh0+UEXEt6wBHaJRKkZJTuoNRgPH5uwLQP64CXqgYs7WRAEKs72mJa5zfVkgbQkMCPhvFcASKinSmdOx24B5BnNznGPOlPxNRZ1G9fXr5D0QzpKYUgDTSwQWLu9FxEgoMU/rhz80qH10iWdIcJ6ayS8vH3qfVbAdwmtJDkilzOtlYx6CJ2w2qY11tHioaMX62RR4T31kRoGpecXLsneBAgEjMLqBy+bQgk/iGQu7gjnTrSbLhcOv2Z9ZwHi+UwBDFBJJZdSRnGFCxmsF2aqbZXp8kT7kYk1c0NHlOA2LxycPAvHQMfPulAWsM/CqZDOkHPa+uNrAshmMCVjiJuaCNfCICo84vuNP0BtuWsyTt4eQ38ATAA+/x7T17RAvVOWiwNjskoMaFc26gJpZ+kzSIRQRYfO8HWqBi1MVgn1yrrKWiJ9mmKid5/QMbwcbI5ePMfaDenlPQLoGi18AtD+aWY1DADty0N1zzFgalMOWpjTJRWHPYDCsw86KSFwm1f5gSASHUlNI6nyeYyWelI05/GoAM10+/QMdu+MF7qejiO8tyS/BEVdc3w5HTqnChN1zDXKEdeI23zOqtqtXnrZFIQR0K8KVLQjYLls27dXC9e880lV/LUoBd5+xSx6LBLMdykkEplp9miUV0T9nSrEwUwiGTBC13FgKj7PsKqZQU+HCMkPKY9jnj7vsMV6fkhDL/Jvo/BONypaZHz+X+HxJztRJrDJtwjHNUHy4OFFn/Fbq6M8ATWffVNEAQ5TGTN7WsesAR3Hfrlkdmmu86b5LqB2q/z/7b0FnF/Xde+7hlnSSMMgDUia0YiZZcmSLTPEEHADTZsUbtKmffe297Wf109y297Xd9ve1qWUAs1NHDKzZVu2JctiZhjSjAY0oGGG9/2t8z+jMTTQkNP2SP/5/885++yz99prr714a9JMRbvR38/OtSBzF+l51R7tejWFrSXkZ+06brnNiNCre9wXJKRVUZ+GKdPHfoetPdcsfYDMqSRajMYs3oMDVBfuoNq3ZZQVY8Y07cxFhDfbawyxIiSlqarJkDArLCxgImVYe80V3qXZJ2jxl2JjBNjqXH4ck8fVC0T+qDbVKeIkmAUwD0ZRj+s8XO4nPxf+1n09H7ZL5zrC74lywppJTZeIrWPyszr3dlNfcJcLE4RQdznlE3nFAeEyUPbjpHhPD4fhyfd6uYbg+x167p3P0sK3PSlEnjzLvOOOaar9+jtCgOiq6vTcyxFMvl5Kd4P7voTzrvBcq4OAEAJf9elacATllL/jUscoe/ehc07lPoJbrPwpEIRl9h6HKuoRIIOOF0OIIBcBrrzpfPJSzgUs2JI4Cidj9FA53Vc+6VH026LE2G9AJQXpgrwgp9qbQJ1x+INEx7F1Bry0PPqo1QY7rqEOJNcGjlB6aoB8dMlEcadB9bXijINs/Xj1TSUjYQjvEF4ZeO3l5+XYeRBaR3hf7eaMT9B3jYokjPDby4bleUcUGiCV1jFRR3D6I/9VW8PE6WHdap7eF56HK7OzaD/AG1n/2lXMERre6YI2kvHKNGaqWTNBv1VK5/qioyEFFvKL55p86H7YIH+eVoYNC58P1gDqiSCcTyT5U7CWS1sRDkxYXt8+iHxP7nTYUTVNbdT3xLsj53xNHG+7J6SgMvWzDb+MI43tFp8/xWYnofYCWWIYTIVyiX3oZ2vjVJm5pXIDRvLRcLUmNasOsSY+SakzASRUUggJh+H71Gap3oYGcb7Hn6MXCq8MTHouORlfaKj7CEJoL5oTbTAUlcJOAAh1MfDI8m/u7uyRg4clEyGjhDUCgnh28dMEg04c4fumTU2x2bNLbdf+Y06FJbc4dPiCtvKHD22aGBc1UPdov1/jPKxLcNWhGnTouj6i++ERYsDkcdO9iTpU/3sdXmlY8/V3qKi/I/KYvkSawhU7rPedVeJSe0LXAoQej65GYdNNTSxi3/sIGx5+v6t02IHItxoQIn7QmAAoQX8mdYhyOlQ21IOHjdc1AVvnIV+ujnqfua7vsKbwGdX1zkP33tZuHpT1rqlr0I5FdVtMboqVpIxbMst/PIirSSajdhfL+1BHu+/HMiMp1XFiBHaBOY0WQr7VYoMieuVJ/VarhOxqv9iLFjLnX2WCaBtmPTHA8tEFLz4MQsOkg6QdCJNdvr1EPDKJHP2FlZ4dFRO8764lz3w0KP2UDSAQ9pwz3p3EqlA+pwTqn2jdRLsnIgOonPd7Ep+hNut4L3iFMJp8T7/D83DV8wr4o/KTx1jlwjrCMu/8Dt+v65OaNVHM5+HEPVbBgLkIVlwNmu7pn941NtY+HBV1RtccoeMGu2tGUlJrMVQs0Cj5CyioI+yEn/AnjNJVg/UJ72sW6bmwIyEF0HlITYV4ntciUpmA4A2KvEuXde7Iy+/J7/BykedUjw61UL/9w3t0hMMbMhdU6Nf1J6wvbKOkutHoFBukHfWdWAGjUVDnxlsRTPY0apUX3MDwNahkt2/io/JJ8A7guzsKaXUZRLiTX8VU3ytFOuoe9juMxTtP/spsF0EcolLyynGpj+8+miOf5kFM5+noomE4PMpEkSa98MvynW4nwDcK/n0KiddT8OhLoD5NZFkTY9k/JR7a09VYDUuEGZ4cIOGhrop6Lpw907Izp7PRZ+AQxZA7GALKCvJRMNzlTM+GY+gwnjSmYb3h9zsRObyu73fWIRhPvhb+Dp9xLUZkzLws8AmRWCMZMIyqOBg3/HN91YTUMI66i56fUhK5YqJHWkd6+1DbBf233ubK4ZRZ828Bocso7QOvm2rEOxui6zocKQIcCsrxCuqeeNYL8UevVkNFdfVRmbDOyONh0bd9exmNkDqt78ih93o9k67p1jvbGr5j8rMqNxnQOpchORA84G1lCWRLtFi0FIr/i4aF6OrvBWlxMoIauzyC01IL3nid+Ep3wQsj1vEK+RHQT9qmTXl64W/TtFUEyNkH69CHGVz5/JVnrkd1AZA+cof0yR+E7g2B4NqBSxZDMJcVQE5T2saYPcJJSCNTfBJCYiLPxzGbxJvHJKZYQek8i2XFuH4EcFJI2eFjp62qqiYw9tDHYKsLlRQ8gycCGF0f43fCxktH8EFjpY8fvD8YSM40Pv/KEY7JxFhMKvdOquzYo3ZxQxMw+NZrdCbBWjuT9aHOHUFOibcUxmZ0BKMYOSvys9Nfq9797a+peqfQ+gG1PITr41367UjjVXGd6sIGudaAc/3zaxHA6JnwCK12HpWLZgLs05KAlQw+mUHXcyHbMPFMBBl07vc5Dw/VJ0ro17ko8ImyhytAWF7n4UogShLydtdrCmrUsxIwdbB7LgAISipvRz+IVoslMPaaHI8AVLqEQ5nE0V3DMnQPdFgvnnjKpSE3UddTw/dmQGmjouRqikgHVU/kXAlh1NYojDPSlAxQ3zB9EQL7tsxQ2x4MKn2DWBH5LQ2JgmvdBY9B1b6JYnsS+Shrv7ylEVd991f5Qsvrr72pxfKmZ6srE4feOTUl3m69YZUdP3LYmruJR/QlWvDRuiWEER8cQEZi5792CA90uEaKR/15HguvBzeDMv5bZXlGY6JPeLyt/PWL4a+gLNW4u4BYNHBFOKPMrrFsnSHBurCw0NavXmAVpUVWWjQH1mzQ/t8//Utr7OrUangsrCwYWc7ic8viqOQhGg++QXE0CzlEXcPGhd8aKWc9In1RSe+EPyB051x//YbfnKiDH+q1l1HxyYfqcErHRSFeCIjwvY6wen4SsEJqHbZB9anN4RE+G567ABfpm3TCcXoP9UnFNYpqbpAPPAFpD9haGGoQ5zpjpQfgA2IrsrsfAA8wGcZBrFgop4RBBQHE+7l4b8zotEFWvQHCrHqxFvaBtEOcD9P3AdSFffDl0nZ0swLot8zcSn4jR/+p7FI7hcSLaSB1ogRRQJlEncoFEoNQp5RlYmFSZmRbVtHsoGuRPutLVKp4ZoHl5+YyXZmoegdb0onv16C4D4wjq/odPDjh2+FIH1QpeAe4oInAkyFl5rcISDDOfuttfybDXGMYIvnkQu+k0Kpa6YHHobqJBF/MKy+15cuWWVNTG6tZr920bZvdccd2Z6MOHrtor+85QMqIRvVvjNQSf9zXeL5G9U9Q6ITosVMjUbH1NHsWVTvdUpNlbQrjCJ2/5iHNHrbR8oaGcWAjNEag8U4KEAJU5BOAQw3WK4MyOvEykXNHtAC2Xk+4GvgDkT8hby2AqSohc3jomiizrocADAHr5SMvn6wy1OAOgSiiWB75wNMxRJ70jSdbH4is7YUTkqGqmJxF5aR+uwZiaLuLMZyURvUsOfPixrvhq6GqLIWif+xc6AKl/CTa2zqZJMQtQsl7Qeo+JkM/bMg1vPl6oc6CkTz0FEgg18epaFTkYJTICIuKJsCOaGN7+TQFSCckpO/w2B0N59BP32Ax7xFfmMa2cQ/evtlu3bjOKhuv2O6jB+2lXXvYBauSCaX3ErsIF6pcGNpZS1w+fzgEU//hsAx+6d2RX8BAeBHCWE9M3NNJ5Hiva+E9fYcOTtpsNBgfUh+zC8F9d2+1tevWWHZWtl24WG2HD512t97nXnzZnnvhVVYzdPIQBhHcGFSZtKphPD7hQlj3BEJf3f90c8ba+9D1RM8ah/ro0IvCmaQOhNdEPcPfkzsWXntbZ3hOpf15qhBCCZFDyqBn/J7gpfdFACegBf+DJTJ8/2RW423lvX0B0L3dkXom6tcPDlGc60fgihn0jNdH3jnMZBX/m46zUHdLvVNuttAmylvCIFQXVVocCccToczsK4vlDiCjM1bmUrncJmhTzuFotBY91iN/DtrSSQBrN2xFK4kblexGkSz9nCeQ2zk1Ic31zHFQx2QETFHjaPhuD4ZkBfCtKxw2gIQuqr2CR/vVJqhXC/rpfK45ACOoeL2HaVPibWFasc0rK7Y7bt5qu3fttaef32l7jl+wbqJvYiTkakWWX4hqjsDtneOuGiMoIEA5G6KiovYT4xcC8vrr/Z5aFtY76dbETz0/DCyyMmfbvIql9tprR2zv3gN25UojKyNCN7p9T6vm7WPFwglLbRVSQ1wPtO19tCGsbILl0IWkwnnFNHCrWi7xzeeqA9Kb5I3Ty4XQQkz9FnUTAk1emlSX7jngdcIRIlnYOX2Hy5bKhoeu+3N6PvLRvfB5rQ6cBe+MAF/3vWzQTKfUgfipO8E9Pf/9D9WL8AoPl0cAwOzsVPIrj1oHDv/9RNoOyNCBA5D4XSWqYY2CWoDIsBoyvChxTB/8srMVIHYvrEQXiHyNJbMVXq+V9Ae9GFB6FT3OdZmotd1cMkibAjuRBr+dBrVlOwVL5JOG7luUW2yPPPm0GmrlcjdZBmcIFiIR/+fMnCxYb3TU3Ht3L7USQtG5k85moIvLZ9vqVctRDU7H2tgDO6KUDGhLIoJHKLi7d5/4Wa3GERgCHAdhSIx83LnmAmdkCN8LznrKW/buxtEqPSi/8ni7hlrzlZ1v2sFDR60NGQHaQZeYMCrDsxqboH6NU3CPtfWR3vqzu7xh/HkbQqcUzMPrLurjFFasoT8coGVYPEBCnaliIZHaqN/v1ZHwqcn3A3fFgN2IwMCLaUJ4Oc4mI7j3hfo1G/Wu4F4wgSa/U79FvXRoskV+TtQ1uWxQinL8kIZDh8tNeg8giWGFykmJsVmp8Knwc3Lil9FDKjoX8EBaBWL2EYY1Au8rPlpbPoiV6CWVge8JDjL3YrRpQyPS3N5mHWQ/1f7fCrBV4ph4zOlTMKqkYClMYTBTJ5AXNqi/26aiqZiK6TyByRKOhQaX/94/URshUk9bi3W3driHYAKBvMJeX4Xoy/UjGCeeUE89HnLFonm2afVSW7xwjuWmY7RBaB3CH6UX5PZVkEl9vQZ+ObAC9GOgvCqHs0i5E6Sg9ASchRuCJ0KtvnXXV5fI9bBtkRo1F916CHMHBZZrLSXU16Da4ER1cF+XIu/pQuvze91155q45MfbELove2NrcnTP7VCBfM1LdX+CivI7XO78LXSYu5QJ2I9QLRQKFw4B9ZV/4awPGsF5pJNOVemgT4xIyx3kDiBnVPTWCDKrpuCfq3Q0c3nG20QP9e2AC4HndVy/9rZJQq06JBuIeumdsm1IX6xdZGPpWwGZlspSlAyR3HUg9DQyGiUno12Qeg21nFgPZWYak4YC5NU15cUYELJTYyfsRi8ma20Ur4z7vWyrJv2zxkk566aTwHE66Q5SEPycKoO42kYugXzSshROQa+dgLYkDmE1MngMZEAIfPdZ2htH+2NH+635Sr1VX6oO+Es6IKoay7MeGe5wpbCjAV+Rb/V7GhOqvGiW3bB+lW3dsNqWLauwGTnsNBBD6snuFqfgBHvpIQRg3g62OIw5j+CbA0/oKgqsj97ko8SE1xFe8xPaK3zSShMeEwitcfNmBlisx4NWR/76TfCN5/XPZ8D4+Ono4ZE/6268AEMYHG9DaGs8PJacV5EPBm0WgqqqyUeIFA5g7geHGs4rdM7LdASIFTRav98mvIGIyoYflvMf/An4uLB7uhrU5ZSbs8BEHrzT1W4iVZMOb9Okc7X1PdVMkTJ+XwvUmEQxkEblmZxjLMHT06JsaWmO5SVLwyC/Y5Z3qK/6IfdStWkQrUcfrMMgBpEheGLthSj1GzdB6oBSx4KYUj1J4I1FgJEqTplIU1LZbg52Q5t4iouXXlkqRE8JRtqydJz8U+HPE0WdNQo+mFA8uhwEEUQGG5iLYmnv8m4clurqa2FBkiwVpyklxlG0uZAnBp16gGohgALYBmfBnWSemz0z39auXGKb1yyzdcsWWFFuNv0nUaV08f09rAII/iToiQGz3X/FWxegrK90EYTx2vnjeMBLfMUIX61v709wIRzxYPyCtshcH/4LSwU9Vs3gAKuCQswYs681H3rqhaBM8PftCM21tMKKODbJeYjnNI4TL/fGRRriQuHbEJpyepfDng5GkNg75lXQ7BDZOZeU6rzZxDM8GBaOlNergk5yYeIA6UAYIVbIx4W33lUWJJJ/sK80vPtd92ksV6FG2veEfQyjBmxGSrRtXFJhv/zAdlsyK8M6oXzx8MixkX4LQQVQaT2U01mTWPKzcsaJFnmiF+c5A8ldvHUCy6dUctJkKAeHggOElO7gz/OKeJGZG97FnZumwUNPgd1IFoX1gXWwgpgCiCYGyKT+OzLzWvomuULef0indvFiFUJpgmXAVyu/Xgcm+2HCbBQe5pMhRAgHnOCjtqv1wSGDjrz9SgoKbcPK5bZp/TpbtXyxzSrI4l3KIKVUaZiJtEK78oCBC+EbVOVjE/mpQXS0d86E344H3AzH4+0ITRvg/VzjBMJqBqtdKhuUDwinCBXnw2xe+ju99ecDL6xI+9+F0KkzV/SMjQ4+CL82zctEBjNsgDeIPuhycE1NV6f0fhovasNN3+4s0lGdczs49NuvB89PXNfd61AIOh55Ss+H7wr5ye+F0KpG5TRxhGz8pGr9CwbO2wekJG5EjfVb5rQYW7uk2H75oTvtwRs2Wn/tOWu/dM6ioHIxIAtT0NkkIaUc9RWFIootgEdJpQYPHA8SiuAr3k8IpZepDdqKeRgnI0doJoG7kjK60ilPZddXRZeAumhMSFWGoJZOPQojksZDfkTBKkPbHbba/JNJRd2+IgouILf6EUdh8dzwBnbgwEGLZxWYOWc2/Ho/Roh23Fo74PkVu6gln+eELE6yBBUhnVdLvaqc35GBSU2Os6KCTFu+dJFtgDVZvmyRZWdMAQZ97MLV5dbOCWKl9lBP0EDhApOP94h4CRa6qfshexiUDF4UjG/kCoWcXqodERzQHW+Yxow+U+Bk1NT+P+mtrJxgN1TiXQjdW3eiN7mgLCUqOm6rAKWGAFpviBqjjw4BRGdaakJgqPHa3NLLAREvy/ORXxEk9cfoLC935Od5BywVBf8pICRSo4PuhO/yt1O/6ntnmyaf8yKWR+oQMjtQsA5KmBCU0BfrdeNjA5ablWK3rVton/ulB+1jH7jFZk1LsOe/9vdWd+a4pcLnSzgUZVNjfWWIDJiQOhlKqu2NwW0XGhNRv8UlEtWNyi4No4ioutLmjsFeyUMvC2f/QXTY2ioia4Z8pQlmhUVJYNAzUqfY9OQ0m0HSx1Tpo/09ctKi/wIw7WUuwToE7fAgWMqoTRoZRxwmlqJdphDFkkbuvUPHjtvsBfMsLX26qwgFXKlj20nJcI1kOv2wSkJEDwkD4Sasp7wrGDeGYNIhPXg6/ZqTn22bVi2xG9ettAXlcy0O03sPnn99cpZCRYkSiLHhjyisvhlL/XWEVd20mz8TNUdGWL1wyuzzSXjAR0dwXyeRC1wRQjOKX2t545nnvdCkP+9CaN1LKZzfy2Mf52e42l5HRi4K3WBqARCo5VOZ0hEAe0v4rX9+OOKrgWGDgsv+l2vh1XffpytaVikQzO7gHZOeDqqPACec4arHBVmeU+3uzI6z0RgJEMegxon0eB7OO/ffdbN9+hMftgdu3W5Tcf5pg/88sPs1O3/sCNtYZEMlAZkmAN0I26iB0UQRayFXUpm+h3HCT2WggyxIqD6FkDwm3bR8o7NB5MK8PPTUQ6joEi2XjTKnQ5njeV4+GlPxyUiDB84CqZPFM/OyYFCCt8rqqGhuTXolwgkO7gnGk/ruyzBlBHU5RsmHpJtPybx5UPUEWJGLcDWjBOJOc5VhG5qX06dOsV2GwsiwPFJWrIu/R7NHdasypwhqS3AetMoI5k22OSUz7cb1K+0GELyiuAAVp9wDuoje6SHzFDMduLvRhjoCPIm0PtJunU0gNNeEzBNH5EXB/eCq+ut9Zl+o4Zix3x64fK55onzkx3sitLQdKTG9dwDMfHVSdV9HFJBEg81Vf3+kESFChh0WMgUvD4DslD7SkWAghKwBcugZ3RLyhkfAJ0YuTOpo8GxQavI7VUSlXX9KRW7d5Fsai/ioYST6OFsLL/ipD95vv/axD9m2DcvJyWx28cwp2//GLstA4n/jlZcsW0IbSCkHIdE/TV5/J5ULncSXe6Z5zpT+AJzkgzNTsszSIDSsxDQc8afAhwqh05X4Bf54AC1IHhlKZxBqhasu1HnIzdzTlIoXlmUK6jtlQqUDjjuimI6kvFNU1FcxhxFl1D+1i4/6rPY5tVbbWDW0xbMynVbX19vs+Qvx58ZAhC781MkTVlxcjNZlhCibqR5UsG/vW2w71+ErzjAqu368A0eIUtcqFut8Oy/wI5hMPk6cC3H0/gTK5GSk29IF5bZl0zpbs2oZLEqeE4Q+6hqAaku1qbEWbVNb1ebgaf31HgTXVaGgrjIRZAiwJ+ip95MJztiejB8c/vPJ2g09qeM9EVraDoTDGbRgm/NqQVn/O8oyKd9egVKDGTZM5+LzaI1fUjOv8xuIC/AAAEAASURBVEphJ4LbERrvdQjxw8FQbTrCARKB9HqpU2V06F6oGlStQYe5wW1frlhWCWn35TUGo0h51gy7ZcMq+/RDH7JP8Vm2oIwB77OrDVV8rtgLzz5niytYmtmsfv9bb1geWfQ1CXzh8TcGCCaQCsGdrRK1pD3qqlIKiCcdQP+sbKSpIHESCJgMlUyFLZH2QiZ0sSFS0Y3gnI+ex83kaXjSSUWXwEgLd7QiiMWBeEf6ybeQQHAFoGI1QsRQO/zgXgATtUkqUtUjzVKMb5ExfeYsDC+5Xs9hnJUqKiqczz918iSr1qiVsh2c+PKW1mbmkjwBgyTs/bRT1jsFIogYOXvoYyBI0Cb9iYyPfupIZMUqyM6yNYsW2k0b19uqFcstJy8btgtfFYw4ChsbQaukp9Vm/1bHOHcVrPrqNavioIzgoaIq7zgFAGjnf2s+9PRRCr3rmDB9v/PO+Fj8Vyxq6NPwK8Wi0hpg8aCi1+5JxwV/LS8KLDjQbP8ddNhHgEplgNB4uLI+gIC/KpiBGoRAzxpoCmg0M1P5QHyC8pzYGg2dKJSEC3VLg+mwjFi3HLLxBJQCuCgGYRoWsQVYxLZuXGe3boBiFOa5VqG9/arVXGhkSWx24e7IoXNsKJRlJWWzbbCr1eLRFCjbKKTJ+yIIBhmIHLw0IoCDtAXifaPJvytgS7k2FsVz6JsV7RILjy3dtdR06k8Kic7jQfy01DjXR2sngVTUdgmo8uggZTQB6aQGT4OqDuuUHw4n6tC32B1BV6q4ACG8kP8O7vM8lF1GIkEtAQ1ON9Q3CkTVhCkozMdXG1UkVG7pkgVWf6XBLlaed4tlTlYOr2c1YzIKefvwKNTuXaLmMuEXF5eQjy/dLaK+74vjg97D+EfaK3jRUP7AbxNNv2lZuW3g03rPLVZZVW1vHTxurx86axdrL+MKQCYqxnaMPIGqAJUF/ZCvN/BQJ/mtQ+M/cQjY42PNAP/1iWvv+PHeFJpCvVdO9WI5zONl6wUsXqfKeKmQS71RTVx3JA57FCCddMYqKMrCRi6OiIEeWQMXDKCeDp4NkDhSoS47wopy6368S/XBAIarhTquwRd7oc8oHm0xJF7MmJ5m29CffvbjH7Rf+4X7bPPqRVBFNnNvaYQCNVnLVW3irsQyUXbi5Ck3hqxbt951w6mpCXalvtbG0edK86CJo5XAqZ13VgD3RtNAtVHUWnpktkHgo8xJKVBcOeMnKFsS70gAuZJR06WC2DKepGAs0WZDSgTpLBHU21Vf9EF184i3TYHCaqMQSxPebwqhI/D3fMi+QgQwVtngecqDrEwrkCKOBO2oIktmWcGsQgw8w7BFePDBWkFdnG+eQQ6PQt2Df75w/jx89iWcqdgUicmYQmpgbUXX0NCAjp2AXH7XXq61+voamiytDUKzC6kRmAhGgk8E/6Qt0anapVx+hfm5tnIpOu61K2zN0nlodNDIUE/PAJNHvjCQKJWV0KyxDSoCLtTjk5orggV3vtH61uPf4vQ9j38VoVU6cea8TnJofJyWaSULqIRTFN3l7XpZ8Et3A6rGt6j4hDUQ4HmD1FCuB+qnYGFQB/TRdc3SkOoImVW/7umXDi8WOfcJxk0lXImDPy4vybPbb1xnn/3kR+0X7rndFs2ZZTHDPdbWfNlaW0WRMQ3jRBSPk4T4uUOHTtjp0xfs5lu2on0gqyjvltpMCFd1/JQjn96nj0vsfIt31kfUQ9eVXEYJGmm1nytAVlRYHyGz/C+SoNSqN4FrCZjHZfWT55xWuDGsjADGJ4wmhn6rIiWLAS3pe/gJBtRhKArOdU9dNnGfa3qQ/05W3IavFYxMq0TAZGAJzCucxUSWkw+OSLRBdUkjIn8U9T0rMwsBr9QySGnW0NhoZ8+et6rKap/w6SB9LkG3yjt95QqUtbMN3ruLSdAPFe+CmKCT1gTXJFQ/dMK3fqpN4SF6S9dsSmqSFbNirlm11DasW2OLFyy0jGmpCM0IkrAlCnrQSuRaF8edADSCOxDqotWf7r9yviWs953f/yrLoYJt8e1HZ4xMe4mm3OlUkIHS7HeqogJ6iSNq5ERfHI6YAU76ufO/9FAsmO6p4wELwiTF+uRsB8PhyKs/PrgCgQaThzSJeK2W5igQUnxpKnrWOeXzcI9cDmuxykqhAOQ1I0dGp9XiQzvU28kD2iuFZ1hRVPs1nIOOEslx9PBFzqKgNg1QCjzVGIwhVpLComKbjg/xACoo8bbjLisIeQN1pDqj6SoEkqVMh/om9mKEAVcWU4CjVvMs74QliaXhKq/YPu+3Vi/arz74EUGwiclM3wGPw0nXBCep/hw2eiCCJGH5AJ5iefQM8FTPePeQomSgfGofw+btUSUBeIP2OWLTHrEVIorZ2dm2HY3MEBvC9ONaWHu5zq6ysdIwhEN+IrNnz4ZVCyaYDDxqWzdpG/ox+WuyJBIulpjICoT8MLGyBL28/lcNoD1xrFKz2L2gmM8t6xfa5abtduxcpb3y5lHG6Dirais+MbA83jEmN4IzstEL7UXx523/9ere+et7UmirqRlLKSxvhCx9hEZICSNwOZXSzNbH99pTCxkYUQ+1VlTAf6sxnLvyH8BKUHHkFYDpGCW5pyhqynMu5I1R/gt/KhCQNFMV8j6MIj+WHHNzM5Ltnq1r7b98/EH79Y8+YBtXLsKxJ9qaYRfqai4yy0mFi38Dedxph2i93hJtlxmcuroGa6gnd0YXyWGudRPRcc5mzSqGVUEQpHfAmN1Zp9j5EyfJTBpZ8mmLEFGIcV0Y1UUQTZ3g44jhbxLCCKHpG9f1LUukJoT3l29RRd8YU/OVEqAs9eodTBzBhzLOauiiqkfA9cSUKk5pwU97kfuZyjAZRb10UJw/6i3ZnIisaWByL92wwaajOuzGTO/6W+dyAjZQxelV5EG1JLiunCBiMfbsedP7Kerbhf92S2uLNTZdwWcFIW9Q6RW0ESne3ziKK6e2rIjKDSh/a6k2BRdvr2Cnl+mY+BH81FtFuWegypyPGnDruhW2fdMqW1TKDsCIGAOstB6cMDJMfFrM7/a/8sSloKL3/vs9KbQeaS2M2z2jdvgli4q9UxQroMgaCB0CMBY554sdnA40maal8wwg7AX9TwBwBvodndJNX8r9usKZFMLU526NCbGkuCU0v7i4yLbesMZuXL7USvJzQEA0C3iHNV1utsbGBnwN+j3ZoVoWxaTwPfl4kSxuCgidkVUA05EE+Ai2jEq0HgZ4GHfQF57bgbJ9my1eNNeFrXwQfPG6tXbmzTcRLuUgFPgLq41qnobGlz+daMLQV/cA46Lzjb4fIkQYWLnvNPxnnBzRo6HgwCn8BHBUnRr0ACCuzdCLOML74UrmU5O++GoXFHnb35Bi66IiZVrI5hSTlmxZ6NQVXaSVcAwPrDBdhXxLnPeOLOtqifabUR+EhO0YX+rqr9itd25ngtEfBXDwfq2WVEIZ+kTZoYEgHnJwANwAHsMYrBLR9qSlsDEoWo8E1JLaDEkxljJIhUfQ4/BMmBFcSUZonQ1Los/2m7YgQNbbvmMnbfe+Qy/tP/7Wbk++ET72Ht9vr/c9CuhSxpr7N9MVkNriQ0BLuBOwtbQGwooQieFmcITQGjgXDmlrOFC+/KlCEC2sZ/JAOEIwGLFQv5TUeASJLFu3qMLW4TAzr6wEfjfNhjHfdl5rRxVGNDUqxG58lTVxpqDfFVB8ctGrQTIfKWBVHnDyeGu5ChsC35hIatxr+NqeP3vBB6RsbgkD3Wfz55ci+c8DYVFLsqnPWy88Z92VNTYNYU/9obPe5jDSwpFa/XdEDlgnJePW0Khv47zTIys41yojXbLy4HHTqZfDhnuiTqG8oTL67SsfiOPwlQaEZwQnCYMS2ARPn7A8H6wcATKKAkeR8GYAinkSXnj2mtV22933EEhA/1nC1TolsEkFVgyPt8MFa97l4wBCy5Q/Sh273tjPilZrN27bYIXolYdlKAnfx3uuoCGpqWmwlqYB2JIWT78QCzsyPSORiPMMK4IwqK3qw1T2nJmePsOTsaeQ/D0JLZTa7XDV0qxDLFwEG3VlMmLqnHnzweTYqO+o6Pc6vi+F1sOthVG7M2pHX0KCdiotDPKXAmQtR6JbQlIHeuRtISUJKQzg02O4aYoZ5gnKa7ZrsIT8+i3tQnHmNAwgC23jxtW2YH6Z5aAXht7DIjRbQ3UDSAyiiKdkBdBzSfgV67v1aqtTXbhGBhx/C+qrRj2kJbK0dLZNI5hUPHI9URAt+A/PLS8LdrDi2VR2rDp29CQUPtXmIFAqZdbKLTfanmtP2SDJYZKhNKLC3nDJEBxhX6Gv3OMfVC1UMYUIqHK6NuzbtykLE5SNbgOpABE1bFwQBH0SAIvgoD5+6lp46H0h4vsTXg91CZaUixJDKDiyOg2MwPOS1HH5unXIB9EIxd3eBnnlBWwT5Th8X3TgpDGSoDnOs43NV+1Kw1U7deYsQttau3jqLDvxYpLQuKFjHxuNticff8r2vLmPJDlTCEdLtYbmJistmWNr1q0mJ0gRiEzkDgSlqamJ4AhkmromNB2p3v5EXAMyqW/mzJkgudIZKyPrdcrt7fLWCU5qp3o7cjSptf25yOXv+SVY/kDHtOV3bQGhX2SEnEo7NeBJR0y+w0H0gRayavliMMX/AQ1/h4YHhY+XTcC6NspefbqVDv+0EL3xTTest63LF9nsWQUOeAV3DuAx1tAg/veyZZJrIgXVk1NLp5ggNZTDgT0ut84EYv4G7ey581bXUM/SO2QLsGBVIEm3tHTb7jcP2lv7D5L3ohG+e9Rm5Uy3nKx8kikmW3lZmU0BocvmzbKUqXDQNKylrs5OPveiRWHKZYjoUrDsupaBvqiMcChEPuWrFqulfuu3J3xkVfC0V1wTFISU0gM7rwyyCU90XY7wcikNrILitQMWRYRAsJWaTIEGmhSBY5ZkBCYGk0liJy91yt0PgakijnH+DTfZko1bbJDYw9aWq95G8cbykZYLLIW9XmKikTu0S8GAHT5y0vbs3Wdr1q4GXi02t6TEjrzxjH38oTssJWOWjSZOt+9881E7dOSI3XP3vbZwyWJ7+tlnrQnB8cYbt7FVXafV1daxGrbC9/a534iie9SnZG3LwUTLyZzqW90VgdAzieRW5Ex+QT72gEwmB6o8wRR46IBMcowTADl6L2woyonvf/xAFFrVdJQk7JpRO7IDyN/BNPVBEKD1cgFWgxseAXJHzsLr0h1TPhokG0cCT0SQKy7KtXWrl9lm1DdLKmZbJpETo7g6trc3IVz0Ex0ygKBXi874ODN/jiOK0MITseubHsfGsOc1cXFX2TH2zJnT9vquXez02mHbt98Mld8E9Wixf/nq43b6xFn5JbF0DZD7jbRfMxMxvuRZfhaUmsBYLatJmKn7BsigRNvk/zAtI9tW3XST7X/lZRyLUFGhNRDAkpgA4QoU9FIUlZaJt4RkBnsf0j7OfWILeRxSwQSXkCgZIGDbEH7piJLVSFviTvm0U3Xonw6HbQhHnftVCdJCaMDKlVHKA1n2j+m1woqFtnDFSuw84whzbPBJq6V5UPvE9ugp6D3XmTi84vTps/booyAmaRFycD66VFll03Ggqq6tIQ3DILrii5YynG5XGnvhrZvtVz79CSufV4GW6Ip1tjXZTZs3wfq1kwsGy+JApxXNVEpfEHO8wPugvmuCp7MdRzKTWOmU42KGrLP9Clt9NKIiPAvM4624eLYVoGbMIkDW+fWgd4+Z1b/hXf4B/lzHwh+gcMaq+1YwdK8AwqkqLp5R/JwQWpRHfKEq9G8G1rdXYHA02OqUBJNpidGYmmfbto3rbANKdjkCJcAzD6Nm6+vpwLlFOd6Cbcyk0D904IDloUpqaWgiKni6LSK0XXyf0mIJERQV8sYb+2z37oP4JJDAECr74Yc+6GlsX97xqu3df8QzgiYTBZ2RmWZLV5bYsoXllgUfqWQy4udiJKwIYfhoqirzaAK8s/O9IEFnXb2d3PWGtVRdIoAVjzae1WqjA8Lo/dNvLf/eV/WXj/YMD6V9gEK7A2orXbXqDiYBgiuILEcnbfojOPqzyAfiW4XU6qcotNqn+8Fkgojwbs7Y7RYBGRhexVydVFBkm2+9hRQHGaRbGLWDBw7Z5Zo6m106x+bOZRViH0WfAGhbTp4+SQzfa1ZZXQ8iRkFF0ywLNVofLMq69evsySeewOfkqn34zuW2bPFK9m6kzIyplpufSxtJGi+1XlOzrVmzlrGlz/Tv6OGDtmDRArc+uiDJxFVG1l52KJhC0HEKBqZY/F2GIA4jivjhGUXEK4RtAHXhEM5eOahOy+aWsyIldoJfq5kc5wXfH+T4gSm0Kms98NihGSvu/jpk5L9oJJ1yaGTBBS21EoJ8Oaazo0jFUm35IIOAyfC6KwjOfOC2G2zN8vk47SQzU1GhXWvB+4us+VBmhdI77QeJkpWqlnrKyirs9NmzOBLFedJEDMs+OfRdd/mKPf7EM/DXvZaTncdgt9ndd91urfB0X/vql11Yyc3Nty03bLN584oA1DSQkX21SZ8VPRzkjlOUtiiZEEWRHdqdKiqO/BkglPiBcah1Okvj6m3b7ehrmK6baoN+0+0QIR27qSM8BBdNbCGh9MJCeiFjNGpMsSPhPipheX0HSBpccbjqZ6RKEQw9r0MI4PVr0qDnHoan7QXITRglMuaU2ppb7rB4AgkGGYtrIFImpv3srFwQr8WOHiWoH9hqX/NLlZfs+ImjCJBk1uFFJfh0FBQWoYvOpe9DLrA1wAMnJCTby6/WQTVnWXHpQryRlFwSIw1w6ulut5KifHTw+FlLqcWYJyfFekxkQowyOqnjMjYhqDIpGxqJUsdworHNgQrLailYJIDY2tUrjlVEAukxjFvK0lo0s+Tr6RnTf2Bk5mVgxQ95REcN/9HYeMx2eOjZavB14GsBCxZAyU0SVMYxbKQR1bwOqnrXzTfiRL8Asy/pswa77UpLnTudS28paTcF7zQJGYrSUGaiEydPO4W72tgGkGfa5Qt7YRXSeQM5LqDKO1/Z6WVWrkQQKVtgTz71rFWUl9ili6ftcn21rVu7xBYuXGAzMjLgTWORyC/ZhXPn3GE/G7+FHCyE2nReSEFDRQfdEBIgtlSHJGocchHTRhmQeCJAVtxzh53Z8YJdPnfW/TBkwo4WgjniBdgXoB34Rz+cTwWBZHAJ8B1kFhcSQc7wmys+oUKk1grkdeqb5z13htrJIbO4n/NbuULIgmeNxDlmzC21tbfcYglaPWiK9Oyj+JbkF8zyrTUKoNz19fX29JNPkCJgnxXAw2ZkZoJEcbYYXlj5rUtKSq2yshZhLQP+eJG9/PpO6+wbtdPII4/vPGafLpptKdEkqwR5xRIpAUxHXIdlAONRGbxoYl5errdT0KBX/jcZgTAV99hcYKWYS/HXcl/V5NS4C/pREETtpMCUZ9VMsKutrZcuXqr6I6/sh/ijN/5QR1/DxZ6kvLLm6OjY+8CEyNBEqtBoQpXlTRYzPkgAZoH91sc+Yp/+0D1WnDsVfqkO6tnI7GOjHBxe6AeqnKk2bdp0lqEEO3f+kj379Au2Y8dO/AqqoQ6kBmApa2yuh8J32fyFM+EFp9jefft9Kb/ttltZRmeTx+EVWzh/ni1ePM/mot5Ln5ZiK3FjzAEJtbwrFi6J5TwZXwuaBr/XiUYEDziEUfHjfgQY5xRDSCTEFjs1yrItCilki2KVKCK/RS+8YtXFSny3mAZQXbFefj/EZirUT31clRdBUJ17vSFCcy6eVtEsovaqQ+/SM2E4l5A+qFsIDYpIG8HQjzDheijXhMBavHC+3XTnneS5Y1VD29IN39zHpJdz0bkz5+zVl1+35559wQ4gEIu9KUAIW8Azmzdvsa1bt7lGQgaSeXjiHTkMi4ZKdCU8eHZ2DtEvh1HJ9TEGTUyCPAS5IoQ72CnKu0cfxhbtUqA2qg/KepoInF27RduvT1qaz+EpH6DE09jDRrAQ++P94rfu9SE7NcLGNNRd+exHP/6Jvf7QD/Hnh6bQqrv94JJHM1ef+BhIfbuMLWqS0ydgTldZjsZty+qV7rJZhEN5T1OjVTdVkaPimmXC23WiO5bQpcG8RAxcNYLfVdRFNfCq4l9T4OUk5WvP7DNnLoPoJ+zOrYVwOuhT2+rRRJTaLCiMKNmJE6dA5HLcIGdDbUetEUeklDT8Mgg2VQZ+aQASoULKwj8NVVYhrpSiDEGqWvUmBCm/oBK+XyDPKGdGDOq/GvSt6l8BbIeSywwQBb1syzYk8qm254UdNpUwrVT4X5HFIAGK6lStPrfdf8MFRa0BDLqEP3fTZGLp0DtjQDJRZPl3yPIq1I3c9ndDIziYUJoIsBiD9PsaGqIOWIPydats/ebNzAzpfBF6oX7yb66VRxupec+cOcME7mOVSrSCkhKf8NOnp0NEprmpuwG4N+GAtGTZCm+DEE388HE0GUuXLrM5M4vsSm0L+yMm2a69J23NinVQfrGX+FRPm4rR5HqyyGDiQWMjxEGtDn+HiC2tl67p46yU91CyAH2jA9MZ81n5Bd9YvmL9k/Yrv64qfqjj34TQZp9nAt73edxJV2NoyFDjfIllQOLihu1m1G+/8sEHLREK8u1vfcdWoeCXsr8TqtHYeAoq3ershADn2gxi7oQ82fB7M/HflXJfy1gNVqKjxy/R+Xgk7k5bw4YDEkhiY2WYHkU9dJXJPWolpbOYADjJgBWyCmdMZxti0q8GnGxA2bQaCM5CZsDpLp7COgkuOhzI+mYiyUGoD+p2AIFUE2v+/PmOKNGRHWDFiJSvWW+J6Zl24LHv2FU81LT3dzLalhgmjnQI8qcQ/ikIVqbsIdgvj8AGqYWcEqB06L0SouXcJAudqF6Y3T68rxarv1KxEWBubbBpg+zetWLbZpsH4WD2OcVUOt4OAgkgdlZObripIO0tt2yDWsPmgYRS+/Fih4PvJADynzp1AsRdAvvFzgPSpXO/ra3VamtqbE5piT147+144lVbA0lgqmtaPdXvVOQf9Y1G0T94X+pVP8JDyKtzwTrYl/H6vbDMe317PTbeiErvD6dk5pEj5oc/fmiWI3xF35WzDWRaolOxN2nH1xhmXhYahoduWW8fu3s7Fr0e2/vWHihFHXrKZoA8bnPnFCNtF1sBSJmfn8fSl2dz5s7BqjTLZqGuWbNmDSwAg8ays337LXYEIaa9HVUQ5KoLyXs5eSPkt6s8F2IL5O44FXdM7QwlgVSAlJ5aGgRRPNG6kDLEyBLFCDhyROCrKyroAwACajAlwCiDz+7du10vvGXLZt4x1ZFRedWECKKivM2m48yehzrxzKULpOW6imM/4Ve4i4pSgbJBbCCD7iZmkFpLrO6JkjpCc0+TTgMvaqW2a2WQ4Uhut/I60z7k2n9ciR57IRj1WD7jczJsE/x8KQGrY0z+IWDfi3+xiIMCdFWPzM/SgzeTLkwRKzTZqapkGyGZzNAXKy94SoXZc0qZRLQXuDVDsWewisLA8nyvrd+wkL4O2/GT55Ft8KXBHbUYl1MRAvmFB1bNgF0SHNXH8FC/dE1lNF469B3ARz0XAAKWSpshJcNPkxLi12bkFr0W1vHDfl9/+w/7JOX7smcfQ+m1ODZ6dG4R2e8f/MCNdssNaxlIs9d2vmLzK8ifDgA3bV5vSzArT9MWapJqWaK1u5T0zIppE1IWzixkj74kEGkP8WqpWPdKAXyc7cIipQGVILmQLD+F+eg2IW5ygNIAKJNnBgOg9LUCjvheHXDBDjwJd1z2334jAkQhdnAE32qnKLy+r2BdzAZZJVSGAyTthxBTLJFYHQ2SkCANNVgJlsjKS5eQ4huwXOJ1BsVSMyS8OVVmkEV9NLg+iLxYg83M8Cb4wHNHApLKie2RA5OQWlvKyeOsBwrbDnuTXlJg2z9wl+VBADw5DvVIHhCbIX9nRY0EyKO+GCyH/JwrYbemAd8U9y9XZHrt5RoEwEsYUdaCnBSkwYJpY2MzhAYfabROL778kmXl5Niq1evsSt0Vq6ussnzOkwk364XAdOGVqMTtYqOkrdB7A1iLQtM1VQvcnACF4wFeC6Hl36Jv+Z1I/y5/j/7BgW+MNnX96Z//4z8GdvZggH6ovz8SQhsZa6ZmFb01ryz77o/cd0v6plWLfOenN3a+BiXNsgqU722tVxE2SkE0qcFGAH63Xbh0kXwR11DbpFluTh4O9tPQwSYRtHnWerrIA8cSnoEWoqikmOjlI1i6Wn2SLF1cAUuSj8Ck5UyO46k8i+YDwIAi3nHny0BMfTsC+TeIJWR1xBZFCBCJK4DZ4U7bhPT8ZiSmwcelonERNRbyitfXgDlLwO+jR4+64CJ3S/DMKcvs8nJrartqrSBKKkJPrCgRTVKa3YR4kEwv51wTRNekvhOpFtJ7VA/LfRLClNog/fsACKW9xYdGE6wd19RrPDxvwxrbjFoyDSFMPLZwphsBTryyzM1CDB2hf4kmc3Zmtut8T58+Q7RMt2XnZHtQL8iDzjkbYpKuB4AN7BpI1nCl2QU2TbLnd+ywEwiVs4qK7YZ1G+wEIVyi/iWlRbxFFNrQiExn7KQt0psD+On9wQHi0vcGJklj41XeTVQMN8RW6Z/YIDmOTQOZgXsjar9P5pQvaoo8/G/6+tEQmlf2NF3s/MIf/9+VKxdXfCg9JTWq6Uo9s/mybd58AzxbDBTiFBSXPG3pyb5MKSI5A7WQ1DjajEdKdnVSlFqO5XPmlNmRI6dQxPfbspWLoU5DdgL/WKUE2ERsYG5elgslwkAhrUzGGlqnsPwSQih/ckAJhdQBZdV1UUuxNLLG6TzYXgPkj7AmuqYbqisQfESNxbtqtILl9BppAI4dO8ZEzCUkCfsS5UXtk9CplsFrtyMA19dcxi8FREYuCOxywUBrS2TxsTJxB/wi10EcvUOIrsBWbajZi+ZCaQb6kDtaYDkS6PPGu++0pZs2SC0SJIUcGbFKhOnGhhanrPHo1iX4jaHekxuuttPQxNdEzC8osJJinLDoh4wZqbR1GoRARiVdCyir+gdC1zehESJdQVmpW1lPnLqIn8tpcn6kosufg1xTY1u2bkazMQXWZLrz0AIPIPM/rgAF/jpEaCTwDpPo8rlnX8JYUsaYyy9GRaXrH4HlSRGbNTjUP/hQ1szyff7gj/DnR0ZovfuJRx6o7OvIIjNs7Ia62lrLzc2zPHjkTlwY9+zehRYCn2XC3llDHdFE6UahfkJIp36cK26ttbXV/S6OHztjhw8fsxmZU2zZikXkCD7Cs6O2iADXZGUIEkPBs+LhxMKI4gopBSQZM0SZNVFiiVeT47nUYLzY+Uh5rAkJFXunOpwFgp/UoKgQNFO3nRqrnSEbImoih3mxOQsXLnLVl5xqRuGrRWWc2jNZi+ctRDAbxGRfT45n9OvU6ysCE8nZHL2bj94j65j0t6KGgoPYlWH44F78H64hOHRCxQrWrLBbH3wAk3BR0A+QrgN/5ONE3OzCGb6+5qpdrr6KkakFQ0q/JwgXcRCSihWIpf/yu0nAUpqJ3jkNeYMGTcgcUrOCXoyFYBoDQl+FbYn34FbpqU+frEXdOozDfTO64QbnvUuh0DKu9uK+m0b0uANXteAZqIVHQrXeocAKpRirv9xqTz35HHs3TmGilHhxKXyvwSbVVNco7cHfzV20+q+p4kc+fiwI/YUvfHf84c/+1psd44NL0lLT5kq/q5l68sRxBBu1PwrBjVwU+LoKeFoKNTs1q8WbSt9cy8xXFMSsokLujdv+fUft9JkTCI/Z7nrYgm5y8+Z1IBXpadkXW/7Pw1ApzxHnSCzE5l0RhBF/0Y6baBPWqQzcGQNFmFBKQaAgupCRSTWAxsDbIaoiRIsgp+oRQguBRT2FIOqJ2ijkE98Z3JcjkcL0hdLeO6ybc6CwvWgFLhJyJa08FJ8ZI2uqkFcl9W4JbbLKiWqKr9Uk7IAIXGFyD8FWrL7nLlu7bRv7qSDg0Ve5rmr/xFNnLtm+t06wV+GIBycoZm86QQrS73d0tLnw14p++Pz5s/DVuHPCZjBH/XD2jL7pCKahWq0RCsai7nKTtzUTE3gqvhfS2Z8+fc62bdsKZd6Ew1ErSIgKFt+Nffv2wrt3waJMdzWh6tYqI1BpEkuekTddc2MHCoIDsFaDnsxc79Je6M8//zyW3se+8du/+z9+U5f4/MjHv1Ft9+73Rs2ZM1hVdeQz5HxbwE5XRfK46kRbIONHIOT0M1sDHk9PC6YCqFgQLeNH0HvedPPNIMYgbEeJFRWx5DXU2TNPPYOFsJDlarYVF+Fji7akD9XUED4fApqzByAKOMe5qLQGSC+QnsHs5Z2v2kdyPoxARMiQ+OGoJFRwI7Yfa9n582egRFMQWBdiZi3yXajEjowxoUSxNSDX8CCTwDUXbYx0qNKmKMezJhJj5SyPeF9lIJUxBFLH5kAxtv6OWyyOXHnVCLXJDF78MPGFTKJYgnlVh3hoUf0R3qUPPqvkohs0MZCFq1bb8ltutbT8fKfi0q9HxUdDITuAx+t2GeqfDtswgO9LL9vQla9Yil5+Fmo6/FOwsgUuomRjQd8vGGuiK6pev8ViCERidbSiOcsBOutb2pVOzOVJo0mMmfZm6bc7797sNoIdO57HIelX7Zd+6ZcIu2qDQmPwapxjTz39DAJxjW27cSvjy97jqkuyARM5nv5q0gtW0hS1tLbDIl3FZlBs548e0oSu+cVPffz3Hn/6VTzqfjzHj4VCh015+OF/6Pzsb3z6GEv5dhTvyHxpUA7Ss0pgQashnW4QYgUgCZNi9ElL1YEgcsUpYfm8cgaE5OFYvIaxwh0/fsI+8YsfcmraBSUYx694BM2IqOtUHF20pIqSiryEFFQIrc3fda+6us4ew4usvJwcyHmZDCDAxjDx5S99haWVaAwm2+rVBGmSXKYZ3vdyTTUrQoFPBlFS8ZSHDh7xpXEOEypQtfEyDqe0vEtme/Hx+tbGSJpE9I7tKkatmIkpfbS817Q/t7M+TBQhlJBa+mcJfgrnh8bbMFa2sq34umzfjj/zVL+uNsj6V3Olyf7l64/a7tePWdvVK/hLtKJFmmU3bt2I6rMUfhhnLSaLp0TALC3kjcP3OFXmfb1QcOJw+MD6aVUR7y4EHAUuYp+acQBTGFUUbc+GQss3IxFnsor5C2BpLtszzz7tRGPBfHJ7wKOLhclH9VpdVQXBmesO/Oq/r26sZFINagUeH43BH+eUJUHQ0pCdslgxdu16vXHRwkUfve2OD/mGmd64H8OfHytCqz0PP/zF2l//zKfPJsTF3Y06juSdgTw+QTkH4NXYT3VgoM0OHzhlx3GsX75ilYfPl5YWu4OQ+JSsrDRraq4CGS7YAw98iKQlKxgN9LD1dSy3b+GMlAuw0QrwTtdzglBigwMKhBEBqqBl+RgBsTPI7LOAPG9yM93LMtnXfc0+9tEPow/PZoBGYWHaoNh7rbioyGZMJ8sm1F0sRQwswClcK3tYESpIRhONPlLLqe6JwgohheRCaMcXrruIKGpHW4Wos+aQ/w354WJlJQYOIprxJlNeae0S28+nByGwh3rHsghsuPs2W7xyHWs/umhngeKg/DH2+uuH7ImnX0Uvf5otK1BfLsiwm7avJwBioSNVAlRZfKvygThABBOen7xiCcnEBoZCrqgzMx8GTPwBnm7dI4zHMSthErZcbUQOAjb8o3vw3wm4EixHoEuxN1573VfUwoKZ7kogwiKeW/JPDqpOpRWW+k9qwoDtYLIzWU6c2uPRLIODmLf7BobqLtc89MlPffYVmvpjPX7sCK3W/dVfffHib37mV/EKHN6ucwFWQaMBhWOg8Uk+d64W6vkSFGabe13JAFCG6ksj4kISM7ysvAw++jQupAfJfrmUcPsZNquw0A0vO2EllNJ2EPVTklwSGUxRB19WodCY5e0o2pIGsiMN4Fa5ccMmD81X7o077rwVFkS8HsiFoPfGrjcxSCQxaKtcL+pSP20WkshQceH8BQ9bSoNqanUIJ6cmkyM3fVOb9Ql4b66DzEHEOiwE7EBWbgFIDe8J2yCLnJC5i3f3TEm00tVLMJTcaTklRVB5kEhbmWFqrq3rsG898po99cyLVlNznnRm47Zt6yK0PevY4aoE9SKTGqFLfL20JppVDgPYHiDubQH6iBP89hvBBHQqTpvlfxpNrONI71V74fm9VoW8sZq2iGgUFrJS6dBM5b/M+iW0b/XqVdAbks/A68sdVHXJBD4NW4K0I1exAr/55h53/MrCaV+v0WrZ0FgLxY4Clo126VLNH/+vP//f/xS84Mf79yeC0GriX/zV3x345iNfy8ScvVKWPAlEMpC4QMjOUY8++owP7B133YWA0YEEPJUZnukUVsu3KK0SnSxcsABe/BpAuMh9lPosy5lZGe4aKrVfEQYGGWrCwRSSSeesdeAswswo3n0Kyy8qKrcz587Yxk1rYGlQb1FuBKRT6lltfHkjPGAUk4A/PC9KDEpQz1TYkXwGV3mXY6CcKSzhQp5YykqfCv45Eum9+iWE9vuwClKb8R9BjuSGM1ieS2dbFaq2WgS2KHaJLV+9wjbce5stWrcW3TJ+yiL/rApdA+P28msH7Mtff8L24SzEdp5E8UyzD5K3WtbWtjZ4+LhkksTk+rsktIpo+O6wjqhCYE0oWiSEYrIrH3XAZgQTTzeUKm24u96qqmvtO0/vtAUrFlv53BKnsilMFPdGjPRLacqEvPHw8gqGyGYMZP2VlkQTXBNdE1rbOEtAlfO/krAr3Erm8WudLexqdR6YpH7pr//24d+j2h+LEOjNm/TnJ4bQX/jCF8bPnLv06v3335mLhmOZKFngecYyfuaiXai8aA999EP4J8tEOwgfVs1yj78yVigIDFQc/hIAJjG7F8yb5/FnysvsUR0MoCaJDBBZLHNCPg2oHgSfQEoBOAGzL9sqjKD8gtrt33caP5AZmM/nI2iRtotyUhVqT5SVq1dbLJTYfQd5VkYG0ThYS+dLZbzJzMjDwIN5AzWbdrkS0msAKeYIrRdrkkQzsNr0PlrpC/jdiwptABYDnz2QNsPyS0qskiV9hGX89g89YOkYN6Th0OSA18DEP27//JVv2yPffcp9RPJyE+yeuzbZffdsJ5NpOryzNuXEmIGsgV0JBMNWq4kl+Ko9OmiLiIL4V23u2djAfn7AU7KMVKf0EOEYfp9tn9uu1tju/TWY7+vsrrtuwhCT6UL8qy+/4hqiNCE2qtJYVjPvoVYeeG81V7AGpTnXR7UKbkxeBNaioplu9NEOudOnZ0I8Bu3lV3Z86Yt//9XPgBtywv6JHD8xhFZrOzo6Rn7v9z+/g2R9uahzlklV1wX/+vRTj9vWG28kdcBC1Fs9DBAZi6qrbd+ePcT5sfNTvICPwIeeeVzCFCquNCiadNkaOP2TuVxLnUyrLngAWQ9J0mzgv8Avanvy9BGixXPs9Z37bdt2luoCwvq1UtA+bXKZl0++NzQbVOvXRIWEpXFEh48gzDQ1ttjJ42cQUE8jpbfaRfw2Bkgino65XYnOxT5IcIuGCg1hBOnEs62JZfdS1WU7iaHo3IVKftdYycwSp0mJGCiWQ5F7Uddpj/EsZAE66mbsrv5R+9q/PG+79+y1GdlTCUxYbp/68D22YE4pFtQeR96CwiJSe+W7n3dsLO6wYJVz7nRACKYVQsis7TGOHT+Gy+h+F7gzWf3knonc6B2NY+Xqbqm1vcdq7IUX99ndt99uG8jIqvAoJWKXV+QphPKXXnyRRDLtEBC0NAj2iUTyeAicXgacRuHD9e3WQRdGA/mBiwji+cSCXvE2zpiR+aWZRVM+U1y89CeGzHrnj01tp8re6yguLh6orq7+zEB/zzhL2C/v2vOmL32F+AswElBcjAlQ3rVr1+B83mh/+8//x7ZuWUFqKhLApOcBPLYfA2jyQAsoKI8xeNJBy28hFuvYWSJampqbbM3qNZid0ZBARUU5tHljS3M3vh6Dlj8zhSBOaVYkwGkfVlFzaA71iGd2NkPn44nw3c128tR+kOGYXSSbzwj58LIJqM3MmgrfmILm47CdO3sRy1kF7E4i/G0NiSIJisXP4/ip09bhIUf9tnrdOvw64m31imX23DPP281btxgRGDQhFs3LAnj6Kt6d4JqFM6gQu5gMF86fI9xpgd1+9zabyeQb7emC5er0hOmpTGKFnrl2graKfZN+XQKeYKJDKxWExF555RXv1zraMH3GDJdfKIV2EMrNqjI0OGZnL7bYzldP2O13bLN77r2RCUlkOjlRxB5mwv9+9OMfwx3hnD39xHN2+OBZZIwKDCPEfmIlzYBIjCrPBxNE7KFWSe1XE+bviPZ8JrG2aPFiO3bk+D9XTFn82cItv/gTRWb1/ydKofUCHQ8//PDIb/7W77x8re1q7quv7FwmHwiZZHETBHhSZ+FdBhDnlpXbheo2e2HHm743oLMRNFH+0eKTNZAaNlFoRs4ps/jDePwFuvERqbyEJgFDiQRE8X/yx2gkP4V451yQ443Xj9i8+XM90tgtlV6XWhgeMBogSjuGGxk5pEXRJj8zcWyfTjqFHCT/IjzNpCPXfZnqd735lp2/UEVSlkarrW9G2MOiiIwwBuWW440i1ZsbKq2no842b1lJnan+qUcN99KLOzxKpJooESW8iYPi3n7bLcROJvs2EMqKL0FahiGxWNKLi8CKbwdbHQb6qUNILaSSbvvEyZNoKUiOuHIlqxpO/1qRKC9+flDPsfzve+sgOvr9tnXbdtt+yw3UB1RJkuPqT94jOEtTk1eYRTDAUmtr6bMdL+2xA2QQVfCF9NXp+FUnQUC0QrAu+LPa4m4c1Wgnm5PKTwVL7ZcWLcv/jaj0WT9xZBYcfioIrRcJqc+dr9wBUuTi+7ys9nINgZhr0CsrwxAIzVIv5Fy4bCU62WR7a+8FO3D0Am6MODJ1Ilxk5hCVjZsoPKCotXhc1/3CD0sCVxTGDASQLijaFTQb9ei2xSvPmTeX8PwzIPowwpSySY3bsuXLwAAGmXaF3nlqoxgVqbDSyWKah0pvHsG8K1ZW4G22yFavYX8RHN7nls1F3ZfvPidlZWUsq7lE37CRJuoqheor3Eh+EkLCtpartgkH/EN7d7A/SQksEttVpBSyd2G3/c3f/o2bju9CKG5EB66Ag1tlTEHr0Uam1LRURdhgroa6JuNz4Y7xtFC+KGqzEFS4CRY6dXZ1Jacqp3wXuTgC6ZpjJtd9NeKBMQhJM1qM06fP243bbqN/C7wO7W6lnB784b/QWQeWSepLxCi1hFwpc4nvlJ4+iyxUcIoEBnRgtpb/daBvlp1B3nrHT54m8h4CU1X9JcLEYDMW/1SQWS3+qSG0XsbSPPLII9/e8ZUvfzM3bUrSsjVrVznQRUHcGQjDyZQpSbaUUKqVIN0MhKjUqRnkiOhC96mslPCA6GyFOBooKQVEUZyv1oSAF8+E+uehlZCX12WiTeqxTGVmzMRVspnlOhUeGBM7wlEZfKnonTQZ+kholRRIU/yQWTqOd2lQdcgvQZMuyBrKhAIx0GG4y6gipUtgkdLh6WcW5tpaUjMMMtCLKhaQNDLKDux9E3P4dFiIOQhcSW5di2FnoOX0ceHC+XjvHbZZJYWsAqmsNLiBknxd2hsZpiTwKXrcEZj+SrCTsOpWPhor2AlxJRc420E/pPUQkYhwIY7T3gsu8Fp3051fMR+2IZ0JII2QWC6oMxTerYw+UwRbUeoANlpBM7PSUaXOwZTdbMVFc9DtLyCusIeooRMe3nWtnRWFd5QtXGSFpbO/WLFt6+cWw3I6AH9Kf37iPPQ7+1EcdPAz/+df/qEBn4j/Rm6YRLEdMSCrokTkjyAVkJb2ObPLbP/BQ+6VJ+KpTJgSYOTvsXihtloI8mMoX3RgMBA/h0USiXtqOjs3ZeZClTtJPFOJimsmuu8qa4faP/LNb9uyRfOsMBc1Id58jrMBPvtE0QXlSW6GL1+xfAUrghypdItCmkT8GYZNegsDTx4qrDyEn84u3F4RGhXRLD2s0vSuXr3R/ujzf4lJPdbe3F1nC+exLMd02EL4SthoePUG3tEAAiq4NMvZryx2HFCMpVaubgRBsV1Kb+BOVvRTVHAYViAUbFmnroNYfQix+PpV757z20xITQSxBQDKqbkIgrZRc0R2hmbSg/x03yWvgUcYg3qyIB1Ahigv77Xm1noX1Bctmk9gQ5yvSlFxsYTVxv9BWUnp/+ZxWvTTPSZB46f64pEnnnz2tc/9xq8dBZZbSWqeqjAhsRMaEMUbip+sr2uwZ59/iutDGFFwQSUipnBmAcaUQbuMV5+czpVXrQmK0dTUapfrmgnZOk2eictI+Kc9WKBL8Ys4P/URbSGKHfgNs+w21dsSBkKBBi5UadCEEAy02iCjjZxvEhE6pUsVlygqJ42KkGAXXoRyn6yYPw9+Gg0A71AQ7q5du+zM2XPwy1stFYp9+Phx1HbDvA/1IbvELlq8HGpc4oKsLIxdOP8oqYtC+t0dEx23EklqQ09Z2iQLiOIKM7QBklgKOfaozX6RLzeiaPhod8h6BCyJWswEdIorqx+FecgnJhXqsvoSUmLvIxe1AgTP62mtYEJ4eSbG27PP7CSt7ly76aYtrjHKycsgzRo7eGW4Hr2J9B6/MK+47Gt68mdx/NQp9OROFhZVPF9XffLDrN5fJSXULEUWj2AahmDbQNSgvfLqDoSWje5QHoP0LddQDXLp3JmokvrdZ3hwMEAAhR/VVV0CmWvIYVdoCxctRrsxHRXUDKtChTaCyXXhgiEmQCPGiULygTTbvoMH0Khs8mXXNQeghg83SC2vsQr8m19+eYcLVnKH1aDKO273rt3ogZNc7SiNiqQ0Zdrs6e6lTX22/WZyeBw7aiVM0rbOBusZ7PBVY/f+AzanYqktAvlFnSsqyvE3qSRJ5GKQeZqHUQ2ipkxLm4b2JxGtCfpsWA61LdDySE+hf1LNoeGJRgADSdFuepmx8YA1mUylJWd0QemrqmqdxRkiuJbSkY8QPhAA6RqIDCsFguuaL0X8FV8n1wJZXmtrG4hBPEsM4lJvj0Kz5F8jQRdTfi2w+UTFnKWv67Gf1fGzotAT/f2Lh79Y89nP/epTUeMx6TGxCYvH0BBMxR1xN9qDqupLdvP2LQBTZCjIikl6dNJ5jeGZxubwOPYcOVJjjz/5Iv7Bx1nOR23x0grbciPUIy8Py1StffM7L+KL+5JVXbho+fC6M7G4aXs3uTzWMUC9qMoKCmeBFIFnmAZTlEwm9RlSd8FjikcsJpZOSK6cEoMYgpYvRWfrS7jQSwJqHJbJM75/dzH89De//ag9+viTdgxf7iusJkKKcZKfy5J2qfI8lrTL+IkvxE+C7RoKCogmURbVMbQT+WhnprFr1YA99vgzVl7BJkdEm8NUBZQSBI+GrWpp7rJTxy7ir3walWUjkyDZneVFZYX2wQF7ge5ZMZK7du1hAi7hTkilhcCUEiLzL4jogfKD1Loi9V0Uvi/kbgB5o9DkVNojj3wXzckqKDL56chRN47ZXCve2FjsU6OjiR8uLZ13LPLin9nXz5RCh70uKlpczT56n4aX7rDo+E/t23coaT85JBYsZDDhEdFEgc/41bb12Ks73wR5T7mDj5yKxIMuhnV48P57bREClhyAXtt5wHbj0HOtawCjMRvL46sQA/JfPtViVzNwnMEBKSm7zIoLytAnV+IvcsEDd7MwPohSagsGrQQSxpYvI78HgqaskjK1K95R11j5odZBzg6htCxxYm+WLltsTfDSXZh9lV3o3nvvt1d3vIQaqwPEGMH/90nraG+x4uJZ+BjfbMvQnFRXV3kYmoTdN97cTb2GnDDXjjKRMnKm2R134BID9sl4IfO8cpccOHCIXCTz3fV1Gls6JJO2YYC8fEK8ouJSWJVE0FIYy9YihEjVYnI/fvwkWo1llJMPuKhxhDpTRtZRlY+Cv5ZufGiQTZgGRjzcTLKLWLES2iQYtLTXW0VCIdcI8R+N+vMLF+q/sGXLlp+q8Ocde48/7wuEVrvm4E/N12/+09//00vnzl/48pJFS7Kl+7Ux5awgPdThM/alr3yTCPJ2S4M3HUDN1dfXCSJ/wO6/7wPW1dFnj3/3ZdiB/Wz+g3XKeXGoffqYLVmcYWsWl7B/dboNxqVYexdbrfUo6CCVKPSNnsVHTkhabatALiFDBvpjxRQqkFd8uxBcSK2M/FqUZSBTeY8mp339DL4HjIIQmfhtKB9fN5v2KGuqeGyxAZ3EUV5t6mHP7zTbsuUm1HgZ8NsXnEeW4PrEU0+A0K9D9ZLsJlRqV5oa7LU33sApnj0VMarEgGinT1WCZMftwx+6D2Re4Cg7DqvR1d2CqnM3Znl2qopXG4WswWqjHBxLSFXwyCPfcpZuxcrlzqIElJlOgMzq3wgrRBvapMrKarzq9qDNaEEn32o33LDBeohbXLZ8JQab52zLTeWwVi21sdHpvzFz5vynNX7vl+N9g9AhQD71q596/stf/vKNTbVVvzuzYPnH5El24WyVPfL1b9hq1Fw33LAFVVmjfevb37INd5IydskS+7b8hN+EIrd2Q0GT8EeYii42zmbPySGBSqmVFs8kZe902AcWbliaUqi9vOvEr0J4bPbcfC3oUKZoW2TzfLBFTTXI8sYb7wtCu9TGcbaJJXWNU0oe4IL4S3Fu7GsCxVZcXyrpeDes2wDynbfjIKx4YAl28t6LUiotLHw7d77uZVevWom+tsr+5m/+1qpqK0l1Kwo5bM9jcp5VmG/tLW124vgpkOgGu9rYTjzjCfvkL37CioqUhJxcH/DI2jBz7963UG+22z333Ey9BOEygUSf1T8189577oVNWsmGScfg1QfYioO0wQi+EjrVV8kWOxFo64hR7CSUS0RE8kx+QSFW05O4KmwlUrzeOrpbmVgjTzdfq/vNtUs31PCK99XxvkNoQeeTn/zkmdlmn75l37MvDw0P/Bk56bLvvvM2u/32O+0CvPCzzzxqswq0uU+Xfekf/wHqOES8YTGOTim2ehXqONL0KiJcPglydVQs4BjIGhUnYQq6xGDLfVOcppBWjuziLIUAgQCkMiCqUzpy6aFVUYYjqbYU1SEdryK5Y3DzFNqovtOwQcrbFo/Ap3S5G9etR6B8hQkxgK55oXTwIFyzayF6SU5ZVVPJLgNkdmLCPvrYo2TyvOxBqxLYpBMfxOKJJGmzS2bb3j2HbNONm+zgoaMekDB3bhGrBUjHe6Qvf4vwpva2IViTB3HoJzs/lJamcsBvq1fUF4PkOLdsDvry2SAviWRq6+wpVoSa2iomQCwGnRQMKHg7SchLiEKTUcoKlo6RaQam9GabkZNu33r08XYYq//1O7/7Xx+mO+8LFkO9nHy8LxFaDbyElXbJmju+vm/XK0cKZxX87oa16z4mC9pTzzxmt995M0IQfg1Q2oJZOVgRs/CrKOOch+Ajz547Ze2tbe48NBP9syK0lQpMiCi+USRLSRr9d6BoBQEcA3hz8C1Dig45SekYhZ/WEi3kGEZTIP11fJwsnPG+gaWyDeXkZMJbDzk7lJQUDduwEX+Nc5iyUy0vd6VT6Xg89YSMMq8vQbtRW1eHuvEyvCsvoW41Q9qc227dboMgfsnsbPy6K+21Vw97xPXNxPVJYFXrmHKsVlfdNeDOu9d4igEZQMQPy8leE2MUg4mcqLSKXIPHb0QVWldfwwSrJAChzYpK02Bn0gmrGoD16rTimWWwOOvIZdeMNmOlHcQOsGHjWjmBPU3Knz/c8/LOQ4LH+/UQUXrfH1DAxLbGy/fvP3jwD9g3b84sXBM1WD3d3b712Nw5cxw5ZbnTbrcdHe2O0K0gdQNmZSVwWb9+gyczkQYg0MeKGqv70h5ElmbOhOTSwhr3AAALAElEQVT6qH6VE9LIXVLsipCVWGeo+wAIDit0od5aQYKyuRUYVRA8mVGypPWAiDIJ95LlqLq2GhVhl509Xwk7lEZatFUO7wvnL4G84/bCCy9AMa/6KiJEl6vqvffeax/5yIfsyKH9mMXPQ7mnIwyfgjovtd/+jV8i+xnaCNXi7ZduPOCVVZ9TZvTV8pWBLhuu00wE9PJHj7DX92nrbO1CSIwiBhGV5nQCJJRbjNUoJyfflpPJtbCgxA1Gyk46c2ap/emf/fnFD9x7+x9s3rz5u8BFKpD39fG+pdCToQYgtbx9/cUXH3s1Lz/n99GlPpSUkDitoeGyK/S1WY1M5xKDxKvKU0wJVmSAECshq58CdYUE0tsKDzT4YjKEvDrgPCZ+KxOR1F3Oi3JfgUqx6FzjGc/m9jomUQcC2EXq7bX77r8bT7xMq7lc6anNouFHcQYVn8kqEmPL8L9Oik9hBZlvf/Inf0ZO5uM2r7zCt81QIkXlxiibO8+2bt1K7GKbZ4ySr4kMLes3bLQv/u0BW7KCbTOSo6wDLY+5zwUTCy0FjhngojYT9S54/9Un9UwC7MVLNXbiPG6sp0+D1NV4/mH8IXtrGhsypaRMsdKSOeSvm4cLayZUXsG1MaSMOIFAix9LeVlHa1v3N9B0/DEajMbgDe//v8Fovv/b+bYWXrx4pCIpPv53zl+48ADZlZKFfKKg6kyIoOEDjrYgpRBYn4Aqh3eDbz2jOlphG84TbqVI9BJ0ySn4Uri7JciTMNJjXfgPn0At9viTh21Ker498JE7Edxyodxj6JXrMW+/wQagBZi2ywgYgL1xyintCQldSDT5xu637PU3dlkjuf5k3Zwzd66r7ZSvWv4lhTPz0Z/nI7DK2YfEM/Djzzz5lB04/Dr68xJ8Qs7ZJz/xMZyl5jHZmGgIbq5LnuiOjCxoLTiUE087gEXD64s5kZwh8g36YzlVdlbSjjncZAIXRWfDIAIBamrqhjfesOn5uOj4P5qWmfm+Zi+8o+/483OJ0OrD6e98J97K87amTpnyh1DS5WJ53WsPCvxehwQod0dVjykrzYMOIbOsjCdPKf6wwQW4UkzTOhTSJM+2uBiCegkhOrLvmD3x3FtWVrHKHkRtlpKGbwUrttzKhYC19XX2nW8/DvvQZmtXltt8PP1mZORTbgYITcArQUeyhnb3sDkomCj2IpEM+VoJlCmJCQqL0eDxeTKwaBsJpfD9q7/+S6h3J2WnYKk7b//9v/9XKH8F78HXg7dfH8QAoX31Qa8oJBXrpBICi4J8xZbJSCPLn09w7iovClvdDb+1963nK+YteHj56vWvAxc9+HN3XIfFz13TgwaPV1cn1lnvPcD/fqjvrbigJnuiw0mILaQVQusI3UXFeuhQXjiZqaW1mL9gPsik/MiRNZwhVVKZgf5Oe4mkKGfPXrIV67fbpo3riW0UksiMjCVNaCXkJ/VZZ1c/e5M8Y6+8/DzLdiH+zRsxcS8k4cxUtBo41qPZkDVOidwD9icWSolZPzbYX0WTS0aZarQeHcRSzizIh/3IsO8+8Tj8ejM8r1I3JNonfvGD6O6z2BGBtjrqsfrwrexHOtQ99XsIJ6cW/F2UBSkKtaE2K+IyH6UeS8R4NDjMNnjPV1dVPbxmw7bX/OGf4z8/9wgdwv706dPxqaljN5Ak8RMM8J3E6aWJbw6R890I7Vjg1j0NsPKHOM8dIjNUTanCBqCcO158HcNFr23etslmlhZDbdmDROwLVcjAEi77ThlBVvG1u/YcJJzqG/iTRLEt2i+wi9cSsAjdLmoxxEvehXiKkliI5asHE07fuqb8dzFQbWUtqr1ca5UXG/DuG7djhJP195M/o7mT1WPAfvmXH7Cb2Od8kJAwppfEV/j3QCwKEFr+0WNYTl93H+0Vq1agtmTFwe8cPAaR7Xna/HBuQfnPPSKHePDvBqHDDum76fKZBQjuv8YieyfoVihWQwMrrcV1Ch0gtKiYDkdG/3X9j/jtK1euwA70o8MtEysKImFkoT5fkL0K0CgCRZ0GGhRcPmElLsBv/8vXvgqyRduDD9zvaRpcyyK9tyi02AGeVRvk96xq/BK/B3GC0qovXfdg/xhGl1qStZy3I8fOeYozubbmERb22c98nD1minmOhO8gtCZZNJ2/fkSR+LIXnfjLLmiuW7+2mgxH3yVb02OFJfMPXC/37+NXZCj+fXTmnb2oqzuWHzMadwOZlD4H0sxniU0WwsmnWAj+PQ9UX1JngXYBL0p5cS1CPhcsIxNByBoeAUJL8IJfR/8rN1hFlcuHQjGP2o1KGYkU1qW9SGSw0UfWyF424JEBSJ5x7e3X8D/pAUmViuEC0erZNrMoh52thjHtn4CFaPf81bKKDg11oeK7D7amBJsILqdaOfjnkwS+XuzMECZRcuYdffSxx57MmJL+1V/5rd//udFahLD9Qb//XSN0CASxI1Onxs6LiRr/CCT0JrjIxaRwjZbjvnJyaM8TJ5XhA/qOILST5cj10NgiZNFHhwwYkw8JYYHTPfwqhp/jp07iGHTZ9ytRnjztn12Fm6tvvUEVYi+0oZEoczQee7ExyeiLTzGXYnxbjjj43uXkrktCrVZVU8OzLTgzXXb/kzw2RZoCUmN0Jy3YbEzbJGiHRMeJwsu6OT5Wg0Hln6j65Zwvf/Nw1Oc//31m8eSe/Hz+/g+B0JOHZnz8YkJzzfDSqNjYe0HkbdDdcvLCJYtgK4pZ2g9tRydtgEzHMAMTjzuF5ky4LGqs490IrSkQaFTkjfcom1cqO/0UZV0CeeU/kc6OuXJQUgqtBPJqDI/E+IZJcmQ6T86Si6gOZxUX2W23b2eDpLmksr2GYWUvacwOEz6V7Lmelb9knPyAOu/obLNLF87hhDV/+KatG48kJya9wNqyh/3oTmaXlDR7Q/+D/PkPh9CTx3Ucyt0yNa4iOnr8tqHRKLaoTVkFb1qYk4cqLUF8NzwxEcwSLMV7O2UGxRXyJVbEqerbKLQwPQCpHP7349B/5tw5ewihUNHYMrRFxQSrgfLsyedYWzq/svOgPfvSDmvtrLONqxbajThgrVq1HtN0lL38xl501weIaG+Qas2SonttxhR01lkJuHLigLVoffXy5atP9XR17/nKP39p57cf//bByX38j/b758JS+JMalKj582XLllO6O6afP1+Xf+bsqbnp0xetI6R/Kb7H85EBs+C9p0uwlBAnCi62QiH60ucGel5R5Ui6XjI2ice+hEC46409Npf8fJoQrvcGoaOJUo3B0NLU2If2YRebxR8iE/9FWIw+u/vem+xDH7yfNAsFdmDfGXvsiRft4NkzhIBNJ/k7qWqHmnumWmtVdnpM7ayc6QfarvXt+73f+9wp2O8faRuHnxR8fxb1/oem0N8P4NXVR6fFjydlxyTElJOVaRFoSQjL+Er460zYEaVxyiFRZIyETBkqtB1ERzsGknPk68BqqNQHyfC+y5YtRf+Mxx+RNzEYR/ZjoPnWt57EKofjPBMhKXnIfgGr49133mW1jdcGXnzh1d4dO3a3dfaMtCSkxF8aGmg9HjfWeTE1rqf2oRvbKn/l8w14aPzn8V4Q+E+Efi+ofJ9rXfVnZwxHYcAZHc2Br54Cm7EA4WthVU1dwtHD58uvdXTHFBXPyhkbG84tKJyBwabcw7aiUMEdPdk4+pd/+XdnWq61js6ZPXfk8uXGC8uXl9b+j//n/7o6MhBz5a+//J2L//P/+4teQsjar5x7te37NOU/b78DAv8/frkoSQjyBFIAAAAASUVORK5CYII=\"\n        width=\"180\"\n      >\n\n      <h1\n        id=\"og-image-title\"\n        class=\"text-[3rem] text-center text-white\"\n        :style=\"headingStyles\"\n      >\n        {{ ANTOINE_ZANARDI_FULL_NAME }}\n      </h1>\n\n      <hr class=\"bg-gray-600 w-11/12\">\n\n      <h2\n        id=\"og-image-subtitle\"\n        class=\"font-bold leading-relaxed text-[2rem] text-white text-center\"\n        :style=\"headingStyles\"\n      >\n        {{ $t(\"App.meta.smallDescription\") }}\n      </h2>\n    </div>\n  </div>\n</template>\n\n<script lang=\"ts\" setup>\nimport { ANTOINE_ZANARDI_FULL_NAME } from \"~/shared/constants/antoine-zanardi.constants\";\n\nconst headingStyles = {\n  textShadow: \"0px 1px 2px rgba(13, 79, 22, 1), 0px 3px 2px rgba(13, 79, 22, 1), 0px 4px 8px rgba(13, 79, 22, 1)\",\n};\n</script>"
+    },
+    "app/components/PageFooter/PageFooter.vue": {
+      "language": "html",
+      "mutants": [
+        {
+          "id": "280",
+          "mutatorName": "ArrowFunction",
+          "replacement": "() => undefined",
+          "statusReason": "Snapshot `Page Footer Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "140"
+          ],
+          "coveredBy": [
+            "140",
+            "141"
+          ],
+          "location": {
+            "end": {
+              "column": 65,
+              "line": 30
+            },
+            "start": {
+              "column": 35,
+              "line": 30
+            }
+          }
+        }
+      ],
+      "source": "<template>\n  <footer class=\"footer py-1\">\n    <div\n      class=\"container text-center\"\n      data-aos=\"fade-up\"\n      data-aos-anchor-placement=\"top-bottom\"\n    >\n      <LinkedInButton class=\"me-2\"/>\n\n      <GitHubButton/>\n    </div>\n\n    <div class=\"font-italic h4 my-2 text-center text-muted title\">\n      <span>\n        {{ ANTOINE_ZANARDI_FULL_NAME }}\n      </span>\n\n      <span>\n        {{ ` - ${fullYear}` }}\n      </span>\n    </div>\n  </footer>\n</template>\n\n<script lang=\"ts\" setup>\nimport GitHubButton from \"~/components/shared/Buttons/GitHubButton.vue\";\nimport LinkedInButton from \"~/components/shared/Buttons/LinkedInButton.vue\";\nimport { ANTOINE_ZANARDI_FULL_NAME } from \"~/shared/constants/antoine-zanardi.constants\";\n\nconst fullYear = computed<number>(() => new Date().getFullYear());\n</script>"
+    },
+    "app/components/shared/Images/CountryFlag/CountryFlag.vue": {
+      "language": "html",
+      "mutants": [
+        {
+          "id": "284",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "Snapshot `Country Flag Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "118"
+          ],
+          "coveredBy": [
+            "118",
+            "119",
+            "120",
+            "121",
+            "122"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 28
+            },
+            "start": {
+              "column": 47,
+              "line": 20
+            }
+          }
+        },
+        {
+          "id": "285",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "Snapshot `Country Flag Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "118"
+          ],
+          "coveredBy": [
+            "118",
+            "119",
+            "120",
+            "121",
+            "122"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 25
+            },
+            "start": {
+              "column": 52,
+              "line": 21
+            }
+          }
+        },
+        {
+          "id": "286",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "Snapshot `Country Flag Component > should match snapshot when rendered. 1` mismatched",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "118"
+          ],
+          "coveredBy": [
+            "118",
+            "119",
+            "120",
+            "121",
+            "122"
+          ],
+          "location": {
+            "end": {
+              "column": 31,
+              "line": 22
+            },
+            "start": {
+              "column": 13,
+              "line": 22
+            }
+          }
+        },
+        {
+          "id": "287",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected '/images/flags/' to be '/images/flags/usa-flag.webp' // Object.is equality",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 4,
+          "killedBy": [
+            "121"
+          ],
+          "coveredBy": [
+            "118",
+            "119",
+            "120",
+            "121",
+            "122"
+          ],
+          "location": {
+            "end": {
+              "column": 25,
+              "line": 23
+            },
+            "start": {
+              "column": 10,
+              "line": 23
+            }
+          }
+        },
+        {
+          "id": "288",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected '/images/flags/' to be '/images/flags/canada-flag.webp' // Object.is equality",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 5,
+          "killedBy": [
+            "122"
+          ],
+          "coveredBy": [
+            "118",
+            "119",
+            "120",
+            "121",
+            "122"
+          ],
+          "location": {
+            "end": {
+              "column": 31,
+              "line": 24
+            },
+            "start": {
+              "column": 13,
+              "line": 24
+            }
+          }
+        }
+      ],
+      "source": "<template>\n  <NuxtImg\n    :alt=\"`${country} flag`\"\n    class=\"country-flag\"\n    data-bs-toggle=\"tooltip\"\n    height=\"25\"\n    loading=\"lazy\"\n    :src=\"`/images/flags/${countryFlagSrc}`\"\n    :title=\"$t(`Countries.${country}`)\"\n    width=\"25\"\n  />\n</template>\n\n<script setup lang=\"ts\">\nimport type { CountryFlagProps } from \"~/components/shared/Images/CountryFlag/country-flag.types\";\nimport type { Country } from \"~/models/country/country.types\";\n\nconst props = defineProps<CountryFlagProps>();\n\nconst countryFlagSrc = computed<string>(() => {\n  const countryFlagsSrc: Record<Country, string> = {\n    france: \"france-flag.webp\",\n    usa: \"usa-flag.webp\",\n    canada: \"canada-flag.webp\",\n  };\n\n  return countryFlagsSrc[props.country];\n});\n</script>\n\n<style scoped lang=\"scss\">\n.country-flag {\n  width: 25px;\n  height: 25px;\n}\n</style>"
     }
   },
   "schemaVersion": "1.0",
@@ -16962,125 +15973,150 @@
       ],
       "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport type ProfessionalExperienceCard from \"~/components/MyExperience/ProfessionalExperienceCard/ProfessionalExperienceCard.vue\";\nimport { MyExperience } from \"#components\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport { COMPANIES } from \"~/models/company/company.constants\";\nimport type { ProfessionalExperience } from \"~/models/professional-experience/professional-experience.types\";\n\ndescribe(\"My Experience Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof MyExperience>>;\n\n  async function mountMyExperienceComponent(options: ComponentMountingOptions<typeof MyExperience> = {}):\n  Promise<ReturnType<typeof mount<typeof MyExperience>>> {\n    return mountSuspendedComponent(MyExperience, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountMyExperienceComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Experiences\", () => {\n    it(\"should render 6 experiences when rendered.\", () => {\n      const experiences = wrapper.findAllComponents<typeof ProfessionalExperienceCard>(\".professional-experience-card\");\n\n      expect(experiences).toHaveLength(6);\n    });\n\n    it(\"should render fullstack developer experience card at Daveo when rendered.\", () => {\n      const experiences = wrapper.findAllComponents<typeof ProfessionalExperienceCard>(\".professional-experience-card\");\n      const expectedExperience: ProfessionalExperience = {\n        company: COMPANIES.Daveo,\n        job: {\n          name: \"MyExperience.fullStackDeveloperConsultant\",\n          startedAt: new Date(\"2022-04-01\"),\n          description: [\n            \"MyExperience.iJoinedDaveo\",\n            \"MyExperience.whatIsConsulting\",\n            \"MyExperience.myMissionsAsConsultant\",\n            \"MyExperience.cloudProductCertifications\",\n            \"MyExperience.conferenceAndWorkshops\",\n          ],\n        },\n      };\n\n      expect(experiences[0].props(\"professionalExperience\")).toStrictEqual<ProfessionalExperience>(expectedExperience);\n    });\n\n    it(\"should render it engineer at OhMyCode when rendered.\", () => {\n      const experiences = wrapper.findAllComponents<typeof ProfessionalExperienceCard>(\".professional-experience-card\");\n      const expectedExperience: ProfessionalExperience = {\n        company: COMPANIES.OhMyCode,\n        job: {\n          name: \"MyExperience.itR&DEngineer\",\n          startedAt: new Date(\"2019-09-01\"),\n          finishedAt: new Date(\"2022-03-31\"),\n          description: [\n            \"MyExperience.firstPermanentContract\",\n            \"MyExperience.asProjectManager\",\n            \"MyExperience.softSkills\",\n            \"MyExperience.expertiseAndTechnicalSkills\",\n          ],\n        },\n      };\n\n      expect(experiences[1].props(\"professionalExperience\")).toStrictEqual<ProfessionalExperience>(expectedExperience);\n    });\n\n    it(\"should render second intern at OhMyCode when rendered.\", () => {\n      const experiences = wrapper.findAllComponents<typeof ProfessionalExperienceCard>(\".professional-experience-card\");\n      const expectedExperience: ProfessionalExperience = {\n        company: COMPANIES.OhMyCode,\n        job: {\n          name: \"MyExperience.internFullStackDeveloper\",\n          startedAt: new Date(\"2018-09-01\"),\n          finishedAt: new Date(\"2019-08-30\"),\n          description: [\n            \"MyExperience.distributionProject\",\n            \"MyExperience.thisFinalInternship\",\n          ],\n        },\n      };\n\n      expect(experiences[2].props(\"professionalExperience\")).toStrictEqual<ProfessionalExperience>(expectedExperience);\n    });\n\n    it(\"should render first intern at OhMyCode when rendered.\", () => {\n      const experiences = wrapper.findAllComponents<typeof ProfessionalExperienceCard>(\".professional-experience-card\");\n      const expectedExperience: ProfessionalExperience = {\n        company: COMPANIES.OhMyCode,\n        job: {\n          name: \"MyExperience.internFullStackDeveloper\",\n          startedAt: new Date(\"2016-09-01\"),\n          finishedAt: new Date(\"2017-04-30\"),\n          description: [\n            \"MyExperience.firstStepsInOhMyCode\",\n            \"MyExperience.allFunctionalitiesInOnApp\",\n          ],\n        },\n      };\n\n      expect(experiences[3].props(\"professionalExperience\")).toStrictEqual<ProfessionalExperience>(expectedExperience);\n    });\n\n    it(\"should render freelance developer at SoBook when rendered.\", () => {\n      const experiences = wrapper.findAllComponents<typeof ProfessionalExperienceCard>(\".professional-experience-card\");\n      const expectedExperience: ProfessionalExperience = {\n        company: COMPANIES.SoBook,\n        job: {\n          name: \"MyExperience.freelanceFullStackDeveloper\",\n          startedAt: new Date(\"2016-02-01\"),\n          finishedAt: new Date(\"2016-08-30\"),\n          description: [\n            \"MyExperience.reiterateAsFreelance\",\n            \"MyExperience.moreResponsibilities\",\n          ],\n        },\n      };\n\n      expect(experiences[4].props(\"professionalExperience\")).toStrictEqual<ProfessionalExperience>(expectedExperience);\n    });\n\n    it(\"should render first intern at SoBook when rendered.\", () => {\n      const experiences = wrapper.findAllComponents<typeof ProfessionalExperienceCard>(\".professional-experience-card\");\n      const expectedExperience: ProfessionalExperience = {\n        company: COMPANIES.SoBook,\n        job: {\n          name: \"MyExperience.internFullStackDeveloper\",\n          startedAt: new Date(\"2015-07-01\"),\n          finishedAt: new Date(\"2015-12-31\"),\n          description: [\"MyExperience.firstInternship\"],\n        },\n      };\n\n      expect(experiences[5].props(\"professionalExperience\")).toStrictEqual<ProfessionalExperience>(expectedExperience);\n    });\n  });\n});"
     },
-    "tests/unit/specs/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.nuxt.spec.ts": {
-      "tests": [
-        {
-          "id": "72",
-          "name": "Wrapped Font Awesome Icon Component should match snapshot when rendered."
-        },
-        {
-          "id": "73",
-          "name": "Wrapped Font Awesome Icon Component Icon should pass icon when rendered."
-        },
-        {
-          "id": "74",
-          "name": "Wrapped Font Awesome Icon Component Icon should pass undefined size when it is not provided in props."
-        },
-        {
-          "id": "75",
-          "name": "Wrapped Font Awesome Icon Component Icon should pass provided size when it is provided in props."
-        },
-        {
-          "id": "76",
-          "name": "Wrapped Font Awesome Icon Component Icon should pass empty class when it is not provided in props."
-        },
-        {
-          "id": "77",
-          "name": "Wrapped Font Awesome Icon Component Icon should pass provided class when it is provided in props."
-        },
-        {
-          "id": "78",
-          "name": "Wrapped Font Awesome Icon Component Icon should set icon color to default when it is not provided in props."
-        },
-        {
-          "id": "79",
-          "name": "Wrapped Font Awesome Icon Component Icon should set icon color to provided color when it is provided in props."
-        }
-      ],
-      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport type { WrappedFontAwesomeIconProps } from \"~/components/shared/Icons/WrappedFontAwesomeIcon/wrapped-font-awesome-icon.types\";\nimport WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\ndescribe(\"Wrapped Font Awesome Icon Component\", () => {\n  const defaultProps: WrappedFontAwesomeIconProps = {\n    icon: \"icon\",\n  };\n  let wrapper: ReturnType<typeof mount<typeof WrappedFontAwesomeIcon>>;\n\n  async function mountWrappedFontAwesomeIconComponent(options: ComponentMountingOptions<typeof WrappedFontAwesomeIcon> = {}):\n  Promise<ReturnType<typeof mount<typeof WrappedFontAwesomeIcon>>> {\n    return mountSuspendedComponent(WrappedFontAwesomeIcon, {\n      props: defaultProps,\n      global: {\n        stubs: {\n          ClientOnly: false,\n        },\n      },\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountWrappedFontAwesomeIconComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Icon\", () => {\n    it(\"should pass icon when rendered.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.props(\"icon\")).toBe(\"icon\");\n    });\n\n    it(\"should pass undefined size when it is not provided in props.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"size\")).toBeUndefined();\n    });\n\n    it(\"should pass provided size when it is provided in props.\", async() => {\n      wrapper = await mountWrappedFontAwesomeIconComponent({\n        props: {\n          ...defaultProps,\n          size: \"2x\",\n        },\n      });\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.props(\"size\")).toBe(\"2x\");\n    });\n\n    it(\"should pass empty class when it is not provided in props.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"class\")).toBe(\"font-awesome-icon\");\n    });\n\n    it(\"should pass provided class when it is provided in props.\", async() => {\n      wrapper = await mountWrappedFontAwesomeIconComponent({\n        props: {\n          ...defaultProps,\n          classes: \"test-class\",\n        },\n      });\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"class\")).toBe(\"font-awesome-icon test-class\");\n    });\n\n    it(\"should set icon color to default when it is not provided in props.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"style\")).toBe(\"color: #000000;\");\n    });\n\n    it(\"should set icon color to provided color when it is provided in props.\", async() => {\n      wrapper = await mountWrappedFontAwesomeIconComponent({\n        props: {\n          ...defaultProps,\n          iconColor: \"#FFFFFF\",\n        },\n      });\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"style\")).toBe(\"color: #FFFFFF;\");\n    });\n  });\n});"
-    },
-    "tests/unit/specs/components/NavBar/NavBar.nuxt.spec.ts": {
-      "tests": [
-        {
-          "id": "80",
-          "name": "NavBar Component should match snapshot when rendered."
-        },
-        {
-          "id": "81",
-          "name": "NavBar Component Navigation should not have show class when rendered."
-        },
-        {
-          "id": "82",
-          "name": "NavBar Component Navigation should toggle show class when clicked on a navbar toggler."
-        },
-        {
-          "id": "83",
-          "name": "NavBar Component Navigation should remove show class when clicked on a navbar toggler after toggling."
-        },
-        {
-          "id": "84",
-          "name": "NavBar Component Navigation should remove show class when clicked on a nav link after toggling."
-        }
-      ],
-      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { NavBar } from \"#components\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\ndescribe(\"NavBar Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof NavBar>>;\n\n  async function mountNavBarComponent(options: ComponentMountingOptions<typeof NavBar> = {}): Promise<ReturnType<typeof mount<typeof NavBar>>> {\n    return mountSuspendedComponent(NavBar, options);\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountNavBarComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Navigation\", () => {\n    it(\"should not have show class when rendered.\", () => {\n      const nav = wrapper.find<HTMLDivElement>(\"#navigation\");\n\n      expect(nav.classes()).not.toContain(\"show\");\n    });\n\n    it(\"should toggle show class when clicked on a navbar toggler.\", async() => {\n      const nav = wrapper.find<HTMLDivElement>(\"#navigation\");\n      const toggler = wrapper.find<HTMLButtonElement>(\".navbar-toggler\");\n      await toggler.trigger(\"click\");\n\n      expect(nav.classes()).toContain(\"show\");\n    });\n\n    it(\"should remove show class when clicked on a navbar toggler after toggling.\", async() => {\n      const nav = wrapper.find<HTMLDivElement>(\"#navigation\");\n      const toggler = wrapper.find<HTMLButtonElement>(\".navbar-toggler\");\n      await toggler.trigger(\"click\");\n      await toggler.trigger(\"click\");\n\n      expect(nav.classes()).not.toContain(\"show\");\n    });\n\n    it(\"should remove show class when clicked on a nav link after toggling.\", async() => {\n      const nav = wrapper.find<HTMLDivElement>(\"#navigation\");\n      const toggler = wrapper.find<HTMLButtonElement>(\".navbar-toggler\");\n      await toggler.trigger(\"click\");\n      const navLink = wrapper.find<HTMLAnchorElement>(\".nav-link\");\n      await navLink.trigger(\"click\");\n\n      expect(nav.classes()).not.toContain(\"show\");\n    });\n  });\n});"
-    },
     "tests/unit/specs/components/MyEducation/MyEducation.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "85",
+          "id": "72",
           "name": "MyEducation Component should match snapshot when rendered."
         },
         {
-          "id": "86",
+          "id": "73",
           "name": "MyEducation Component Education Degrees should render 5 education degree cards when rendered."
         },
         {
-          "id": "87",
+          "id": "74",
           "name": "MyEducation Component Education Degrees should render GCP ACE education degree card when rendered."
         },
         {
-          "id": "88",
+          "id": "75",
           "name": "MyEducation Component Education Degrees should render CKAD education degree card when rendered."
         },
         {
-          "id": "89",
+          "id": "76",
           "name": "MyEducation Component Education Degrees should render IT Master degree card when rendered."
         },
         {
-          "id": "90",
+          "id": "77",
           "name": "MyEducation Component Education Degrees should render IT certification degree card when rendered."
         },
         {
-          "id": "91",
+          "id": "78",
           "name": "MyEducation Component Education Degrees should render high school degree card when rendered."
         }
       ],
       "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { MyEducation } from \"#components\";\nimport type EducationDegreeCard from \"~/components/MyEducation/EducationDegreeCard/EducationDegreeCard.vue\";\nimport { SCHOOLS } from \"~/models/school/school.constants\";\nimport type { EducationDegree } from \"~/models/education-degree/education-degree.types\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\ndescribe(\"MyEducation Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof MyEducation>>;\n\n  async function mountMyEducationComponent(options: ComponentMountingOptions<typeof MyEducation> = {}): Promise<ReturnType<typeof mount<typeof MyEducation>>> {\n    return mountSuspendedComponent(MyEducation, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountMyEducationComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Education Degrees\", () => {\n    it(\"should render 5 education degree cards when rendered.\", () => {\n      const educationDegreeCards = wrapper.findAllComponents<typeof EducationDegreeCard>(\".education-degree-card\");\n\n      expect(educationDegreeCards).toHaveLength(5);\n    });\n\n    it(\"should render GCP ACE education degree card when rendered.\", () => {\n      const educationDegreeCards = wrapper.findAllComponents<typeof EducationDegreeCard>(\".education-degree-card\");\n      const expectedEducationDegree: EducationDegree = {\n        degree: {\n          name: `Degrees.gcpACE`,\n          description: [\"MyEducation.gcpACECertification\"],\n          obtainedAt: new Date(\"2022-12-01\"),\n        },\n        school: {\n          ...SCHOOLS.google,\n          translatedName: `Schools.${SCHOOLS.google.name}`,\n        },\n      };\n\n      expect(educationDegreeCards[0].props(\"educationDegree\")).toStrictEqual<EducationDegree>(expectedEducationDegree);\n    });\n\n    it(\"should render CKAD education degree card when rendered.\", () => {\n      const educationDegreeCards = wrapper.findAllComponents<typeof EducationDegreeCard>(\".education-degree-card\");\n      const expectedEducationDegree: EducationDegree = {\n        degree: {\n          name: `Degrees.CKAD`,\n          description: [\"MyEducation.kubernetesCertification\"],\n          obtainedAt: new Date(\"2022-08-01\"),\n        },\n        school: {\n          ...SCHOOLS.cloudNativeComputingFoundation,\n          translatedName: `Schools.${SCHOOLS.cloudNativeComputingFoundation.name}`,\n        },\n      };\n\n      expect(educationDegreeCards[1].props(\"educationDegree\")).toStrictEqual<EducationDegree>(expectedEducationDegree);\n    });\n\n    it(\"should render IT Master degree card when rendered.\", () => {\n      const educationDegreeCards = wrapper.findAllComponents<typeof EducationDegreeCard>(\".education-degree-card\");\n      const expectedEducationDegree: EducationDegree = {\n        degree: {\n          name: `Degrees.ITMasterDegree`,\n          description: [\"MyEducation.firstThreeYearsInEpitech\", \"MyEducation.lastYearsInEpitech\"],\n          startedAt: new Date(\"2014-01-01\"),\n          obtainedAt: new Date(\"2019-01-01\"),\n        },\n        school: {\n          ...SCHOOLS.epitech,\n          translatedName: `Schools.${SCHOOLS.epitech.name}`,\n        },\n      };\n\n      expect(educationDegreeCards[2].props(\"educationDegree\")).toStrictEqual<EducationDegree>(expectedEducationDegree);\n    });\n\n    it(\"should render IT certification degree card when rendered.\", () => {\n      const educationDegreeCards = wrapper.findAllComponents<typeof EducationDegreeCard>(\".education-degree-card\");\n      const expectedEducationDegree: EducationDegree = {\n        degree: {\n          name: `Degrees.ITCertification`,\n          description: [\"MyEducation.internationalExperienceForManagement\", \"MyEducation.softManagementSkills\"],\n          startedAt: new Date(\"2017-01-01\"),\n          obtainedAt: new Date(\"2018-01-01\"),\n        },\n        school: {\n          ...SCHOOLS.laval,\n          translatedName: `Schools.${SCHOOLS.laval.name}`,\n        },\n      };\n\n      expect(educationDegreeCards[3].props(\"educationDegree\")).toStrictEqual<EducationDegree>(expectedEducationDegree);\n    });\n\n    it(\"should render high school degree card when rendered.\", () => {\n      const educationDegreeCards = wrapper.findAllComponents<typeof EducationDegreeCard>(\".education-degree-card\");\n      const expectedEducationDegree: EducationDegree = {\n        degree: {\n          name: `Degrees.highSchoolDiploma`,\n          description: [\"MyEducation.scientistHighSchoolDiploma\"],\n          startedAt: new Date(\"2011-01-01\"),\n          obtainedAt: new Date(\"2014-01-01\"),\n        },\n        school: {\n          ...SCHOOLS.vimeu,\n          translatedName: `Schools.${SCHOOLS.vimeu.name}`,\n        },\n      };\n\n      expect(educationDegreeCards[4].props(\"educationDegree\")).toStrictEqual<EducationDegree>(expectedEducationDegree);\n    });\n  });\n});"
     },
-    "tests/unit/specs/components/MyPortfolio/MyPortfolio.nuxt.spec.ts": {
+    "tests/unit/specs/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.nuxt.spec.ts": {
+      "tests": [
+        {
+          "id": "79",
+          "name": "Wrapped Font Awesome Icon Component should match snapshot when rendered."
+        },
+        {
+          "id": "80",
+          "name": "Wrapped Font Awesome Icon Component Icon should pass icon when rendered."
+        },
+        {
+          "id": "81",
+          "name": "Wrapped Font Awesome Icon Component Icon should pass undefined size when it is not provided in props."
+        },
+        {
+          "id": "82",
+          "name": "Wrapped Font Awesome Icon Component Icon should pass provided size when it is provided in props."
+        },
+        {
+          "id": "83",
+          "name": "Wrapped Font Awesome Icon Component Icon should pass empty class when it is not provided in props."
+        },
+        {
+          "id": "84",
+          "name": "Wrapped Font Awesome Icon Component Icon should pass provided class when it is provided in props."
+        },
+        {
+          "id": "85",
+          "name": "Wrapped Font Awesome Icon Component Icon should set icon color to default when it is not provided in props."
+        },
+        {
+          "id": "86",
+          "name": "Wrapped Font Awesome Icon Component Icon should set icon color to provided color when it is provided in props."
+        }
+      ],
+      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport type { WrappedFontAwesomeIconProps } from \"~/components/shared/Icons/WrappedFontAwesomeIcon/wrapped-font-awesome-icon.types\";\nimport WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\ndescribe(\"Wrapped Font Awesome Icon Component\", () => {\n  const defaultProps: WrappedFontAwesomeIconProps = {\n    icon: \"icon\",\n  };\n  let wrapper: ReturnType<typeof mount<typeof WrappedFontAwesomeIcon>>;\n\n  async function mountWrappedFontAwesomeIconComponent(options: ComponentMountingOptions<typeof WrappedFontAwesomeIcon> = {}):\n  Promise<ReturnType<typeof mount<typeof WrappedFontAwesomeIcon>>> {\n    return mountSuspendedComponent(WrappedFontAwesomeIcon, {\n      props: defaultProps,\n      global: {\n        stubs: {\n          ClientOnly: false,\n        },\n      },\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountWrappedFontAwesomeIconComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Icon\", () => {\n    it(\"should pass icon when rendered.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.props(\"icon\")).toBe(\"icon\");\n    });\n\n    it(\"should pass undefined size when it is not provided in props.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"size\")).toBeUndefined();\n    });\n\n    it(\"should pass provided size when it is provided in props.\", async() => {\n      wrapper = await mountWrappedFontAwesomeIconComponent({\n        props: {\n          ...defaultProps,\n          size: \"2x\",\n        },\n      });\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.props(\"size\")).toBe(\"2x\");\n    });\n\n    it(\"should pass empty class when it is not provided in props.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"class\")).toBe(\"font-awesome-icon\");\n    });\n\n    it(\"should pass provided class when it is provided in props.\", async() => {\n      wrapper = await mountWrappedFontAwesomeIconComponent({\n        props: {\n          ...defaultProps,\n          classes: \"test-class\",\n        },\n      });\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"class\")).toBe(\"font-awesome-icon test-class\");\n    });\n\n    it(\"should set icon color to default when it is not provided in props.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"style\")).toBe(\"color: #000000;\");\n    });\n\n    it(\"should set icon color to provided color when it is provided in props.\", async() => {\n      wrapper = await mountWrappedFontAwesomeIconComponent({\n        props: {\n          ...defaultProps,\n          iconColor: \"#FFFFFF\",\n        },\n      });\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"style\")).toBe(\"color: #FFFFFF;\");\n    });\n  });\n});"
+    },
+    "tests/unit/specs/components/shared/Layouts/SectionTitle/SectionTitle.nuxt.spec.ts": {
+      "tests": [
+        {
+          "id": "87",
+          "name": "Section Title Component should match snapshot when rendered."
+        },
+        {
+          "id": "88",
+          "name": "Section Title Component Icon should set icon source when rendered."
+        },
+        {
+          "id": "89",
+          "name": "Section Title Component Icon should set icon color to default when it is not provided in props."
+        },
+        {
+          "id": "90",
+          "name": "Section Title Component Icon should set icon color to provided color when it is provided in props."
+        },
+        {
+          "id": "91",
+          "name": "Section Title Component Title should set title when rendered."
+        }
+      ],
+      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport type WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type { SectionTitleProps } from \"~/components/shared/Layouts/SectionTitle/section-title.types\";\n\nimport SectionTitle from \"@/components/shared/Layouts/SectionTitle/SectionTitle.vue\";\n\ndescribe(\"Section Title Component\", () => {\n  const defaultProps: SectionTitleProps = {\n    icon: \"icon\",\n    title: \"title\",\n  };\n  let wrapper: ReturnType<typeof mount<typeof SectionTitle>>;\n\n  async function mountSectionTitleComponent(options: ComponentMountingOptions<typeof SectionTitle> = {}):\n  Promise<ReturnType<typeof mount<typeof SectionTitle>>> {\n    return mountSuspendedComponent(SectionTitle, {\n      props: defaultProps,\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountSectionTitleComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Icon\", () => {\n    it(\"should set icon source when rendered.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\"#section-title-icon\");\n\n      expect(icon.props(\"icon\")).toBe(\"icon\");\n    });\n\n    it(\"should set icon color to default when it is not provided in props.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\"#section-title-icon\");\n\n      expect(icon.attributes(\"iconcolor\")).toBe(\"#000000\");\n    });\n\n    it(\"should set icon color to provided color when it is provided in props.\", async() => {\n      wrapper = await mountSectionTitleComponent({\n        props: {\n          ...defaultProps,\n          iconColor: \"#FFFFFF\",\n        },\n      });\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\"#section-title-icon\");\n\n      expect(icon.attributes(\"iconcolor\")).toBe(\"#FFFFFF\");\n    });\n  });\n\n  describe(\"Title\", () => {\n    it(\"should set title when rendered.\", () => {\n      const title = wrapper.find<HTMLSpanElement>(\".section-title-text\");\n\n      expect(title.text()).toBe(\"title\");\n    });\n  });\n});"
+    },
+    "tests/unit/specs/components/NavBar/NavBar.nuxt.spec.ts": {
       "tests": [
         {
           "id": "92",
-          "name": "My Portfolio Component should match snapshot when rendered."
+          "name": "NavBar Component should match snapshot when rendered."
         },
         {
           "id": "93",
-          "name": "My Portfolio Component Projects should render 4 projects when rendered."
+          "name": "NavBar Component Navigation should not have show class when rendered."
         },
         {
           "id": "94",
-          "name": "My Portfolio Component Projects should render my portfolio project when rendered."
+          "name": "NavBar Component Navigation should toggle show class when clicked on a navbar toggler."
         },
         {
           "id": "95",
-          "name": "My Portfolio Component Projects should render my Werewolves Assistant project when rendered."
+          "name": "NavBar Component Navigation should remove show class when clicked on a navbar toggler after toggling."
         },
         {
           "id": "96",
+          "name": "NavBar Component Navigation should remove show class when clicked on a nav link after toggling."
+        }
+      ],
+      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { NavBar } from \"#components\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\ndescribe(\"NavBar Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof NavBar>>;\n\n  async function mountNavBarComponent(options: ComponentMountingOptions<typeof NavBar> = {}): Promise<ReturnType<typeof mount<typeof NavBar>>> {\n    return mountSuspendedComponent(NavBar, options);\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountNavBarComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Navigation\", () => {\n    it(\"should not have show class when rendered.\", () => {\n      const nav = wrapper.find<HTMLDivElement>(\"#navigation\");\n\n      expect(nav.classes()).not.toContain(\"show\");\n    });\n\n    it(\"should toggle show class when clicked on a navbar toggler.\", async() => {\n      const nav = wrapper.find<HTMLDivElement>(\"#navigation\");\n      const toggler = wrapper.find<HTMLButtonElement>(\".navbar-toggler\");\n      await toggler.trigger(\"click\");\n\n      expect(nav.classes()).toContain(\"show\");\n    });\n\n    it(\"should remove show class when clicked on a navbar toggler after toggling.\", async() => {\n      const nav = wrapper.find<HTMLDivElement>(\"#navigation\");\n      const toggler = wrapper.find<HTMLButtonElement>(\".navbar-toggler\");\n      await toggler.trigger(\"click\");\n      await toggler.trigger(\"click\");\n\n      expect(nav.classes()).not.toContain(\"show\");\n    });\n\n    it(\"should remove show class when clicked on a nav link after toggling.\", async() => {\n      const nav = wrapper.find<HTMLDivElement>(\"#navigation\");\n      const toggler = wrapper.find<HTMLButtonElement>(\".navbar-toggler\");\n      await toggler.trigger(\"click\");\n      const navLink = wrapper.find<HTMLAnchorElement>(\".nav-link\");\n      await navLink.trigger(\"click\");\n\n      expect(nav.classes()).not.toContain(\"show\");\n    });\n  });\n});"
+    },
+    "tests/unit/specs/components/MyPortfolio/MyPortfolio.nuxt.spec.ts": {
+      "tests": [
+        {
+          "id": "97",
+          "name": "My Portfolio Component should match snapshot when rendered."
+        },
+        {
+          "id": "98",
+          "name": "My Portfolio Component Projects should render 4 projects when rendered."
+        },
+        {
+          "id": "99",
+          "name": "My Portfolio Component Projects should render my portfolio project when rendered."
+        },
+        {
+          "id": "100",
+          "name": "My Portfolio Component Projects should render my Werewolves Assistant project when rendered."
+        },
+        {
+          "id": "101",
           "name": "My Portfolio Component Projects should render book distribution project when rendered."
         },
         {
-          "id": "97",
+          "id": "102",
           "name": "My Portfolio Component Projects should render my GitHub profile project when rendered."
         }
       ],
@@ -17089,220 +16125,186 @@
     "tests/unit/specs/components/MySkills/SkillProgressBar/SkillProgressBar.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "98",
+          "id": "103",
           "name": "Skill Progress Bar Component should match snapshot when rendered."
         },
         {
-          "id": "99",
+          "id": "104",
           "name": "Skill Progress Bar Component Icon should pass skill icon when rendered."
         },
         {
-          "id": "100",
+          "id": "105",
           "name": "Skill Progress Bar Component Icon should pass skill color when rendered."
         },
         {
-          "id": "101",
+          "id": "106",
           "name": "Skill Progress Bar Component Skill should render skill name when rendered."
         },
         {
-          "id": "102",
+          "id": "107",
           "name": "Skill Progress Bar Component Skill should set skill url to anchor when rendered."
         },
         {
-          "id": "103",
+          "id": "108",
           "name": "Skill Progress Bar Component Progress Bar should set aria label to skill name and percent when rendered."
         },
         {
-          "id": "104",
+          "id": "109",
           "name": "Skill Progress Bar Component Progress Bar should set progress bar style when rendered."
         },
         {
-          "id": "105",
+          "id": "110",
           "name": "Skill Progress Bar Component Progress Bar should set progress bar percent in progress bar label when rendered."
         }
       ],
       "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\nimport type { SkillProgressBarProps } from \"~/components/MySkills/SkillProgressBar/skill-progress-bar.types\";\nimport SkillProgressBar from \"~/components/MySkills/SkillProgressBar/SkillProgressBar.vue\";\n\ndescribe(\"Skill Progress Bar Component\", () => {\n  const defaultProps: SkillProgressBarProps = {\n    skill: {\n      name: \"MySkills.html\",\n      iconClasses: \"fab fa-html5\",\n      color: \"#E44D27\",\n      percent: \"95%\",\n      url: \"https://fr.wikipedia.org/wiki/HTML5\",\n    },\n  };\n  let wrapper: ReturnType<typeof mount<typeof SkillProgressBar>>;\n\n  async function mountSkillProgressBarComponent(options: ComponentMountingOptions<typeof SkillProgressBar> = {}):\n  Promise<ReturnType<typeof mount<typeof SkillProgressBar>>> {\n    return mountSuspendedComponent(SkillProgressBar, {\n      props: defaultProps,\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountSkillProgressBarComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Icon\", () => {\n    it(\"should pass skill icon when rendered.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".skill-icon\");\n\n      expect(icon.props(\"icon\")).toBe(defaultProps.skill.iconClasses);\n    });\n\n    it(\"should pass skill color when rendered.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".skill-icon\");\n\n      expect(icon.props(\"iconColor\")).toBe(defaultProps.skill.color);\n    });\n  });\n\n  describe(\"Skill\", () => {\n    it(\"should render skill name when rendered.\", () => {\n      const skillName = wrapper.find<HTMLAnchorElement>(\".skill-name\");\n\n      expect(skillName.text()).toBe(defaultProps.skill.name);\n    });\n\n    it(\"should set skill url to anchor when rendered.\", () => {\n      const skillUrl = wrapper.find<HTMLAnchorElement>(\".skill-name\");\n\n      expect(skillUrl.attributes(\"href\")).toBe(defaultProps.skill.url);\n    });\n  });\n\n  describe(\"Progress Bar\", () => {\n    it(\"should set aria label to skill name and percent when rendered.\", () => {\n      const progressBar = wrapper.find<HTMLDivElement>(\".progress-bar\");\n\n      expect(progressBar.attributes(\"aria-label\")).toBe(\"SkillProgressBar.skillProgress, {\\\"skillName\\\":\\\"MySkills.html\\\",\\\"skillPercent\\\":\\\"95%\\\"}\");\n    });\n\n    it(\"should set progress bar style when rendered.\", () => {\n      const progressBar = wrapper.find<HTMLDivElement>(\".progress-bar\");\n      const expectedStyle = `width: ${defaultProps.skill.percent}; background-color: ${defaultProps.skill.color};`;\n\n      expect(progressBar.attributes(\"style\")).toBe(expectedStyle);\n    });\n\n    it(\"should set progress bar percent in progress bar label when rendered.\", () => {\n      const progressBarLabel = wrapper.find<HTMLDivElement>(\".progress-value\");\n\n      expect(progressBarLabel.text()).toBe(defaultProps.skill.percent);\n    });\n  });\n});"
     },
-    "tests/unit/specs/app.nuxt.spec.ts": {
-      "tests": [
-        {
-          "id": "106",
-          "name": "App Component should match snapshot when rendered."
-        },
-        {
-          "id": "107",
-          "name": "App Component should define og image component when rendered."
-        },
-        {
-          "id": "108",
-          "name": "App Component should use head for sso purposes when rendered."
-        },
-        {
-          "id": "109",
-          "name": "App Component should stamp a comment in HTML when rendered."
-        }
-      ],
-      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\nimport { stampInHtml } from \"dev-stamp\";\n\nimport App from \"@/App.vue\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\nvi.mock(\"dev-stamp\");\n\ndescribe(\"App Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof App>>;\n\n  async function mountAppComponent(options: ComponentMountingOptions<typeof App> = {}): Promise<ReturnType<typeof mount<typeof App>>> {\n    return mountSuspendedComponent(App, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountAppComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  it(\"should define og image component when rendered.\", () => {\n    expect(defineOgImageComponent).toHaveBeenCalledExactlyOnceWith(\"DefaultOgImage\");\n  });\n\n  it(\"should use head for sso purposes when rendered.\", () => {\n    const expectedUseHeadAttribute = {\n      title: \"App.meta.title\",\n      meta: [{ name: \"description\", content: \"App.meta.description\" }],\n      htmlAttrs: { lang: \"fr\" },\n    };\n\n    expect(useHead).toHaveBeenNthCalledWith(1, expectedUseHeadAttribute);\n  });\n\n  it(\"should stamp a comment in HTML when rendered.\", () => {\n    const expectedComment = \"👋 Hey ! J'ai aussi créé 💮 `dev-stamp` qui a généré ce message ! Retrouvez le sur GitHub ou npm !\";\n\n    expect(stampInHtml).toHaveBeenCalledExactlyOnceWith(expectedComment);\n  });\n});"
-    },
-    "tests/unit/specs/components/shared/Images/CountryFlag.nuxt.spec.ts": {
-      "tests": [
-        {
-          "id": "110",
-          "name": "Country Flag Component should match snapshot when rendered."
-        },
-        {
-          "id": "111",
-          "name": "Country Flag Component Flag should render France flag when country is France."
-        },
-        {
-          "id": "112",
-          "name": "Country Flag Component Flag 'should render France flag when countr…'"
-        },
-        {
-          "id": "113",
-          "name": "Country Flag Component Flag 'should render USA flag when country i…'"
-        },
-        {
-          "id": "114",
-          "name": "Country Flag Component Flag 'should render Canada flag when countr…'"
-        }
-      ],
-      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport type { NuxtImg } from \"#components\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type { CountryFlagProps } from \"~/components/shared/Images/CountryFlag/country-flag.types\";\nimport type { Country } from \"~/models/country/country.types\";\n\nimport CountryFlag from \"@/components/shared/Images/CountryFlag/CountryFlag.vue\";\n\ndescribe(\"Country Flag Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof CountryFlag>>;\n  const defaultProps: CountryFlagProps = {\n    country: \"france\",\n  };\n\n  async function mountCountryFlagComponent(options: ComponentMountingOptions<typeof CountryFlag> = {}): Promise<ReturnType<typeof mount<typeof CountryFlag>>> {\n    return mountSuspendedComponent(CountryFlag, {\n      props: defaultProps,\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountCountryFlagComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Flag\", () => {\n    it(\"should render France flag when country is France.\", () => {\n      const flag = wrapper.findComponent<typeof NuxtImg>(\".country-flag\");\n\n      expect(flag.attributes(\"src\")).toBe(\"/images/flags/france-flag.webp\");\n    });\n\n    it.each<{\n      country: Country;\n      expectedFlag: string;\n      test: string;\n    }>([\n      {\n        country: \"france\",\n        expectedFlag: \"/images/flags/france-flag.webp\",\n        test: \"should render France flag when country is France.\",\n      },\n      {\n        country: \"usa\",\n        expectedFlag: \"/images/flags/usa-flag.webp\",\n        test: \"should render USA flag when country is USA.\",\n      },\n      {\n        country: \"canada\",\n        expectedFlag: \"/images/flags/canada-flag.webp\",\n        test: \"should render Canada flag when country is Canada.\",\n      },\n    ])(\"$test\", async({ country, expectedFlag }) => {\n      wrapper = await mountCountryFlagComponent({ props: { country } });\n      const flag = wrapper.findComponent<typeof NuxtImg>(\".country-flag\");\n\n      expect(flag.attributes(\"src\")).toBe(expectedFlag);\n    });\n  });\n});"
-    },
     "tests/unit/specs/components/MyExperience/ProfessionalExperienceCard/ProfessionalExperienceCard.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "115",
+          "id": "111",
           "name": "Professional Experience Card Component should match snapshot when rendered."
         },
         {
-          "id": "116",
+          "id": "112",
           "name": "Professional Experience Card Component Period Timeline should pass job started date when rendered."
         },
         {
-          "id": "117",
+          "id": "113",
           "name": "Professional Experience Card Component Period Timeline should pass job finished date when rendered."
         },
         {
-          "id": "118",
+          "id": "114",
           "name": "Professional Experience Card Component Period Timeline should pass company image when rendered."
         },
         {
-          "id": "119",
+          "id": "115",
           "name": "Professional Experience Card Component Period Timeline should pass company url when rendered."
         },
         {
-          "id": "120",
+          "id": "116",
           "name": "Professional Experience Card Component Job should render job name when rendered."
         },
         {
-          "id": "121",
+          "id": "117",
           "name": "Professional Experience Card Component Job should render job description when rendered."
         }
       ],
       "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type { ProfessionalExperienceCardProps } from \"~/components/MyExperience/ProfessionalExperienceCard/professional-experience-card.types\";\nimport ProfessionalExperienceCard from \"~/components/MyExperience/ProfessionalExperienceCard/ProfessionalExperienceCard.vue\";\nimport type PeriodTimeline from \"~/components/shared/Period/PeriodTimeline.vue\";\nimport { COMPANIES } from \"~/models/company/company.constants\";\n\ndescribe(\"Professional Experience Card Component\", () => {\n  const defaultProps: ProfessionalExperienceCardProps = {\n    professionalExperience: {\n      job: {\n        name: \"MyExperience.internFullStackDeveloper\",\n        description: [\"MyExperience.distributionProject\", \"MyExperience.thisFinalInternship\"],\n        startedAt: new Date(\"2018-09-01T00:00:00.000Z\"),\n        finishedAt: new Date(\"2019-08-30T00:00:00.000Z\"),\n      },\n      company: COMPANIES.OhMyCode,\n    },\n  };\n  let wrapper: ReturnType<typeof mount<typeof ProfessionalExperienceCard>>;\n\n  async function mountProfessionalExperienceCardComponent(options: ComponentMountingOptions<typeof ProfessionalExperienceCard> = {}):\n  Promise<ReturnType<typeof mount<typeof ProfessionalExperienceCard>>> {\n    return mountSuspendedComponent(ProfessionalExperienceCard, {\n      props: defaultProps,\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountProfessionalExperienceCardComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Period Timeline\", () => {\n    it(\"should pass job started date when rendered.\", () => {\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".experience-timeline\");\n\n      expect(periodTimeline.props(\"startedAt\")).toBe(defaultProps.professionalExperience.job.startedAt);\n    });\n\n    it(\"should pass job finished date when rendered.\", () => {\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".experience-timeline\");\n\n      expect(periodTimeline.props(\"finishedAt\")).toBe(defaultProps.professionalExperience.job.finishedAt);\n    });\n\n    it(\"should pass company image when rendered.\", () => {\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".experience-timeline\");\n\n      expect(periodTimeline.props(\"image\")).toBe(defaultProps.professionalExperience.company.image);\n    });\n\n    it(\"should pass company url when rendered.\", () => {\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".experience-timeline\");\n\n      expect(periodTimeline.props(\"url\")).toBe(defaultProps.professionalExperience.company.url);\n    });\n  });\n\n  describe(\"Job\", () => {\n    it(\"should render job name when rendered.\", () => {\n      const jobName = wrapper.find<HTMLDivElement>(\".job-name\");\n\n      expect(jobName.text()).toBe(\"MyExperience.internFullStackDeveloper\");\n    });\n\n    it(\"should render job description when rendered.\", () => {\n      const jobDescriptions = wrapper.findAll<HTMLParagraphElement>(\".job-description\");\n\n      expect(jobDescriptions).toHaveLength(2);\n      expect(jobDescriptions[0].text()).toBe(\"MyExperience.distributionProject\");\n      expect(jobDescriptions[1].text()).toBe(\"MyExperience.thisFinalInternship\");\n    });\n  });\n});"
     },
+    "tests/unit/specs/components/shared/Images/CountryFlag.nuxt.spec.ts": {
+      "tests": [
+        {
+          "id": "118",
+          "name": "Country Flag Component should match snapshot when rendered."
+        },
+        {
+          "id": "119",
+          "name": "Country Flag Component Flag should render France flag when country is France."
+        },
+        {
+          "id": "120",
+          "name": "Country Flag Component Flag 'should render France flag when countr…'"
+        },
+        {
+          "id": "121",
+          "name": "Country Flag Component Flag 'should render USA flag when country i…'"
+        },
+        {
+          "id": "122",
+          "name": "Country Flag Component Flag 'should render Canada flag when countr…'"
+        }
+      ],
+      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport type { NuxtImg } from \"#components\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type { CountryFlagProps } from \"~/components/shared/Images/CountryFlag/country-flag.types\";\nimport type { Country } from \"~/models/country/country.types\";\n\nimport CountryFlag from \"@/components/shared/Images/CountryFlag/CountryFlag.vue\";\n\ndescribe(\"Country Flag Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof CountryFlag>>;\n  const defaultProps: CountryFlagProps = {\n    country: \"france\",\n  };\n\n  async function mountCountryFlagComponent(options: ComponentMountingOptions<typeof CountryFlag> = {}): Promise<ReturnType<typeof mount<typeof CountryFlag>>> {\n    return mountSuspendedComponent(CountryFlag, {\n      props: defaultProps,\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountCountryFlagComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Flag\", () => {\n    it(\"should render France flag when country is France.\", () => {\n      const flag = wrapper.findComponent<typeof NuxtImg>(\".country-flag\");\n\n      expect(flag.attributes(\"src\")).toBe(\"/images/flags/france-flag.webp\");\n    });\n\n    it.each<{\n      country: Country;\n      expectedFlag: string;\n      test: string;\n    }>([\n      {\n        country: \"france\",\n        expectedFlag: \"/images/flags/france-flag.webp\",\n        test: \"should render France flag when country is France.\",\n      },\n      {\n        country: \"usa\",\n        expectedFlag: \"/images/flags/usa-flag.webp\",\n        test: \"should render USA flag when country is USA.\",\n      },\n      {\n        country: \"canada\",\n        expectedFlag: \"/images/flags/canada-flag.webp\",\n        test: \"should render Canada flag when country is Canada.\",\n      },\n    ])(\"$test\", async({ country, expectedFlag }) => {\n      wrapper = await mountCountryFlagComponent({ props: { country } });\n      const flag = wrapper.findComponent<typeof NuxtImg>(\".country-flag\");\n\n      expect(flag.attributes(\"src\")).toBe(expectedFlag);\n    });\n  });\n});"
+    },
     "tests/unit/specs/components/MyPortfolio/MyProject/MyProject.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "122",
+          "id": "123",
           "name": "My Project Component should match snapshot when rendered."
         },
         {
-          "id": "123",
+          "id": "124",
           "name": "My Project Component Image should set alt to project name when rendered."
         },
         {
-          "id": "124",
+          "id": "125",
           "name": "My Project Component Image should set image source when rendered."
         },
         {
-          "id": "125",
+          "id": "126",
           "name": "My Project Component Project should render project name when rendered."
         },
         {
-          "id": "126",
+          "id": "127",
           "name": "My Project Component Project should render project description when rendered."
         }
       ],
       "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport MyProject from \"~/components/MyPortfolio/MyProject/MyProject.vue\";\nimport type { MyProjectProps } from \"~/components/MyPortfolio/MyProject/my-project.types\";\nimport type { NuxtImg } from \"#components\";\n\ndescribe(\"My Project Component\", () => {\n  const defaultProps: MyProjectProps = {\n    project: {\n      name: \"MyPortfolio.projects.portfolio.name\",\n      description: \"MyPortfolio.projects.portfolio.description\",\n      image: \"portfolio-thumbnail.webp\",\n      url: \"https://www.antoinezanardi.fr\",\n    },\n  };\n  let wrapper: ReturnType<typeof mount<typeof MyProject>>;\n\n  async function mountMyProjectComponent(options: ComponentMountingOptions<typeof MyProject> = {}): Promise<ReturnType<typeof mount<typeof MyProject>>> {\n    return mountSuspendedComponent(MyProject, {\n      props: defaultProps,\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountMyProjectComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Image\", () => {\n    it(\"should set alt to project name when rendered.\", () => {\n      const image = wrapper.findComponent<typeof NuxtImg>(\".project-image\");\n\n      expect(image.attributes(\"alt\")).toBe(defaultProps.project.name);\n    });\n\n    it(\"should set image source when rendered.\", () => {\n      const image = wrapper.findComponent<typeof NuxtImg>(\".project-image\");\n\n      expect(image.props(\"src\")).toBe(\"/images/projects/portfolio-thumbnail.webp\");\n    });\n  });\n\n  describe(\"Project\", () => {\n    it(\"should render project name when rendered.\", () => {\n      const projectName = wrapper.find<HTMLHeadingElement>(\".project-name\");\n\n      expect(projectName.text()).toBe(\"MyPortfolio.projects.portfolio.name\");\n    });\n\n    it(\"should render project description when rendered.\", () => {\n      const projectDescription = wrapper.find<HTMLParagraphElement>(\".project-desc\");\n\n      expect(projectDescription.text()).toBe(\"MyPortfolio.projects.portfolio.description\");\n    });\n  });\n});"
     },
-    "tests/unit/specs/components/shared/Layouts/SectionTitle/SectionTitle.nuxt.spec.ts": {
-      "tests": [
-        {
-          "id": "127",
-          "name": "Section Title Component should match snapshot when rendered."
-        },
-        {
-          "id": "128",
-          "name": "Section Title Component Icon should set icon source when rendered."
-        },
-        {
-          "id": "129",
-          "name": "Section Title Component Icon should set icon color to default when it is not provided in props."
-        },
-        {
-          "id": "130",
-          "name": "Section Title Component Icon should set icon color to provided color when it is provided in props."
-        },
-        {
-          "id": "131",
-          "name": "Section Title Component Title should set title when rendered."
-        }
-      ],
-      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport type WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type { SectionTitleProps } from \"~/components/shared/Layouts/SectionTitle/section-title.types\";\n\nimport SectionTitle from \"@/components/shared/Layouts/SectionTitle/SectionTitle.vue\";\n\ndescribe(\"Section Title Component\", () => {\n  const defaultProps: SectionTitleProps = {\n    icon: \"icon\",\n    title: \"title\",\n  };\n  let wrapper: ReturnType<typeof mount<typeof SectionTitle>>;\n\n  async function mountSectionTitleComponent(options: ComponentMountingOptions<typeof SectionTitle> = {}):\n  Promise<ReturnType<typeof mount<typeof SectionTitle>>> {\n    return mountSuspendedComponent(SectionTitle, {\n      props: defaultProps,\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountSectionTitleComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Icon\", () => {\n    it(\"should set icon source when rendered.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\"#section-title-icon\");\n\n      expect(icon.props(\"icon\")).toBe(\"icon\");\n    });\n\n    it(\"should set icon color to default when it is not provided in props.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\"#section-title-icon\");\n\n      expect(icon.attributes(\"iconcolor\")).toBe(\"#000000\");\n    });\n\n    it(\"should set icon color to provided color when it is provided in props.\", async() => {\n      wrapper = await mountSectionTitleComponent({\n        props: {\n          ...defaultProps,\n          iconColor: \"#FFFFFF\",\n        },\n      });\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\"#section-title-icon\");\n\n      expect(icon.attributes(\"iconcolor\")).toBe(\"#FFFFFF\");\n    });\n  });\n\n  describe(\"Title\", () => {\n    it(\"should set title when rendered.\", () => {\n      const title = wrapper.find<HTMLSpanElement>(\".section-title-text\");\n\n      expect(title.text()).toBe(\"title\");\n    });\n  });\n});"
-    },
-    "tests/unit/specs/components/MySkills/MyTool/MyTool.nuxt.spec.ts": {
-      "tests": [
-        {
-          "id": "132",
-          "name": "My Tool Component should match snapshot when rendered."
-        },
-        {
-          "id": "133",
-          "name": "My Tool Component Tool Icon should pass icon classes when rendered."
-        },
-        {
-          "id": "134",
-          "name": "My Tool Component Tool Icon should pass tool color when rendered."
-        },
-        {
-          "id": "135",
-          "name": "My Tool Component Tool Icon should pass tool description when rendered."
-        }
-      ],
-      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type { MyToolProps } from \"~/components/MySkills/MyTool/my-tool.types\";\nimport MyTool from \"~/components/MySkills/MyTool/MyTool.vue\";\nimport type WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\n\ndescribe(\"My Tool Component\", () => {\n  const defaultProps: MyToolProps = {\n    tool: {\n      color: \"#3498db\",\n      description: \"MySkills.tools.vuejs\",\n      iconClasses: \"fab fa-vuejs\",\n    },\n  };\n  let wrapper: ReturnType<typeof mount<typeof MyTool>>;\n\n  async function mountMyToolComponent(options: ComponentMountingOptions<typeof MyTool> = {}): Promise<ReturnType<typeof mount<typeof MyTool>>> {\n    return mountSuspendedComponent(MyTool, {\n      props: defaultProps,\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountMyToolComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Tool Icon\", () => {\n    it(\"should pass icon classes when rendered.\", () => {\n      const toolIcon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".tool\");\n\n      expect(toolIcon.attributes(\"icon\")).toBe(defaultProps.tool.iconClasses);\n    });\n\n    it(\"should pass tool color when rendered.\", () => {\n      const toolIcon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".tool\");\n\n      expect(toolIcon.attributes(\"iconcolor\")).toBe(defaultProps.tool.color);\n    });\n\n    it(\"should pass tool description when rendered.\", () => {\n      const toolIcon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".tool\");\n\n      expect(toolIcon.attributes(\"title\")).toBe(defaultProps.tool.description);\n    });\n  });\n});"
-    },
     "tests/unit/specs/components/OgImage/DefaultOgImage.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "136",
+          "id": "128",
           "name": "Default Og Image Component should match snapshot when rendered."
         },
         {
-          "id": "137",
+          "id": "129",
           "name": "Default Og Image Component Og Image Title should set Og Image title when rendered."
         },
         {
-          "id": "138",
+          "id": "130",
           "name": "Default Og Image Component Og Image Title should set Og Image subtitle when rendered."
         }
       ],
       "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport { ANTOINE_ZANARDI_FULL_NAME } from \"~/shared/constants/antoine-zanardi.constants\";\n\nimport DefaultOgImage from \"@/components/OgImage/DefaultOgImage.vue\";\n\ndescribe(\"Default Og Image Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof DefaultOgImage>>;\n\n  async function mountDefaultOgImageComponent(options: ComponentMountingOptions<typeof DefaultOgImage> = {}): Promise<ReturnType<typeof mount<typeof DefaultOgImage>>> {\n    return mountSuspendedComponent(DefaultOgImage, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountDefaultOgImageComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Og Image Title\", () => {\n    it(\"should set Og Image title when rendered.\", () => {\n      const title = wrapper.find(\"#og-image-title\");\n\n      expect(title.text()).toBe(ANTOINE_ZANARDI_FULL_NAME);\n    });\n\n    it(\"should set Og Image subtitle when rendered.\", () => {\n      const subtitle = wrapper.find(\"#og-image-subtitle\");\n\n      expect(subtitle.text()).toBe(\"Expert Web FullStack basé à Lille, qui allie qualité, IA et efficacité\");\n    });\n  });\n});"
     },
-    "tests/unit/specs/components/MyProfile/MyProfile.nuxt.spec.ts": {
+    "tests/unit/specs/app.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "139",
-          "name": "My Profile Component should match snapshot when rendered."
+          "id": "131",
+          "name": "App Component should match snapshot when rendered."
+        },
+        {
+          "id": "132",
+          "name": "App Component should define og image component when rendered."
+        },
+        {
+          "id": "133",
+          "name": "App Component should use head for sso purposes when rendered."
+        },
+        {
+          "id": "134",
+          "name": "App Component should stamp a comment in HTML when rendered."
         }
       ],
-      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { MyProfile } from \"#components\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\ndescribe(\"My Profile Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof MyProfile>>;\n\n  async function mountMyProfileComponent(options: ComponentMountingOptions<typeof MyProfile> = {}): Promise<ReturnType<typeof mount<typeof MyProfile>>> {\n    return mountSuspendedComponent(MyProfile, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountMyProfileComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n});"
+      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\nimport { stampInHtml } from \"dev-stamp\";\n\nimport App from \"@/App.vue\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\nvi.mock(\"dev-stamp\");\n\ndescribe(\"App Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof App>>;\n\n  async function mountAppComponent(options: ComponentMountingOptions<typeof App> = {}): Promise<ReturnType<typeof mount<typeof App>>> {\n    return mountSuspendedComponent(App, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountAppComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  it(\"should define og image component when rendered.\", () => {\n    expect(defineOgImageComponent).toHaveBeenCalledExactlyOnceWith(\"DefaultOgImage\");\n  });\n\n  it(\"should use head for sso purposes when rendered.\", () => {\n    const expectedUseHeadAttribute = {\n      title: \"App.meta.title\",\n      meta: [{ name: \"description\", content: \"App.meta.description\" }],\n      htmlAttrs: { lang: \"fr\" },\n    };\n\n    expect(useHead).toHaveBeenNthCalledWith(1, expectedUseHeadAttribute);\n  });\n\n  it(\"should stamp a comment in HTML when rendered.\", () => {\n    const expectedComment = \"👋 Hey ! J'ai aussi créé 💮 `dev-stamp` qui a généré ce message ! Retrouvez le sur GitHub ou npm !\";\n\n    expect(stampInHtml).toHaveBeenCalledExactlyOnceWith(expectedComment);\n  });\n});"
+    },
+    "tests/unit/specs/components/MySkills/MyTool/MyTool.nuxt.spec.ts": {
+      "tests": [
+        {
+          "id": "135",
+          "name": "My Tool Component should match snapshot when rendered."
+        },
+        {
+          "id": "136",
+          "name": "My Tool Component Tool Icon should pass icon classes when rendered."
+        },
+        {
+          "id": "137",
+          "name": "My Tool Component Tool Icon should pass tool color when rendered."
+        },
+        {
+          "id": "138",
+          "name": "My Tool Component Tool Icon should pass tool description when rendered."
+        }
+      ],
+      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type { MyToolProps } from \"~/components/MySkills/MyTool/my-tool.types\";\nimport MyTool from \"~/components/MySkills/MyTool/MyTool.vue\";\nimport type WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\n\ndescribe(\"My Tool Component\", () => {\n  const defaultProps: MyToolProps = {\n    tool: {\n      color: \"#3498db\",\n      description: \"MySkills.tools.vuejs\",\n      iconClasses: \"fab fa-vuejs\",\n    },\n  };\n  let wrapper: ReturnType<typeof mount<typeof MyTool>>;\n\n  async function mountMyToolComponent(options: ComponentMountingOptions<typeof MyTool> = {}): Promise<ReturnType<typeof mount<typeof MyTool>>> {\n    return mountSuspendedComponent(MyTool, {\n      props: defaultProps,\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountMyToolComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Tool Icon\", () => {\n    it(\"should pass icon classes when rendered.\", () => {\n      const toolIcon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".tool\");\n\n      expect(toolIcon.attributes(\"icon\")).toBe(defaultProps.tool.iconClasses);\n    });\n\n    it(\"should pass tool color when rendered.\", () => {\n      const toolIcon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".tool\");\n\n      expect(toolIcon.attributes(\"iconcolor\")).toBe(defaultProps.tool.color);\n    });\n\n    it(\"should pass tool description when rendered.\", () => {\n      const toolIcon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".tool\");\n\n      expect(toolIcon.attributes(\"title\")).toBe(defaultProps.tool.description);\n    });\n  });\n});"
     },
     "tests/unit/specs/components/AboutMe/AboutMyProfile/AboutMyProfile.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "140",
+          "id": "139",
           "name": "AboutMyProfile Component should match snapshot when rendered."
         }
       ],
@@ -17311,33 +16313,42 @@
     "tests/unit/specs/components/PageFooter/PageFooter.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "141",
+          "id": "140",
           "name": "Page Footer Component should match snapshot when rendered."
         },
         {
-          "id": "142",
+          "id": "141",
           "name": "Page Footer Component Text should display Antoine ZANARDI and full year when rendered."
         }
       ],
       "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { PageFooter } from \"#components\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\ndescribe(\"Page Footer Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof PageFooter>>;\n\n  async function mountPageFooterComponent(options: ComponentMountingOptions<typeof PageFooter> = {}): Promise<ReturnType<typeof mount<typeof PageFooter>>> {\n    return mountSuspendedComponent(PageFooter, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountPageFooterComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Text\", () => {\n    it(\"should display Antoine ZANARDI and full year when rendered.\", () => {\n      const title = wrapper.find<HTMLDivElement>(\".title\");\n\n      expect(title.text()).toBe(\"Antoine ZANARDI - 2022\");\n    });\n  });\n});"
     },
-    "tests/unit/specs/components/shared/Buttons/GitHubButton.nuxt.spec.ts": {
+    "tests/unit/specs/components/MyProfile/MyProfile.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "143",
-          "name": "GitHub Button Component should match snapshot when rendered."
+          "id": "142",
+          "name": "My Profile Component should match snapshot when rendered."
         }
       ],
-      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\nimport GitHubButton from \"@/components/shared/Buttons/GitHubButton.vue\";\n\ndescribe(\"GitHub Button Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof GitHubButton>>;\n\n  async function mountGitHubButtonComponent(options: ComponentMountingOptions<typeof GitHubButton> = {}): Promise<ReturnType<typeof mount<typeof GitHubButton>>> {\n    return mountSuspendedComponent(GitHubButton, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountGitHubButtonComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n});"
+      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { MyProfile } from \"#components\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\ndescribe(\"My Profile Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof MyProfile>>;\n\n  async function mountMyProfileComponent(options: ComponentMountingOptions<typeof MyProfile> = {}): Promise<ReturnType<typeof mount<typeof MyProfile>>> {\n    return mountSuspendedComponent(MyProfile, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountMyProfileComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n});"
     },
     "tests/unit/specs/components/shared/Buttons/LinkedInButton.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "144",
+          "id": "143",
           "name": "LinkedIn Button Component should match snapshot when rendered."
         }
       ],
       "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\nimport LinkedInButton from \"@/components/shared/Buttons/LinkedInButton.vue\";\n\ndescribe(\"LinkedIn Button Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof LinkedInButton>>;\n\n  async function mountLinkedInButtonComponent(options: ComponentMountingOptions<typeof LinkedInButton> = {}):\n  Promise<ReturnType<typeof mount<typeof LinkedInButton>>> {\n    return mountSuspendedComponent(LinkedInButton, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountLinkedInButtonComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n});"
+    },
+    "tests/unit/specs/components/shared/Buttons/GitHubButton.nuxt.spec.ts": {
+      "tests": [
+        {
+          "id": "144",
+          "name": "GitHub Button Component should match snapshot when rendered."
+        }
+      ],
+      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\nimport GitHubButton from \"@/components/shared/Buttons/GitHubButton.vue\";\n\ndescribe(\"GitHub Button Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof GitHubButton>>;\n\n  async function mountGitHubButtonComponent(options: ComponentMountingOptions<typeof GitHubButton> = {}): Promise<ReturnType<typeof mount<typeof GitHubButton>>> {\n    return mountSuspendedComponent(GitHubButton, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountGitHubButtonComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n});"
     },
     "tests/unit/specs/components/AboutMe/AboutMe.nuxt.spec.ts": {
       "tests": [
@@ -17400,7 +16411,7 @@
       "source": "import { useDates } from \"~/composables/useDates\";\n\ndescribe(\"Use Dates Composable\", () => {\n  describe(\"getMonthFullName\", () => {\n    it(\"should return the full month name when called.\", () => {\n      const date = new Date(\"2021-01-01\");\n      const expectedMonthFullName = \"janvier\";\n      const { getMonthFullName } = useDates();\n      const result = getMonthFullName(date);\n\n      expect(result).toBe(expectedMonthFullName);\n    });\n  });\n});"
     }
   },
-  "projectRoot": "/Users/mac-Z14AZANA/WebstormProjects/antoinezanardi.fr",
+  "projectRoot": "/Users/antoinezanardi/WebstormProjects/antoinezanardi.fr",
   "config": {
     "cleanTempDir": "always",
     "incremental": true,
@@ -17543,7 +16554,7 @@
     },
     "dependencies": {
       "@stryker-mutator/typescript-checker": "9.1.1",
-      "typescript": "5.9.2"
+      "typescript": "5.9.3"
     }
   }
 }

--- a/tests/unit/specs/components/MyProfile/__snapshots__/MyProfile.nuxt.spec.ts.snap
+++ b/tests/unit/specs/components/MyProfile/__snapshots__/MyProfile.nuxt.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`My Profile Component > should match snapshot when rendered. 1`] = `
       <div data-v-d3c3f494="" class="container">
         <div data-v-d3c3f494="" class="content-center">
           <div data-v-d3c3f494="" class="cc-profile-image"><a data-v-d3c3f494="" href="https://www.linkedin.com/in/antoinezanardi/" rel="noopener noreferrer" target="_blank">
-              <nuxt-img-stub data-v-d3c3f494="" alt="Photo de profil" height="180" src="/images/antoine.webp" width="180" preload="false" crossorigin="false" placeholder="false" custom="false" id="profile-pic"></nuxt-img-stub>
+              <nuxt-img-stub data-v-d3c3f494="" alt="Photo de profil" height="180" src="/images/antoine.webp" width="180" preload="true" crossorigin="false" placeholder="false" custom="false" id="profile-pic"></nuxt-img-stub>
             </a></div>
           <h1 data-v-d3c3f494="" class="h1 text-shadow title">Antoine ZANARDI</h1>
           <h2 data-v-d3c3f494="" class="category mb-3 text-shadow text-white">Consultant Tech Lead</h2>


### PR DESCRIPTION
This pull request makes a small update to the `MyProfile` component to improve image loading performance by enabling preloading for the profile picture.

- The `preload` attribute was added to the profile image in `MyProfile.vue` to hint the browser to load the image earlier, which can improve perceived loading speed.
- The corresponding unit test snapshot was updated to reflect this change, showing `preload="true"` for the profile image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Performance
  - Improved My Profile page load experience by preloading the profile picture. This speeds up initial image rendering and reduces perceived wait time, helping minimize visual jank during page load. No changes to navigation, data flow, or error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->