### PR TITLE
feat(about-me): add personality section with ENTJ details

### DIFF
--- a/app/components/AboutMe/AboutMyPersonalInfo/AboutMyPersonalInfo.constants.ts
+++ b/app/components/AboutMe/AboutMyPersonalInfo/AboutMyPersonalInfo.constants.ts
@@ -1,0 +1,5 @@
+const ENTJ_PERSONALITY_HREF = "https://www.16personalities.com/fr/la-personnalite-entj";
+
+export {
+  ENTJ_PERSONALITY_HREF,
+};

--- a/app/components/AboutMe/AboutMyPersonalInfo/AboutMyPersonalInfo.vue
+++ b/app/components/AboutMe/AboutMyPersonalInfo/AboutMyPersonalInfo.vue
@@ -48,6 +48,42 @@
         </div>
       </div>
 
+      <div class="align-items-center mt-3 row">
+        <div class="col-sm-4">
+          <b
+            class="text-uppercase"
+          >
+            {{ `${$t('AboutMyPersonalInfo.personality')} :` }}
+          </b>
+        </div>
+
+        <div
+          id="personality"
+          class="align-items-center col-sm-8 d-flex gap-1"
+        >
+          <NuxtImg
+            aria-hidden="true"
+            height="24"
+            loading="lazy"
+            src="/svg/entj-personality.svg"
+            width="24"
+          />
+
+          <a
+            :href="ENTJ_PERSONALITY_HREF"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {{ $t('AboutMyPersonalInfo.entj') }}
+
+            <WrappedFontAwesomeIcon
+              icon="fa-arrow-up-right-from-square"
+              :icon-color="PRIMARY_COLOR"
+            />
+          </a>
+        </div>
+      </div>
+
       <div class="mt-3 row">
         <div class="col-sm-4">
           <b
@@ -186,8 +222,10 @@
 </template>
 
 <script setup lang="ts">
+import { ENTJ_PERSONALITY_HREF } from "~/components/AboutMe/AboutMyPersonalInfo/AboutMyPersonalInfo.constants";
 import WrappedFontAwesomeIcon from "~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue";
 import { ANTOINE_ZANARDI_BIRTH_DATE } from "~/shared/constants/antoine-zanardi.constants";
+import { PRIMARY_COLOR } from "~/shared/constants/style.constants";
 
 const config = useRuntimeConfig();
 

--- a/app/components/MyPortfolio/MyProject/MyProject.vue
+++ b/app/components/MyPortfolio/MyProject/MyProject.vue
@@ -33,7 +33,7 @@
             <WrappedFontAwesomeIcon
               classes="my-3"
               icon="fa-arrow-up-right-from-square"
-              icon-color="#FFFFFF"
+              :icon-color="WHITE_COLOR"
               size="2x"
             />
           </p>
@@ -46,6 +46,7 @@
 <script setup lang="ts">
 import type { MyProjectProps } from "~/components/MyPortfolio/MyProject/my-project.types";
 import WrappedFontAwesomeIcon from "~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue";
+import { WHITE_COLOR } from "~/shared/constants/style.constants";
 
 defineProps<MyProjectProps>();
 </script>

--- a/app/components/shared/Period/PeriodTimeline.vue
+++ b/app/components/shared/Period/PeriodTimeline.vue
@@ -38,7 +38,7 @@
           id="arrow-up-icon"
           classes="my-3"
           icon="fa-arrow-up"
-          icon-color="#00000"
+          :icon-color="WHITE_COLOR"
           size="2x"
         />
 
@@ -73,6 +73,7 @@ import type { PeriodTimelineProps } from "~/components/shared/Period/period-time
 import { useDates } from "~/composables/useDates";
 import WrappedFontAwesomeIcon from "~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue";
 import { Period } from "~/models/period/period.class";
+import { WHITE_COLOR } from "~/shared/constants/style.constants";
 
 const props = withDefaults(defineProps<PeriodTimelineProps>(), {
   doesShowYearOnly: false,

--- a/app/shared/constants/style.constants.ts
+++ b/app/shared/constants/style.constants.ts
@@ -1,0 +1,11 @@
+const PRIMARY_COLOR = "#12671D";
+
+const BLACK_COLOR = "#000000";
+
+const WHITE_COLOR = "#FFFFFF";
+
+export {
+  PRIMARY_COLOR,
+  BLACK_COLOR,
+  WHITE_COLOR,
+};

--- a/modules/i18n/locales/fr.json
+++ b/modules/i18n/locales/fr.json
@@ -28,6 +28,8 @@
     "personalInfo": "Informations personnelles",
     "genre": "Sexe",
     "male": "Homme",
+    "personality": "Personnalité",
+    "entj": "ENTJ - Commandant",
     "age": "Age",
     "yearsOld": "{age} ans",
     "email": "email",

--- a/public/svg/entj-personality.svg
+++ b/public/svg/entj-personality.svg
@@ -1,0 +1,134 @@
+<svg data-v-70ce7b86="" role="img" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 350 350" class="svg--imported sp-avatar avatar avf svg--avatar tw-max-w-[400px] tr--free tp--entj g--m avatar--dynamic tn--3 svg--avatar"><g><defs><style>.uam2bavklp-1{clip-path:url(#clippath);}.uam2bavklp-2{fill:none;}.uam2bavklp-2,.uam2bavklp-3,.uam2bavklp-4,.uam2bavklp-5,.uam2bavklp-6,.uam2bavklp-7,.uam2bavklp-8,.uam2bavklp-9,.uam2bavklp-10,.uam2bavklp-11,.uam2bavklp-12,.uam2bavklp-13,.uam2bavklp-14,.uam2bavklp-15,.uam2bavklp-16{stroke-width:0px;}.uam2bavklp-3{fill:#846651;}.uam2bavklp-3,.uam2bavklp-4,.uam2bavklp-5,.uam2bavklp-6,.uam2bavklp-7,.uam2bavklp-8,.uam2bavklp-9,.uam2bavklp-10,.uam2bavklp-11,.uam2bavklp-12,.uam2bavklp-13,.uam2bavklp-14,.uam2bavklp-15,.uam2bavklp-16{fill-rule:evenodd;}.uam2bavklp-4{fill:#2b2b2b;}.uam2bavklp-5{fill:#785d81;}.uam2bavklp-6{fill:#543042;}.uam2bavklp-7{fill:#897599;}.uam2bavklp-8{fill:#d8b69e;}.uam2bavklp-9{fill:#bc917b;}.uam2bavklp-10{fill:#ca9ab1;}.uam2bavklp-11{fill:#c7c7c6;}.uam2bavklp-12{fill:#e1c3af;}.uam2bavklp-13{fill:#ac8196;}.uam2bavklp-14{fill:#734d60;}.uam2bavklp-15{fill:#9f81b3;}.uam2bavklp-16{fill:#8f637c;}
+  .avatar--face.type--entj.gender--m.tier--free.tone--1 .uam2bavklp-12 {
+  fill: #fbeae2;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--1 .uam2bavklp-8 {
+  fill: #e6d1c3;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--1 .uam2bavklp-9 {
+  fill: #c3a491;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--1 .uam2bavklp-3 {
+  fill: #9c7965;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--2 .uam2bavklp-12 {
+  fill: #f6e4db;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--2 .uam2bavklp-8 {
+  fill: #dbc4b6;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--2 .uam2bavklp-9 {
+  fill: #b99985;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--2 .uam2bavklp-3 {
+  fill: #92715d;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--3 .uam2bavklp-12 {
+  fill: #eedacf;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--3 .uam2bavklp-8 {
+  fill: #d4baaa;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--3 .uam2bavklp-9 {
+  fill: #b18e79;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--3 .uam2bavklp-3 {
+  fill: #92715d;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--4 .uam2bavklp-12 {
+  fill: #e6d1c3;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--4 .uam2bavklp-8 {
+  fill: #cbaf9e;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--4 .uam2bavklp-9 {
+  fill: #ac8972;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--4 .uam2bavklp-3 {
+  fill: #7a5e4d;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--5 .uam2bavklp-12 {
+  fill: #dbc4b6;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--5 .uam2bavklp-8 {
+  fill: #c3a491;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--5 .uam2bavklp-9 {
+  fill: #9c7965;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--5 .uam2bavklp-3 {
+  fill: #6e5444;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--6 .uam2bavklp-12 {
+  fill: #d4baaa;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--6 .uam2bavklp-8 {
+  fill: #b99985;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--6 .uam2bavklp-9 {
+  fill: #92715d;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--6 .uam2bavklp-3 {
+  fill: #634a3c;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--7 .uam2bavklp-12 {
+  fill: #cbaf9e;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--7 .uam2bavklp-8 {
+  fill: #b18e79;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--7 .uam2bavklp-9 {
+  fill: #92715d;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--7 .uam2bavklp-3 {
+  fill: #564134;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--8 .uam2bavklp-12 {
+  fill: #c3a491;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--8 .uam2bavklp-8 {
+  fill: #ac8972;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--8 .uam2bavklp-9 {
+  fill: #7a5e4d;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--8 .uam2bavklp-3 {
+  fill: #4b372c;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--9 .uam2bavklp-12 {
+  fill: #b99985;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--9 .uam2bavklp-8 {
+  fill: #9c7965;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--9 .uam2bavklp-9 {
+  fill: #6e5444;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--9 .uam2bavklp-3 {
+  fill: #3f2d23;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--10 .uam2bavklp-12 {
+  fill: #b18e79;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--10 .uam2bavklp-8 {
+  fill: #92715d;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--10 .uam2bavklp-9 {
+  fill: #634a3c;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--10 .uam2bavklp-3 {
+  fill: #39281f;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--11 .uam2bavklp-12 {
+  fill: #ac8972;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--11 .uam2bavklp-8 {
+  fill: #92715d;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--11 .uam2bavklp-9 {
+  fill: #564134;
+  }
+  .avatar--face.type--entj.gender--m.tier--free.tone--11 .uam2bavklp-3 {
+  fill: #37271e;
+  }
+</style><clipPath id="clippath"><rect class="cls-2 uam2bavklp-2" x="0" y=".1" width="350" height="350"></rect></clipPath></defs><g class="cls-1 uam2bavklp-1"><polygon class="cls-5 uam2bavklp-5" points="278.9 318.8 219.5 330.6 194.5 301.6 257.6 275.9 278.9 318.8"></polygon><polygon class="cls-16 uam2bavklp-16" points="298.1 357.2 317.1 395.4 300.5 415.3 278.1 414.9 238.7 369.1 260.4 349.5 298.1 357.2"></polygon><polygon class="cls-13 uam2bavklp-13" points="298.1 357.2 238.7 369.1 213.7 340 276.8 314.4 298.1 357.2"></polygon><polygon class="cls-7 uam2bavklp-7" points="218.6 290.6 197 310.4 195.7 359.6 206.4 402.7 237.3 423.8 234.1 350 218.6 290.6"></polygon><polygon class="cls-15 uam2bavklp-15" points="197 310.4 170.9 301.6 166.6 362.1 173.5 427.1 206.4 402.7 197 310.4"></polygon><polygon class="cls-11 uam2bavklp-11" points="227.3 324.8 168.5 327.2 169.3 344.6 229.4 338.4 227.3 324.8"></polygon><polygon class="cls-15 uam2bavklp-15" points="114.7 282.4 71.6 302.4 126.4 340.2 123.4 285.4 114.7 282.4"></polygon><polygon class="cls-5 uam2bavklp-5" points="71.6 302.4 68.1 340.2 132.4 352.1 122 327.6 71.6 302.4"></polygon><polygon class="cls-13 uam2bavklp-13" points="121.4 344.9 68.1 340.2 62.5 399.6 132.4 383.9 121.4 344.9"></polygon><polygon class="cls-6 uam2bavklp-6" points="256.2 256.1 264.1 466.4 237.3 423.8 218.6 290.6 232 275.2 256.2 256.1"></polygon><polygon class="cls-14 uam2bavklp-14" points="170.9 301.6 173.5 427.1 106.5 495.5 114.7 282.4 150.4 286.3 170.9 301.6"></polygon><polygon class="cls-8 uam2bavklp-8" points="132.4 262 138.3 242.1 132.4 213.6 123.1 212.6 115.7 220.6 114.4 210.5 110.6 207.9 110.6 141.2 223.1 112.7 259.9 231.5 220.1 244.2 204.5 275.1 197 310.4 191.5 287.3 179.8 274.9 159.9 262.3 132.4 262"></polygon><polygon class="cls-9 uam2bavklp-9" points="136.2 134.7 144.8 149 148 157.6 175.5 259.3 220.1 244.2 207.6 262 208.6 277.3 210.2 290.6 197 310.4 175.9 285.4 132.4 262 132.4 231.3 136.8 217.1 132.4 213.6 115.7 220.6 110.6 207.9 114.7 184 110.6 141.2 136.2 134.7"></polygon><polygon class="cls-3 uam2bavklp-3" points="124.1 194.5 134 199 121.4 206.3 118.8 199.7 124.1 194.5"></polygon><polygon class="cls-9 uam2bavklp-9" points="148 157.6 171.7 155.2 189.4 184 175.9 142.9 148 157.6"></polygon><polygon class="cls-9 uam2bavklp-9" points="219.6 134.5 202.1 157.2 195.7 137 219.6 134.5"></polygon><polygon class="cls-12 uam2bavklp-12" points="195.7 137 208.3 178.6 189.4 184 175.9 142.9 195.7 137"></polygon><polygon class="cls-3 uam2bavklp-3" points="208.3 178.6 202.9 189.9 189.4 184 208.3 178.6"></polygon><polygon class="cls-3 uam2bavklp-3" points="159.9 262.3 208.6 277.3 220.1 244.2 159.9 262.3"></polygon><polygon class="cls-3 uam2bavklp-3" points="237.9 196.3 170.3 216.2 171.9 222.2 240 201.7 237.9 196.3"></polygon><polygon class="cls-7 uam2bavklp-7" points="110.6 141.2 132.4 186.1 110.6 207.9 110.6 141.2"></polygon><polygon class="cls-14 uam2bavklp-14" points="49.3 191.8 61.8 186.1 68.6 176.7 83.3 144.4 90.6 106.1 104.7 84.3 96.3 56.7 146.3 51.2 180.6 34.1 200.5 61.4 221.4 79.8 237.8 101.7 253.2 115.4 259.9 126.7 278 128.8 250.7 147.8 240.3 162.2 234.3 137.3 223.1 112.7 164.1 124.1 110.6 141.2 108.5 179.1 110.6 207.9 78.6 206 50.9 212.2 53.8 202.7 49.3 191.8"></polygon><polygon class="cls-13 uam2bavklp-13" points="49.3 191.8 99.3 195 68.6 176.7 49.3 191.8"></polygon><polygon class="cls-16 uam2bavklp-16" points="99.3 195 105.8 131 85.2 106.1 68.6 176.7 99.3 195"></polygon><polygon class="cls-6 uam2bavklp-6" points="105.8 131 181.1 108.9 96.3 56.7 85.2 106.1 105.8 131"></polygon><polygon class="cls-14 uam2bavklp-14" points="181.1 108.9 221.5 96.5 221.4 79.8 180.6 34.1 164.8 97.1 181.1 108.9"></polygon><polygon class="cls-10 uam2bavklp-10" points="180.6 34.1 164.8 97.1 96.3 56.7 180.6 34.1"></polygon><polygon class="cls-16 uam2bavklp-16" points="253.2 115.4 249.5 138 221.5 96.5 221.4 79.8 253.2 115.4"></polygon><polygon class="cls-13 uam2bavklp-13" points="253.2 115.4 249.5 138 285.2 125.2 253.2 115.4"></polygon><polygon class="cls-6 uam2bavklp-6" points="285.2 125.2 285.2 138 239.5 165.7 223.1 112.7 221.5 96.5 249.5 134.7 285.2 125.2"></polygon><polygon class="cls-6 uam2bavklp-6" points="105.8 131 110.6 141.2 110.6 207.9 50.9 212.2 49.3 191.8 87.2 187.8 105.8 131"></polygon><polygon class="cls-16 uam2bavklp-16" points="221.5 96.5 181.1 108.9 105.8 131 110.6 141.2 223.1 112.7 221.5 96.5"></polygon><polygon class="cls-16 uam2bavklp-16" points="148.8 54 153.7 25.5 128.9 1.8 148.8 54"></polygon><polygon class="cls-13 uam2bavklp-13" points="148.8 54 128.9 1.8 122.5 31.4 148.8 54"></polygon><polygon class="cls-3 uam2bavklp-3" points="132.4 213.6 145.3 207.6 132.4 231.3 132.4 213.6"></polygon><polygon class="cls-16 uam2bavklp-16" points="179.8 274.9 132.4 262 103.9 251.8 114.7 282.4 197 310.4 179.8 274.9"></polygon><polygon class="cls-6 uam2bavklp-6" points="132.4 244.2 103.9 251.8 132.4 262 132.4 244.2"></polygon><polygon class="cls-16 uam2bavklp-16" points="220.1 244.2 197 310.4 256.2 256.1 220.1 244.2"></polygon><path class="cls-4 uam2bavklp-4" d="m171,156.2c0,3.1-2.5,5.7-5.7,5.7s-5.7-2.5-5.7-5.7,2.5-5.7,5.7-5.7,5.7,2.5,5.7,5.7Z"></path><path class="cls-4 uam2bavklp-4" d="m213.3,142.9c0,3.1-2.5,5.7-5.7,5.7s-5.7-2.5-5.7-5.7,2.5-5.7,5.7-5.7,5.7,2.5,5.7,5.7Z"></path><polygon class="cls-7 uam2bavklp-7" points="216.9 122.6 144.8 149 148 157.6 219.6 134.5 216.9 122.6"></polygon></g></g></svg>

--- a/tests/acceptance/features/home/features/about-me/about-me.feature
+++ b/tests/acceptance/features/home/features/about-me/about-me.feature
@@ -20,6 +20,8 @@ Feature: 👤 Home Page - About Me Section
     And the exact text "Homme" should be visible
     And the exact text "Age :" should be visible
     And the text with regexp "\d{2} ans" should be visible
+    And the exact text "Personnalité :" should be visible
+    And the exact text "ENTJ - Commandant" should be visible
     And the exact text "email :" should be visible
     And the link with exact name "Envoyez-moi un email à john@doe.com" should be visible
     And the exact text "Téléphone :" should be visible

--- a/tests/stryker/incremental/incremental.json
+++ b/tests/stryker/incremental/incremental.json
@@ -12,13 +12,13 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "79"
+            "124"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80"
+            "122",
+            "123",
+            "124",
+            "125"
           ],
           "location": {
             "end": {
@@ -40,13 +40,13 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "79"
+            "124"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80"
+            "122",
+            "123",
+            "124",
+            "125"
           ],
           "location": {
             "end": {
@@ -68,13 +68,13 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "79"
+            "124"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80"
+            "122",
+            "123",
+            "124",
+            "125"
           ],
           "location": {
             "end": {
@@ -96,13 +96,13 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "79"
+            "124"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80"
+            "122",
+            "123",
+            "124",
+            "125"
           ],
           "location": {
             "end": {
@@ -124,13 +124,13 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "79"
+            "124"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80"
+            "122",
+            "123",
+            "124",
+            "125"
           ],
           "location": {
             "end": {
@@ -152,13 +152,13 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "79"
+            "124"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80"
+            "122",
+            "123",
+            "124",
+            "125"
           ],
           "location": {
             "end": {
@@ -180,13 +180,13 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "79"
+            "124"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80"
+            "122",
+            "123",
+            "124",
+            "125"
           ],
           "location": {
             "end": {
@@ -208,13 +208,13 @@
           "testsCompleted": 2,
           "static": false,
           "killedBy": [
-            "78"
+            "123"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80"
+            "122",
+            "123",
+            "124",
+            "125"
           ],
           "location": {
             "end": {
@@ -236,13 +236,13 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "80"
+            "125"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80"
+            "122",
+            "123",
+            "124",
+            "125"
           ],
           "location": {
             "end": {
@@ -264,13 +264,13 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "77"
+            "122"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80"
+            "122",
+            "123",
+            "124",
+            "125"
           ],
           "location": {
             "end": {
@@ -310,13 +310,13 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "80"
+            "125"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80"
+            "122",
+            "123",
+            "124",
+            "125"
           ],
           "location": {
             "end": {
@@ -344,23 +344,23 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "67"
+            "59"
           ],
           "coveredBy": [
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
+            "59",
+            "60",
+            "61",
+            "62",
+            "63"
           ],
           "location": {
             "end": {
               "column": 2,
-              "line": 199
+              "line": 237
             },
             "start": {
               "column": 36,
-              "line": 194
+              "line": 232
             }
           }
         },
@@ -373,23 +373,23 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "67"
+            "59"
           ],
           "coveredBy": [
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
+            "59",
+            "60",
+            "61",
+            "62",
+            "63"
           ],
           "location": {
             "end": {
               "column": 80,
-              "line": 198
+              "line": 236
             },
             "start": {
               "column": 10,
-              "line": 198
+              "line": 236
             }
           }
         },
@@ -402,23 +402,23 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "67"
+            "59"
           ],
           "coveredBy": [
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
+            "59",
+            "60",
+            "61",
+            "62",
+            "63"
           ],
           "location": {
             "end": {
               "column": 50,
-              "line": 198
+              "line": 236
             },
             "start": {
               "column": 19,
-              "line": 198
+              "line": 236
             }
           }
         },
@@ -431,23 +431,23 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "67"
+            "59"
           ],
           "coveredBy": [
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
+            "59",
+            "60",
+            "61",
+            "62",
+            "63"
           ],
           "location": {
             "end": {
               "column": 2,
-              "line": 205
+              "line": 243
             },
             "start": {
               "column": 53,
-              "line": 201
+              "line": 239
             }
           }
         },
@@ -460,23 +460,23 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "67"
+            "59"
           ],
           "coveredBy": [
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
+            "59",
+            "60",
+            "61",
+            "62",
+            "63"
           ],
           "location": {
             "end": {
               "column": 59,
-              "line": 202
+              "line": 240
             },
             "start": {
               "column": 51,
-              "line": 202
+              "line": 240
             }
           }
         },
@@ -489,23 +489,23 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "67"
+            "59"
           ],
           "coveredBy": [
-            "67",
-            "68",
-            "69",
-            "70",
-            "71"
+            "59",
+            "60",
+            "61",
+            "62",
+            "63"
           ],
           "location": {
             "end": {
               "column": 36,
-              "line": 204
+              "line": 242
             },
             "start": {
               "column": 33,
-              "line": 204
+              "line": 242
             }
           }
         },
@@ -518,24 +518,24 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "70"
+            "62"
           ],
           "coveredBy": [
-            "70"
+            "62"
           ],
           "location": {
             "end": {
               "column": 43,
-              "line": 204
+              "line": 242
             },
             "start": {
               "column": 40,
-              "line": 204
+              "line": 242
             }
           }
         }
       ],
-      "source": "<template>\n  <div>\n    <div class=\"card-body\">\n      <h3 class=\"h3 mb-2 mt-0 title\">\n        <WrappedFontAwesomeIcon\n          classes=\"me-2\"\n          icon=\"fa-id-card\"\n        />\n\n        <span>\n          {{ $t('AboutMyPersonalInfo.personalInfo') }}\n        </span>\n      </h3>\n\n      <hr>\n\n      <div class=\"row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.genre')} :` }}\n          </b>\n        </div>\n\n        <div\n          id=\"genre\"\n          class=\"col-sm-8\"\n        >\n          {{ $t('AboutMyPersonalInfo.male') }}\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.age')} :` }}\n          </b>\n        </div>\n\n        <div\n          id=\"age\"\n          class=\"col-sm-8\"\n        >\n          {{ $t('AboutMyPersonalInfo.yearsOld', { age }) }}\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.email')} :` }}\n          </b>\n        </div>\n\n        <div class=\"col-sm-8\">\n          <b>\n            <a\n              :aria-label=\"$t('AboutMyPersonalInfo.emailLink', { 'email': config.public.email })\"\n              :href=\"`mailto:${config.public.email}`\"\n            >\n              {{ config.public.email }}\n            </a>\n          </b>\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.phone')} :` }}\n          </b>\n        </div>\n\n        <div class=\"col-sm-8\">\n          <b>\n            <a\n              id=\"phone-number\"\n              :aria-label=\"$t('AboutMyPersonalInfo.phoneLink', { 'phone': formattedPhoneNumber })\"\n              :href=\"`tel:${config.public.phoneNumber}`\"\n            >\n              {{ formattedPhoneNumber }}\n            </a>\n          </b>\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.address')} :` }}\n          </b>\n        </div>\n\n        <div\n          id=\"address\"\n          class=\"col-sm-8\"\n        >\n          {{ config.public.address }}\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.languages')} :` }}\n          </b>\n        </div>\n\n        <div\n          class=\"col-sm-8\"\n        >\n          {{ $t('AboutMyPersonalInfo.englishAndFrench') }}\n        </div>\n      </div>\n\n      <div class=\"align-items-center mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.licenses')} :` }}\n          </b>\n        </div>\n\n        <div class=\"col-sm-8 d-flex\">\n          <WrappedFontAwesomeIcon\n            :aria-label=\"$t('AboutMyPersonalInfo.car')\"\n            class=\"me-2\"\n            data-bs-toggle=\"tooltip\"\n            icon=\"fa-car\"\n            role=\"img\"\n            size=\"2x\"\n            :title=\"$t('AboutMyPersonalInfo.car')\"\n          />\n\n          <WrappedFontAwesomeIcon\n            :aria-label=\"$t('AboutMyPersonalInfo.boat')\"\n            class=\"me-2\"\n            data-bs-toggle=\"tooltip\"\n            icon=\"fa-anchor\"\n            role=\"img\"\n            size=\"2x\"\n            :title=\"$t('AboutMyPersonalInfo.boat')\"\n          />\n        </div>\n      </div>\n\n      <div class=\"align-items-center mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.workingAt')} :` }}\n          </b>\n        </div>\n\n        <div class=\"col-sm-8\">\n          <a\n            :aria-label=\"$t('AboutMyPersonalInfo.companyLink', { 'company': 'Daveo' })\"\n            href=\"https://www.daveo.fr/\"\n            rel=\"noopener noreferrer\"\n            target=\"_blank\"\n          >\n            <NuxtImg\n              alt=\"Daveo\"\n              class=\"daveo-logo\"\n              loading=\"lazy\"\n              src=\"/images/logos/daveo-logo.webp\"\n            />\n          </a>\n        </div>\n      </div>\n    </div>\n  </div>\n</template>\n\n<script setup lang=\"ts\">\nimport WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\nimport { ANTOINE_ZANARDI_BIRTH_DATE } from \"~/shared/constants/antoine-zanardi.constants\";\n\nconst config = useRuntimeConfig();\n\nconst age = computed<number>(() => {\n  const birthday = new Date(ANTOINE_ZANARDI_BIRTH_DATE);\n  const epochYear = 1970;\n\n  return new Date(Date.now() - birthday.getTime()).getUTCFullYear() - epochYear;\n});\n\nconst formattedPhoneNumber = computed<string>(() => {\n  const matches = config.public.phoneNumber.match(/.{2}/gu);\n\n  return matches ? matches.join(\" \") : \"?\";\n});\n</script>\n\n<style lang=\"scss\" scoped>\n.daveo-logo {\n  margin-left: -5px;\n  width: 150px;\n}\n</style>"
+      "source": "<template>\n  <div>\n    <div class=\"card-body\">\n      <h3 class=\"h3 mb-2 mt-0 title\">\n        <WrappedFontAwesomeIcon\n          classes=\"me-2\"\n          icon=\"fa-id-card\"\n        />\n\n        <span>\n          {{ $t('AboutMyPersonalInfo.personalInfo') }}\n        </span>\n      </h3>\n\n      <hr>\n\n      <div class=\"row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.genre')} :` }}\n          </b>\n        </div>\n\n        <div\n          id=\"genre\"\n          class=\"col-sm-8\"\n        >\n          {{ $t('AboutMyPersonalInfo.male') }}\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.age')} :` }}\n          </b>\n        </div>\n\n        <div\n          id=\"age\"\n          class=\"col-sm-8\"\n        >\n          {{ $t('AboutMyPersonalInfo.yearsOld', { age }) }}\n        </div>\n      </div>\n\n      <div class=\"align-items-center mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.personality')} :` }}\n          </b>\n        </div>\n\n        <div\n          id=\"personality\"\n          class=\"align-items-center col-sm-8 d-flex gap-1\"\n        >\n          <NuxtImg\n            aria-hidden=\"true\"\n            height=\"24\"\n            loading=\"lazy\"\n            src=\"/svg/entj-personality.svg\"\n            width=\"24\"\n          />\n\n          <a\n            :href=\"ENTJ_PERSONALITY_HREF\"\n            rel=\"noopener noreferrer\"\n            target=\"_blank\"\n          >\n            {{ $t('AboutMyPersonalInfo.entj') }}\n\n            <WrappedFontAwesomeIcon\n              icon=\"fa-arrow-up-right-from-square\"\n              :icon-color=\"PRIMARY_COLOR\"\n            />\n          </a>\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.email')} :` }}\n          </b>\n        </div>\n\n        <div class=\"col-sm-8\">\n          <b>\n            <a\n              :aria-label=\"$t('AboutMyPersonalInfo.emailLink', { 'email': config.public.email })\"\n              :href=\"`mailto:${config.public.email}`\"\n            >\n              {{ config.public.email }}\n            </a>\n          </b>\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.phone')} :` }}\n          </b>\n        </div>\n\n        <div class=\"col-sm-8\">\n          <b>\n            <a\n              id=\"phone-number\"\n              :aria-label=\"$t('AboutMyPersonalInfo.phoneLink', { 'phone': formattedPhoneNumber })\"\n              :href=\"`tel:${config.public.phoneNumber}`\"\n            >\n              {{ formattedPhoneNumber }}\n            </a>\n          </b>\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.address')} :` }}\n          </b>\n        </div>\n\n        <div\n          id=\"address\"\n          class=\"col-sm-8\"\n        >\n          {{ config.public.address }}\n        </div>\n      </div>\n\n      <div class=\"mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.languages')} :` }}\n          </b>\n        </div>\n\n        <div\n          class=\"col-sm-8\"\n        >\n          {{ $t('AboutMyPersonalInfo.englishAndFrench') }}\n        </div>\n      </div>\n\n      <div class=\"align-items-center mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.licenses')} :` }}\n          </b>\n        </div>\n\n        <div class=\"col-sm-8 d-flex\">\n          <WrappedFontAwesomeIcon\n            :aria-label=\"$t('AboutMyPersonalInfo.car')\"\n            class=\"me-2\"\n            data-bs-toggle=\"tooltip\"\n            icon=\"fa-car\"\n            role=\"img\"\n            size=\"2x\"\n            :title=\"$t('AboutMyPersonalInfo.car')\"\n          />\n\n          <WrappedFontAwesomeIcon\n            :aria-label=\"$t('AboutMyPersonalInfo.boat')\"\n            class=\"me-2\"\n            data-bs-toggle=\"tooltip\"\n            icon=\"fa-anchor\"\n            role=\"img\"\n            size=\"2x\"\n            :title=\"$t('AboutMyPersonalInfo.boat')\"\n          />\n        </div>\n      </div>\n\n      <div class=\"align-items-center mt-3 row\">\n        <div class=\"col-sm-4\">\n          <b\n            class=\"text-uppercase\"\n          >\n            {{ `${$t('AboutMyPersonalInfo.workingAt')} :` }}\n          </b>\n        </div>\n\n        <div class=\"col-sm-8\">\n          <a\n            :aria-label=\"$t('AboutMyPersonalInfo.companyLink', { 'company': 'Daveo' })\"\n            href=\"https://www.daveo.fr/\"\n            rel=\"noopener noreferrer\"\n            target=\"_blank\"\n          >\n            <NuxtImg\n              alt=\"Daveo\"\n              class=\"daveo-logo\"\n              loading=\"lazy\"\n              src=\"/images/logos/daveo-logo.webp\"\n            />\n          </a>\n        </div>\n      </div>\n    </div>\n  </div>\n</template>\n\n<script setup lang=\"ts\">\nimport { ENTJ_PERSONALITY_HREF } from \"~/components/AboutMe/AboutMyPersonalInfo/AboutMyPersonalInfo.constants\";\nimport WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\nimport { ANTOINE_ZANARDI_BIRTH_DATE } from \"~/shared/constants/antoine-zanardi.constants\";\nimport { PRIMARY_COLOR } from \"~/shared/constants/style.constants\";\n\nconst config = useRuntimeConfig();\n\nconst age = computed<number>(() => {\n  const birthday = new Date(ANTOINE_ZANARDI_BIRTH_DATE);\n  const epochYear = 1970;\n\n  return new Date(Date.now() - birthday.getTime()).getUTCFullYear() - epochYear;\n});\n\nconst formattedPhoneNumber = computed<string>(() => {\n  const matches = config.public.phoneNumber.match(/.{2}/gu);\n\n  return matches ? matches.join(\" \") : \"?\";\n});\n</script>\n\n<style lang=\"scss\" scoped>\n.daveo-logo {\n  margin-left: -5px;\n  width: 150px;\n}\n</style>"
     },
     "app/components/MyEducation/EducationDegreeCard/EducationDegreeCard.vue": {
       "language": "html",
@@ -1166,16 +1166,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1197,16 +1197,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1228,16 +1228,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1259,16 +1259,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1290,16 +1290,16 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "98"
+            "85"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1321,16 +1321,16 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "98"
+            "85"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1352,16 +1352,16 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "98"
+            "85"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1383,16 +1383,16 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "98"
+            "85"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1414,16 +1414,16 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "98"
+            "85"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1445,16 +1445,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1476,16 +1476,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1507,16 +1507,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1538,16 +1538,16 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "99"
+            "86"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1569,16 +1569,16 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "99"
+            "86"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1600,16 +1600,16 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "99"
+            "86"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1631,16 +1631,16 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "99"
+            "86"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1662,16 +1662,16 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "99"
+            "86"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1693,16 +1693,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1724,16 +1724,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1755,16 +1755,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1786,16 +1786,16 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "100"
+            "87"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1817,16 +1817,16 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "100"
+            "87"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1848,16 +1848,16 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "100"
+            "87"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1879,16 +1879,16 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "100"
+            "87"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1910,16 +1910,16 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "100"
+            "87"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1941,16 +1941,16 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "100"
+            "87"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -1972,16 +1972,16 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "100"
+            "87"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2003,16 +2003,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2034,16 +2034,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2065,16 +2065,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2096,16 +2096,16 @@
           "testsCompleted": 6,
           "static": false,
           "killedBy": [
-            "101"
+            "88"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2127,16 +2127,16 @@
           "testsCompleted": 6,
           "static": false,
           "killedBy": [
-            "101"
+            "88"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2158,16 +2158,16 @@
           "testsCompleted": 6,
           "static": false,
           "killedBy": [
-            "101"
+            "88"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2189,16 +2189,16 @@
           "testsCompleted": 6,
           "static": false,
           "killedBy": [
-            "101"
+            "88"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2220,16 +2220,16 @@
           "testsCompleted": 6,
           "static": false,
           "killedBy": [
-            "101"
+            "88"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2251,16 +2251,16 @@
           "testsCompleted": 6,
           "static": false,
           "killedBy": [
-            "101"
+            "88"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2282,16 +2282,16 @@
           "testsCompleted": 6,
           "static": false,
           "killedBy": [
-            "101"
+            "88"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2313,16 +2313,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2344,16 +2344,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2375,16 +2375,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2406,16 +2406,16 @@
           "testsCompleted": 7,
           "static": false,
           "killedBy": [
-            "102"
+            "89"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2437,16 +2437,16 @@
           "testsCompleted": 7,
           "static": false,
           "killedBy": [
-            "102"
+            "89"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2468,16 +2468,16 @@
           "testsCompleted": 7,
           "static": false,
           "killedBy": [
-            "102"
+            "89"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2499,16 +2499,16 @@
           "testsCompleted": 7,
           "static": false,
           "killedBy": [
-            "102"
+            "89"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2530,16 +2530,16 @@
           "testsCompleted": 7,
           "static": false,
           "killedBy": [
-            "102"
+            "89"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2561,16 +2561,16 @@
           "testsCompleted": 7,
           "static": false,
           "killedBy": [
-            "102"
+            "89"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2592,16 +2592,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2623,16 +2623,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2654,16 +2654,16 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "96"
+            "83"
           ],
           "coveredBy": [
-            "96",
-            "97",
-            "98",
-            "99",
-            "100",
-            "101",
-            "102"
+            "83",
+            "84",
+            "85",
+            "86",
+            "87",
+            "88",
+            "89"
           ],
           "location": {
             "end": {
@@ -2691,17 +2691,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -2723,17 +2723,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -2755,17 +2755,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -2787,17 +2787,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -2819,17 +2819,17 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "83"
+            "66"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -2851,17 +2851,17 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "83"
+            "66"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -2883,17 +2883,17 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "83"
+            "66"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -2915,17 +2915,17 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "83"
+            "66"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -2947,17 +2947,17 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "83"
+            "66"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -2979,17 +2979,17 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "83"
+            "66"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3011,17 +3011,17 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "83"
+            "66"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3043,17 +3043,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3075,17 +3075,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3107,17 +3107,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3139,17 +3139,17 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "84"
+            "67"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3171,17 +3171,17 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "84"
+            "67"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3203,17 +3203,17 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "84"
+            "67"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3235,17 +3235,17 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "84"
+            "67"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3267,17 +3267,17 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "84"
+            "67"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3299,17 +3299,17 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "84"
+            "67"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3331,17 +3331,17 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "84"
+            "67"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3363,17 +3363,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3395,17 +3395,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3427,17 +3427,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3459,17 +3459,17 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "85"
+            "68"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3491,17 +3491,17 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "85"
+            "68"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3523,17 +3523,17 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "85"
+            "68"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3555,17 +3555,17 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "85"
+            "68"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3587,17 +3587,17 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "85"
+            "68"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3619,17 +3619,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3651,17 +3651,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3683,17 +3683,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3715,17 +3715,17 @@
           "testsCompleted": 6,
           "static": false,
           "killedBy": [
-            "86"
+            "69"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3747,17 +3747,17 @@
           "testsCompleted": 6,
           "static": false,
           "killedBy": [
-            "86"
+            "69"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3779,17 +3779,17 @@
           "testsCompleted": 6,
           "static": false,
           "killedBy": [
-            "86"
+            "69"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3811,17 +3811,17 @@
           "testsCompleted": 6,
           "static": false,
           "killedBy": [
-            "86"
+            "69"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3843,17 +3843,17 @@
           "testsCompleted": 6,
           "static": false,
           "killedBy": [
-            "86"
+            "69"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3875,17 +3875,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3907,17 +3907,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3939,17 +3939,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -3971,17 +3971,17 @@
           "testsCompleted": 7,
           "static": false,
           "killedBy": [
-            "87"
+            "70"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -4003,17 +4003,17 @@
           "testsCompleted": 7,
           "static": false,
           "killedBy": [
-            "87"
+            "70"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -4035,17 +4035,17 @@
           "testsCompleted": 7,
           "static": false,
           "killedBy": [
-            "87"
+            "70"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -4067,17 +4067,17 @@
           "testsCompleted": 7,
           "static": false,
           "killedBy": [
-            "87"
+            "70"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -4099,17 +4099,17 @@
           "testsCompleted": 7,
           "static": false,
           "killedBy": [
-            "87"
+            "70"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -4131,17 +4131,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -4163,17 +4163,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -4195,17 +4195,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -4227,17 +4227,17 @@
           "testsCompleted": 8,
           "static": false,
           "killedBy": [
-            "88"
+            "71"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -4259,17 +4259,17 @@
           "testsCompleted": 8,
           "static": false,
           "killedBy": [
-            "88"
+            "71"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -4291,17 +4291,17 @@
           "testsCompleted": 8,
           "static": false,
           "killedBy": [
-            "88"
+            "71"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -4323,17 +4323,17 @@
           "testsCompleted": 8,
           "static": false,
           "killedBy": [
-            "88"
+            "71"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -4355,17 +4355,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -4387,17 +4387,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -4419,17 +4419,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "81"
+            "64"
           ],
           "coveredBy": [
-            "81",
-            "82",
-            "83",
-            "84",
-            "85",
-            "86",
-            "87",
-            "88"
+            "64",
+            "65",
+            "66",
+            "67",
+            "68",
+            "69",
+            "70",
+            "71"
           ],
           "location": {
             "end": {
@@ -4457,15 +4457,15 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "141"
+            "105"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -4487,15 +4487,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "139"
+            "103"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -4517,15 +4517,15 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "141"
+            "105"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -4547,15 +4547,15 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "141"
+            "105"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -4577,15 +4577,15 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "141"
+            "105"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -4607,15 +4607,15 @@
           "testsCompleted": 3,
           "static": false,
           "killedBy": [
-            "141"
+            "105"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -4637,15 +4637,15 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "142"
+            "106"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -4667,15 +4667,15 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "142"
+            "106"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -4697,15 +4697,15 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "142"
+            "106"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -4727,15 +4727,15 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "142"
+            "106"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -4757,15 +4757,15 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "142"
+            "106"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -4787,15 +4787,15 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "143"
+            "107"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -4817,15 +4817,15 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "143"
+            "107"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -4847,15 +4847,15 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "143"
+            "107"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -4877,15 +4877,15 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "143"
+            "107"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -4907,15 +4907,15 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "143"
+            "107"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -4937,15 +4937,15 @@
           "testsCompleted": 6,
           "static": false,
           "killedBy": [
-            "144"
+            "108"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -4967,15 +4967,15 @@
           "testsCompleted": 6,
           "static": false,
           "killedBy": [
-            "144"
+            "108"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -4997,15 +4997,15 @@
           "testsCompleted": 6,
           "static": false,
           "killedBy": [
-            "144"
+            "108"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -5027,15 +5027,15 @@
           "testsCompleted": 6,
           "static": false,
           "killedBy": [
-            "144"
+            "108"
           ],
           "coveredBy": [
-            "139",
-            "140",
-            "141",
-            "142",
-            "143",
-            "144"
+            "103",
+            "104",
+            "105",
+            "106",
+            "107",
+            "108"
           ],
           "location": {
             "end": {
@@ -10361,17 +10361,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "103"
+            "90"
           ],
           "coveredBy": [
-            "103",
-            "104",
-            "105",
-            "106",
-            "107",
-            "108",
-            "109",
-            "110"
+            "90",
+            "91",
+            "92",
+            "93",
+            "94",
+            "95",
+            "96",
+            "97"
           ],
           "location": {
             "end": {
@@ -10393,17 +10393,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "103"
+            "90"
           ],
           "coveredBy": [
-            "103",
-            "104",
-            "105",
-            "106",
-            "107",
-            "108",
-            "109",
-            "110"
+            "90",
+            "91",
+            "92",
+            "93",
+            "94",
+            "95",
+            "96",
+            "97"
           ],
           "location": {
             "end": {
@@ -10425,17 +10425,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "103"
+            "90"
           ],
           "coveredBy": [
-            "103",
-            "104",
-            "105",
-            "106",
-            "107",
-            "108",
-            "109",
-            "110"
+            "90",
+            "91",
+            "92",
+            "93",
+            "94",
+            "95",
+            "96",
+            "97"
           ],
           "location": {
             "end": {
@@ -10457,17 +10457,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "103"
+            "90"
           ],
           "coveredBy": [
-            "103",
-            "104",
-            "105",
-            "106",
-            "107",
-            "108",
-            "109",
-            "110"
+            "90",
+            "91",
+            "92",
+            "93",
+            "94",
+            "95",
+            "96",
+            "97"
           ],
           "location": {
             "end": {
@@ -10489,17 +10489,17 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "103"
+            "90"
           ],
           "coveredBy": [
-            "103",
-            "104",
-            "105",
-            "106",
-            "107",
-            "108",
-            "109",
-            "110"
+            "90",
+            "91",
+            "92",
+            "93",
+            "94",
+            "95",
+            "96",
+            "97"
           ],
           "location": {
             "end": {
@@ -10527,14 +10527,14 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "111"
+            "117"
           ],
           "coveredBy": [
-            "111",
-            "112",
-            "113",
-            "114",
-            "115"
+            "117",
+            "118",
+            "119",
+            "120",
+            "121"
           ],
           "location": {
             "end": {
@@ -10556,12 +10556,12 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "113"
+            "119"
           ],
           "coveredBy": [
-            "113",
-            "114",
-            "115"
+            "119",
+            "120",
+            "121"
           ],
           "location": {
             "end": {
@@ -10583,12 +10583,12 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "113"
+            "119"
           ],
           "coveredBy": [
-            "113",
-            "114",
-            "115"
+            "119",
+            "120",
+            "121"
           ],
           "location": {
             "end": {
@@ -10610,10 +10610,10 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "115"
+            "121"
           ],
           "coveredBy": [
-            "115"
+            "121"
           ],
           "location": {
             "end": {
@@ -10635,10 +10635,10 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "115"
+            "121"
           ],
           "coveredBy": [
-            "115"
+            "121"
           ],
           "location": {
             "end": {
@@ -10666,12 +10666,12 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "118"
+            "72"
           ],
           "coveredBy": [
-            "118",
-            "119",
-            "120"
+            "72",
+            "73",
+            "74"
           ],
           "location": {
             "end": {
@@ -10693,12 +10693,12 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "118"
+            "72"
           ],
           "coveredBy": [
-            "118",
-            "119",
-            "120"
+            "72",
+            "73",
+            "74"
           ],
           "location": {
             "end": {
@@ -10726,11 +10726,11 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "116"
+            "142"
           ],
           "coveredBy": [
-            "116",
-            "117"
+            "142",
+            "143"
           ],
           "location": {
             "end": {
@@ -10818,14 +10818,14 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "72"
+            "98"
           ],
           "coveredBy": [
-            "72",
-            "73",
-            "74",
-            "75",
-            "76"
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
           ],
           "location": {
             "end": {
@@ -10847,14 +10847,14 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "72"
+            "98"
           ],
           "coveredBy": [
-            "72",
-            "73",
-            "74",
-            "75",
-            "76"
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
           ],
           "location": {
             "end": {
@@ -10876,14 +10876,14 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "72"
+            "98"
           ],
           "coveredBy": [
-            "72",
-            "73",
-            "74",
-            "75",
-            "76"
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
           ],
           "location": {
             "end": {
@@ -10905,14 +10905,14 @@
           "testsCompleted": 4,
           "static": false,
           "killedBy": [
-            "75"
+            "101"
           ],
           "coveredBy": [
-            "72",
-            "73",
-            "74",
-            "75",
-            "76"
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
           ],
           "location": {
             "end": {
@@ -10934,14 +10934,14 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "76"
+            "102"
           ],
           "coveredBy": [
-            "72",
-            "73",
-            "74",
-            "75",
-            "76"
+            "98",
+            "99",
+            "100",
+            "101",
+            "102"
           ],
           "location": {
             "end": {
@@ -11012,11 +11012,11 @@
           "location": {
             "end": {
               "column": 2,
-              "line": 81
+              "line": 82
             },
             "start": {
               "column": 64,
-              "line": 77
+              "line": 78
             }
           }
         },
@@ -11030,11 +11030,11 @@
           "location": {
             "end": {
               "column": 26,
-              "line": 78
+              "line": 79
             },
             "start": {
               "column": 21,
-              "line": 78
+              "line": 79
             }
           }
         },
@@ -11074,11 +11074,11 @@
           "location": {
             "end": {
               "column": 2,
-              "line": 105
+              "line": 106
             },
             "start": {
               "column": 48,
-              "line": 86
+              "line": 87
             }
           }
         },
@@ -11118,11 +11118,11 @@
           "location": {
             "end": {
               "column": 23,
-              "line": 87
+              "line": 88
             },
             "start": {
               "column": 7,
-              "line": 87
+              "line": 88
             }
           }
         },
@@ -11162,11 +11162,11 @@
           "location": {
             "end": {
               "column": 23,
-              "line": 87
+              "line": 88
             },
             "start": {
               "column": 7,
-              "line": 87
+              "line": 88
             }
           }
         },
@@ -11206,11 +11206,11 @@
           "location": {
             "end": {
               "column": 23,
-              "line": 87
+              "line": 88
             },
             "start": {
               "column": 7,
-              "line": 87
+              "line": 88
             }
           }
         },
@@ -11250,11 +11250,11 @@
           "location": {
             "end": {
               "column": 4,
-              "line": 89
+              "line": 90
             },
             "start": {
               "column": 25,
-              "line": 87
+              "line": 88
             }
           }
         },
@@ -11294,11 +11294,11 @@
           "location": {
             "end": {
               "column": 14,
-              "line": 88
+              "line": 89
             },
             "start": {
               "column": 12,
-              "line": 88
+              "line": 89
             }
           }
         },
@@ -11327,11 +11327,11 @@
           "location": {
             "end": {
               "column": 52,
-              "line": 90
+              "line": 91
             },
             "start": {
               "column": 22,
-              "line": 90
+              "line": 91
             }
           }
         },
@@ -11360,11 +11360,11 @@
           "location": {
             "end": {
               "column": 22,
-              "line": 92
+              "line": 93
             },
             "start": {
               "column": 20,
-              "line": 92
+              "line": 93
             }
           }
         },
@@ -11393,11 +11393,11 @@
           "location": {
             "end": {
               "column": 18,
-              "line": 93
+              "line": 94
             },
             "start": {
               "column": 7,
-              "line": 93
+              "line": 94
             }
           }
         },
@@ -11426,11 +11426,11 @@
           "location": {
             "end": {
               "column": 18,
-              "line": 93
+              "line": 94
             },
             "start": {
               "column": 7,
-              "line": 93
+              "line": 94
             }
           }
         },
@@ -11454,11 +11454,11 @@
           "location": {
             "end": {
               "column": 4,
-              "line": 95
+              "line": 96
             },
             "start": {
               "column": 20,
-              "line": 93
+              "line": 94
             }
           }
         },
@@ -11482,11 +11482,11 @@
           "location": {
             "end": {
               "column": 77,
-              "line": 94
+              "line": 95
             },
             "start": {
               "column": 5,
-              "line": 94
+              "line": 95
             }
           }
         },
@@ -11510,11 +11510,11 @@
           "location": {
             "end": {
               "column": 35,
-              "line": 94
+              "line": 95
             },
             "start": {
               "column": 21,
-              "line": 94
+              "line": 95
             }
           }
         },
@@ -11538,11 +11538,11 @@
           "location": {
             "end": {
               "column": 63,
-              "line": 94
+              "line": 95
             },
             "start": {
               "column": 37,
-              "line": 94
+              "line": 95
             }
           }
         },
@@ -11571,11 +11571,11 @@
           "location": {
             "end": {
               "column": 30,
-              "line": 96
+              "line": 97
             },
             "start": {
               "column": 7,
-              "line": 96
+              "line": 97
             }
           }
         },
@@ -11604,11 +11604,11 @@
           "location": {
             "end": {
               "column": 30,
-              "line": 96
+              "line": 97
             },
             "start": {
               "column": 7,
-              "line": 96
+              "line": 97
             }
           }
         },
@@ -11637,11 +11637,11 @@
           "location": {
             "end": {
               "column": 30,
-              "line": 96
+              "line": 97
             },
             "start": {
               "column": 7,
-              "line": 96
+              "line": 97
             }
           }
         },
@@ -11668,11 +11668,11 @@
           "location": {
             "end": {
               "column": 4,
-              "line": 103
+              "line": 104
             },
             "start": {
               "column": 32,
-              "line": 96
+              "line": 97
             }
           }
         },
@@ -11699,11 +11699,11 @@
           "location": {
             "end": {
               "column": 36,
-              "line": 97
+              "line": 98
             },
             "start": {
               "column": 9,
-              "line": 97
+              "line": 98
             }
           }
         },
@@ -11730,11 +11730,11 @@
           "location": {
             "end": {
               "column": 36,
-              "line": 97
+              "line": 98
             },
             "start": {
               "column": 9,
-              "line": 97
+              "line": 98
             }
           }
         },
@@ -11761,11 +11761,11 @@
           "location": {
             "end": {
               "column": 36,
-              "line": 97
+              "line": 98
             },
             "start": {
               "column": 9,
-              "line": 97
+              "line": 98
             }
           }
         },
@@ -11787,11 +11787,11 @@
           "location": {
             "end": {
               "column": 6,
-              "line": 99
+              "line": 100
             },
             "start": {
               "column": 38,
-              "line": 97
+              "line": 98
             }
           }
         },
@@ -11813,11 +11813,11 @@
           "location": {
             "end": {
               "column": 43,
-              "line": 98
+              "line": 99
             },
             "start": {
               "column": 21,
-              "line": 98
+              "line": 99
             }
           }
         },
@@ -11839,11 +11839,11 @@
           "location": {
             "end": {
               "column": 39,
-              "line": 98
+              "line": 99
             },
             "start": {
               "column": 27,
-              "line": 98
+              "line": 99
             }
           }
         },
@@ -11870,11 +11870,11 @@
           "location": {
             "end": {
               "column": 21,
-              "line": 100
+              "line": 101
             },
             "start": {
               "column": 9,
-              "line": 100
+              "line": 101
             }
           }
         },
@@ -11901,11 +11901,11 @@
           "location": {
             "end": {
               "column": 21,
-              "line": 100
+              "line": 101
             },
             "start": {
               "column": 9,
-              "line": 100
+              "line": 101
             }
           }
         },
@@ -11931,11 +11931,11 @@
           "location": {
             "end": {
               "column": 6,
-              "line": 102
+              "line": 103
             },
             "start": {
               "column": 23,
-              "line": 100
+              "line": 101
             }
           }
         },
@@ -11961,11 +11961,11 @@
           "location": {
             "end": {
               "column": 69,
-              "line": 101
+              "line": 102
             },
             "start": {
               "column": 7,
-              "line": 101
+              "line": 102
             }
           }
         },
@@ -11991,11 +11991,11 @@
           "location": {
             "end": {
               "column": 38,
-              "line": 101
+              "line": 102
             },
             "start": {
               "column": 23,
-              "line": 101
+              "line": 102
             }
           }
         },
@@ -12021,11 +12021,11 @@
           "location": {
             "end": {
               "column": 68,
-              "line": 101
+              "line": 102
             },
             "start": {
               "column": 40,
-              "line": 101
+              "line": 102
             }
           }
         },
@@ -12054,11 +12054,11 @@
           "location": {
             "end": {
               "column": 29,
-              "line": 104
+              "line": 105
             },
             "start": {
               "column": 10,
-              "line": 104
+              "line": 105
             }
           }
         },
@@ -12098,11 +12098,11 @@
           "location": {
             "end": {
               "column": 2,
-              "line": 116
+              "line": 117
             },
             "start": {
               "column": 51,
-              "line": 107
+              "line": 108
             }
           }
         },
@@ -12142,11 +12142,11 @@
           "location": {
             "end": {
               "column": 17,
-              "line": 109
+              "line": 110
             },
             "start": {
               "column": 7,
-              "line": 109
+              "line": 110
             }
           }
         },
@@ -12186,11 +12186,11 @@
           "location": {
             "end": {
               "column": 17,
-              "line": 109
+              "line": 110
             },
             "start": {
               "column": 7,
-              "line": 109
+              "line": 110
             }
           }
         },
@@ -12230,11 +12230,11 @@
           "location": {
             "end": {
               "column": 17,
-              "line": 109
+              "line": 110
             },
             "start": {
               "column": 7,
-              "line": 109
+              "line": 110
             }
           }
         },
@@ -12274,11 +12274,11 @@
           "location": {
             "end": {
               "column": 4,
-              "line": 111
+              "line": 112
             },
             "start": {
               "column": 19,
-              "line": 109
+              "line": 110
             }
           }
         },
@@ -12318,11 +12318,11 @@
           "location": {
             "end": {
               "column": 14,
-              "line": 110
+              "line": 111
             },
             "start": {
               "column": 12,
-              "line": 110
+              "line": 111
             }
           }
         },
@@ -12349,11 +12349,11 @@
           "location": {
             "end": {
               "column": 81,
-              "line": 115
+              "line": 116
             },
             "start": {
               "column": 45,
-              "line": 115
+              "line": 116
             }
           }
         },
@@ -12393,11 +12393,11 @@
           "location": {
             "end": {
               "column": 2,
-              "line": 126
+              "line": 127
             },
             "start": {
               "column": 52,
-              "line": 118
+              "line": 119
             }
           }
         },
@@ -12437,11 +12437,11 @@
           "location": {
             "end": {
               "column": 17,
-              "line": 120
+              "line": 121
             },
             "start": {
               "column": 7,
-              "line": 120
+              "line": 121
             }
           }
         },
@@ -12481,11 +12481,11 @@
           "location": {
             "end": {
               "column": 17,
-              "line": 120
+              "line": 121
             },
             "start": {
               "column": 7,
-              "line": 120
+              "line": 121
             }
           }
         },
@@ -12514,11 +12514,11 @@
           "location": {
             "end": {
               "column": 4,
-              "line": 124
+              "line": 125
             },
             "start": {
               "column": 19,
-              "line": 120
+              "line": 121
             }
           }
         },
@@ -12545,11 +12545,11 @@
           "location": {
             "end": {
               "column": 99,
-              "line": 123
+              "line": 124
             },
             "start": {
               "column": 48,
-              "line": 123
+              "line": 124
             }
           }
         },
@@ -12589,11 +12589,11 @@
           "location": {
             "end": {
               "column": 26,
-              "line": 125
+              "line": 126
             },
             "start": {
               "column": 12,
-              "line": 125
+              "line": 126
             }
           }
         },
@@ -12633,11 +12633,11 @@
           "location": {
             "end": {
               "column": 82,
-              "line": 128
+              "line": 129
             },
             "start": {
               "column": 50,
-              "line": 128
+              "line": 129
             }
           }
         },
@@ -12677,11 +12677,11 @@
           "location": {
             "end": {
               "column": 82,
-              "line": 128
+              "line": 129
             },
             "start": {
               "column": 56,
-              "line": 128
+              "line": 129
             }
           }
         },
@@ -12721,11 +12721,11 @@
           "location": {
             "end": {
               "column": 82,
-              "line": 128
+              "line": 129
             },
             "start": {
               "column": 57,
-              "line": 128
+              "line": 129
             }
           }
         },
@@ -12765,11 +12765,11 @@
           "location": {
             "end": {
               "column": 2,
-              "line": 144
+              "line": 145
             },
             "start": {
               "column": 53,
-              "line": 130
+              "line": 131
             }
           }
         },
@@ -12809,11 +12809,11 @@
           "location": {
             "end": {
               "column": 47,
-              "line": 132
+              "line": 133
             },
             "start": {
               "column": 7,
-              "line": 132
+              "line": 133
             }
           }
         },
@@ -12853,11 +12853,11 @@
           "location": {
             "end": {
               "column": 47,
-              "line": 132
+              "line": 133
             },
             "start": {
               "column": 7,
-              "line": 132
+              "line": 133
             }
           }
         },
@@ -12897,11 +12897,11 @@
           "location": {
             "end": {
               "column": 47,
-              "line": 132
+              "line": 133
             },
             "start": {
               "column": 7,
-              "line": 132
+              "line": 133
             }
           }
         },
@@ -12922,11 +12922,11 @@
           "location": {
             "end": {
               "column": 4,
-              "line": 134
+              "line": 135
             },
             "start": {
               "column": 49,
-              "line": 132
+              "line": 133
             }
           }
         },
@@ -12966,11 +12966,11 @@
           "location": {
             "end": {
               "column": 16,
-              "line": 135
+              "line": 136
             },
             "start": {
               "column": 7,
-              "line": 135
+              "line": 136
             }
           }
         },
@@ -13010,11 +13010,11 @@
           "location": {
             "end": {
               "column": 16,
-              "line": 135
+              "line": 136
             },
             "start": {
               "column": 7,
-              "line": 135
+              "line": 136
             }
           }
         },
@@ -13043,11 +13043,11 @@
           "location": {
             "end": {
               "column": 4,
-              "line": 140
+              "line": 141
             },
             "start": {
               "column": 18,
-              "line": 135
+              "line": 136
             }
           }
         },
@@ -13076,11 +13076,11 @@
           "location": {
             "end": {
               "column": 51,
-              "line": 136
+              "line": 137
             },
             "start": {
               "column": 14,
-              "line": 136
+              "line": 137
             }
           }
         },
@@ -13109,11 +13109,11 @@
           "location": {
             "end": {
               "column": 6,
-              "line": 139
+              "line": 140
             },
             "start": {
               "column": 53,
-              "line": 136
+              "line": 137
             }
           }
         },
@@ -13153,11 +13153,11 @@
           "location": {
             "end": {
               "column": 48,
-              "line": 141
+              "line": 142
             },
             "start": {
               "column": 12,
-              "line": 141
+              "line": 142
             }
           }
         },
@@ -13197,16 +13197,16 @@
           "location": {
             "end": {
               "column": 4,
-              "line": 143
+              "line": 144
             },
             "start": {
               "column": 50,
-              "line": 141
+              "line": 142
             }
           }
         }
       ],
-      "source": "<template>\n  <div\n    id=\"period-timeline\"\n    class=\"d-flex flex-column h-100\"\n  >\n    <a\n      id=\"timeline-logo\"\n      :href=\"url\"\n      rel=\"noopener noreferrer\"\n      target=\"_blank\"\n    >\n      <NuxtImg\n        :alt=\"imageAlt\"\n        class=\"logo timeline-logo-image white-logo\"\n        loading=\"lazy\"\n        :src=\"`/images/logos/${image}`\"\n      />\n    </a>\n\n    <hr class=\"my-3\">\n\n    <div class=\"d-flex flex-column flex-grow-1\">\n      <div\n        id=\"period-dates\"\n        :aria-label=\"periodDatesAriaLabel\"\n        class=\"align-items-center d-flex flex-column flex-grow-1 justify-content-center\"\n        role=\"region\"\n      >\n        <div\n          id=\"finished-at-date\"\n          class=\"period-date\"\n        >\n          {{ formattedFinishedAt }}\n        </div>\n\n        <WrappedFontAwesomeIcon\n          v-if=\"doesPeriodHaveTwoDates\"\n          id=\"arrow-up-icon\"\n          classes=\"my-3\"\n          icon=\"fa-arrow-up\"\n          icon-color=\"#00000\"\n          size=\"2x\"\n        />\n\n        <div\n          v-if=\"formattedStartedAt\"\n          id=\"started-at-date\"\n          class=\"period-date\"\n        >\n          {{ formattedStartedAt }}\n        </div>\n      </div>\n\n      <div\n        v-if=\"formattedPeriod\"\n        id=\"period-label\"\n        class=\"align-items-center d-flex flex-column\"\n      >\n        <hr class=\"w-100\">\n\n        <div\n          class=\"font-italic font-weight-bold small\"\n        >\n          {{ formattedPeriod }}\n        </div>\n      </div>\n    </div>\n  </div>\n</template>\n\n<script lang=\"ts\" setup>\nimport type { PeriodTimelineProps } from \"~/components/shared/Period/period-timeline.types\";\nimport { useDates } from \"~/composables/useDates\";\nimport WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\nimport { Period } from \"~/models/period/period.class\";\n\nconst props = withDefaults(defineProps<PeriodTimelineProps>(), {\n  doesShowYearOnly: false,\n  startedAt: undefined,\n  finishedAt: undefined,\n});\n\nconst { t } = useI18n();\nconst { getMonthFullName } = useDates();\n\nconst formattedPeriod = computed<string>(() => {\n  if (!props.startedAt) {\n    return \"\";\n  }\n  const finishedAt = props.finishedAt ?? new Date();\n  const period = new Period(props.startedAt, finishedAt);\n  let periodText = \"\";\n  if (period.year) {\n    periodText += t(\"shared.years\", { yearCount: period.year }, period.year);\n  }\n  if (!props.doesShowYearOnly) {\n    if (period.month && period.year) {\n      periodText += ` ${t(\"shared.and\")} `;\n    }\n    if (period.month) {\n      periodText += t(\"shared.months\", { monthCount: period.month });\n    }\n  }\n  return `( ${periodText} )`;\n});\n\nconst formattedStartedAt = computed<string>(() => {\n  const { startedAt, doesShowYearOnly } = props;\n  if (!startedAt) {\n    return \"\";\n  }\n  const startedAtMonth = getMonthFullName(startedAt);\n  const startedAtYear = startedAt.getFullYear().toString();\n\n  return doesShowYearOnly ? startedAtYear : `${startedAtMonth} ${startedAtYear}`;\n});\n\nconst formattedFinishedAt = computed<string>(() => {\n  const { finishedAt, doesShowYearOnly } = props;\n  if (finishedAt) {\n    const finishedAtYear = finishedAt.getFullYear().toString();\n\n    return doesShowYearOnly ? finishedAtYear : `${getMonthFullName(finishedAt)} ${finishedAtYear}`;\n  }\n  return t(\"shared.today\");\n});\n\nconst doesPeriodHaveTwoDates = computed<boolean>(() => !!formattedStartedAt.value);\n\nconst periodDatesAriaLabel = computed<string>(() => {\n  const { startedAt } = props;\n  if (props.periodDatesAriaLabel !== undefined) {\n    return props.periodDatesAriaLabel;\n  }\n  if (startedAt) {\n    return t(\"PeriodTimeline.periodDatesAriaLabel\", {\n      startedAt: formattedStartedAt.value,\n      finishedAt: formattedFinishedAt.value,\n    });\n  }\n  return t(\"PeriodTimeline.obtainedAtAriaLabel\", {\n    obtainedAt: formattedFinishedAt.value,\n  });\n});\n</script>\n\n<style lang=\"scss\" scoped>\n.period-date {\n  font-size: 1.25rem;\n}\n.logo {\n  width: 100%;\n  height: 100%;\n  object-fit: contain;\n  max-height: 100px;\n  max-width: 200px;\n  filter: brightness(0) invert(1);\n}\n</style>"
+      "source": "<template>\n  <div\n    id=\"period-timeline\"\n    class=\"d-flex flex-column h-100\"\n  >\n    <a\n      id=\"timeline-logo\"\n      :href=\"url\"\n      rel=\"noopener noreferrer\"\n      target=\"_blank\"\n    >\n      <NuxtImg\n        :alt=\"imageAlt\"\n        class=\"logo timeline-logo-image white-logo\"\n        loading=\"lazy\"\n        :src=\"`/images/logos/${image}`\"\n      />\n    </a>\n\n    <hr class=\"my-3\">\n\n    <div class=\"d-flex flex-column flex-grow-1\">\n      <div\n        id=\"period-dates\"\n        :aria-label=\"periodDatesAriaLabel\"\n        class=\"align-items-center d-flex flex-column flex-grow-1 justify-content-center\"\n        role=\"region\"\n      >\n        <div\n          id=\"finished-at-date\"\n          class=\"period-date\"\n        >\n          {{ formattedFinishedAt }}\n        </div>\n\n        <WrappedFontAwesomeIcon\n          v-if=\"doesPeriodHaveTwoDates\"\n          id=\"arrow-up-icon\"\n          classes=\"my-3\"\n          icon=\"fa-arrow-up\"\n          :icon-color=\"WHITE_COLOR\"\n          size=\"2x\"\n        />\n\n        <div\n          v-if=\"formattedStartedAt\"\n          id=\"started-at-date\"\n          class=\"period-date\"\n        >\n          {{ formattedStartedAt }}\n        </div>\n      </div>\n\n      <div\n        v-if=\"formattedPeriod\"\n        id=\"period-label\"\n        class=\"align-items-center d-flex flex-column\"\n      >\n        <hr class=\"w-100\">\n\n        <div\n          class=\"font-italic font-weight-bold small\"\n        >\n          {{ formattedPeriod }}\n        </div>\n      </div>\n    </div>\n  </div>\n</template>\n\n<script lang=\"ts\" setup>\nimport type { PeriodTimelineProps } from \"~/components/shared/Period/period-timeline.types\";\nimport { useDates } from \"~/composables/useDates\";\nimport WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\nimport { Period } from \"~/models/period/period.class\";\nimport { WHITE_COLOR } from \"~/shared/constants/style.constants\";\n\nconst props = withDefaults(defineProps<PeriodTimelineProps>(), {\n  doesShowYearOnly: false,\n  startedAt: undefined,\n  finishedAt: undefined,\n});\n\nconst { t } = useI18n();\nconst { getMonthFullName } = useDates();\n\nconst formattedPeriod = computed<string>(() => {\n  if (!props.startedAt) {\n    return \"\";\n  }\n  const finishedAt = props.finishedAt ?? new Date();\n  const period = new Period(props.startedAt, finishedAt);\n  let periodText = \"\";\n  if (period.year) {\n    periodText += t(\"shared.years\", { yearCount: period.year }, period.year);\n  }\n  if (!props.doesShowYearOnly) {\n    if (period.month && period.year) {\n      periodText += ` ${t(\"shared.and\")} `;\n    }\n    if (period.month) {\n      periodText += t(\"shared.months\", { monthCount: period.month });\n    }\n  }\n  return `( ${periodText} )`;\n});\n\nconst formattedStartedAt = computed<string>(() => {\n  const { startedAt, doesShowYearOnly } = props;\n  if (!startedAt) {\n    return \"\";\n  }\n  const startedAtMonth = getMonthFullName(startedAt);\n  const startedAtYear = startedAt.getFullYear().toString();\n\n  return doesShowYearOnly ? startedAtYear : `${startedAtMonth} ${startedAtYear}`;\n});\n\nconst formattedFinishedAt = computed<string>(() => {\n  const { finishedAt, doesShowYearOnly } = props;\n  if (finishedAt) {\n    const finishedAtYear = finishedAt.getFullYear().toString();\n\n    return doesShowYearOnly ? finishedAtYear : `${getMonthFullName(finishedAt)} ${finishedAtYear}`;\n  }\n  return t(\"shared.today\");\n});\n\nconst doesPeriodHaveTwoDates = computed<boolean>(() => !!formattedStartedAt.value);\n\nconst periodDatesAriaLabel = computed<string>(() => {\n  const { startedAt } = props;\n  if (props.periodDatesAriaLabel !== undefined) {\n    return props.periodDatesAriaLabel;\n  }\n  if (startedAt) {\n    return t(\"PeriodTimeline.periodDatesAriaLabel\", {\n      startedAt: formattedStartedAt.value,\n      finishedAt: formattedFinishedAt.value,\n    });\n  }\n  return t(\"PeriodTimeline.obtainedAtAriaLabel\", {\n    obtainedAt: formattedFinishedAt.value,\n  });\n});\n</script>\n\n<style lang=\"scss\" scoped>\n.period-date {\n  font-size: 1.25rem;\n}\n.logo {\n  width: 100%;\n  height: 100%;\n  object-fit: contain;\n  max-height: 100px;\n  max-width: 200px;\n  filter: brightness(0) invert(1);\n}\n</style>"
     },
     "app/composables/useAppSchemaOrg.ts": {
       "language": "typescript",
@@ -13220,13 +13220,13 @@
           "static": false,
           "killedBy": [],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "146",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "151",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13248,13 +13248,13 @@
           "static": false,
           "killedBy": [],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "146",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "151",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13276,12 +13276,12 @@
           "static": false,
           "killedBy": [],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "146",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "151",
+            "153"
           ],
           "location": {
             "end": {
@@ -13303,15 +13303,15 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "146"
+            "151"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "146",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "151",
+            "153"
           ],
           "location": {
             "end": {
@@ -13333,15 +13333,15 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "146"
+            "151"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "146",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "151",
+            "153"
           ],
           "location": {
             "end": {
@@ -13363,13 +13363,13 @@
           "static": false,
           "killedBy": [],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "146",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "151",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13391,12 +13391,12 @@
           "static": false,
           "killedBy": [],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13418,15 +13418,15 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13448,15 +13448,15 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13478,15 +13478,15 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13508,15 +13508,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13538,15 +13538,15 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13568,15 +13568,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13598,15 +13598,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13628,15 +13628,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13658,15 +13658,15 @@
           "testsCompleted": 5,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13688,15 +13688,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13718,15 +13718,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13748,15 +13748,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13778,15 +13778,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13808,15 +13808,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13838,15 +13838,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13868,15 +13868,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13898,15 +13898,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13928,15 +13928,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13958,15 +13958,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -13988,15 +13988,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14018,15 +14018,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14048,15 +14048,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14078,15 +14078,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14108,15 +14108,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14138,15 +14138,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14168,15 +14168,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14198,15 +14198,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14228,15 +14228,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14258,15 +14258,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14288,15 +14288,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14318,15 +14318,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14348,15 +14348,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14378,15 +14378,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14408,15 +14408,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14438,15 +14438,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14468,15 +14468,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14498,15 +14498,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14528,15 +14528,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14558,15 +14558,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14588,15 +14588,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14618,15 +14618,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14648,15 +14648,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14678,15 +14678,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14708,15 +14708,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14738,15 +14738,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14768,15 +14768,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14798,15 +14798,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14828,15 +14828,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14858,15 +14858,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14888,15 +14888,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14918,15 +14918,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14948,15 +14948,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -14978,15 +14978,15 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "147"
+            "152"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -15008,14 +15008,14 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "148"
+            "153"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "153"
           ],
           "location": {
             "end": {
@@ -15037,14 +15037,14 @@
           "testsCompleted": 1,
           "static": false,
           "killedBy": [
-            "148"
+            "153"
           ],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "153"
           ],
           "location": {
             "end": {
@@ -15066,13 +15066,13 @@
           "static": false,
           "killedBy": [],
           "coveredBy": [
-            "77",
-            "78",
-            "79",
-            "80",
-            "146",
-            "147",
-            "148"
+            "122",
+            "123",
+            "124",
+            "125",
+            "151",
+            "152",
+            "153"
           ],
           "location": {
             "end": {
@@ -15304,11 +15304,11 @@
             "42",
             "43",
             "44",
+            "146",
+            "147",
+            "148",
             "149",
-            "150",
-            "151",
-            "152",
-            "153"
+            "150"
           ],
           "location": {
             "end": {
@@ -15342,11 +15342,11 @@
             "42",
             "43",
             "44",
+            "146",
+            "147",
+            "148",
             "149",
-            "150",
-            "151",
-            "152",
-            "153"
+            "150"
           ],
           "location": {
             "end": {
@@ -15380,11 +15380,11 @@
             "42",
             "43",
             "44",
+            "146",
+            "147",
+            "148",
             "149",
-            "150",
-            "151",
-            "152",
-            "153"
+            "150"
           ],
           "location": {
             "end": {
@@ -15418,11 +15418,11 @@
             "42",
             "43",
             "44",
+            "146",
+            "147",
+            "148",
             "149",
-            "150",
-            "151",
-            "152",
-            "153"
+            "150"
           ],
           "location": {
             "end": {
@@ -15456,11 +15456,11 @@
             "42",
             "43",
             "44",
+            "146",
+            "147",
+            "148",
             "149",
-            "150",
-            "151",
-            "152",
-            "153"
+            "150"
           ],
           "location": {
             "end": {
@@ -15491,11 +15491,11 @@
             "42",
             "43",
             "44",
+            "146",
+            "147",
+            "148",
             "149",
-            "150",
-            "151",
-            "152",
-            "153"
+            "150"
           ],
           "location": {
             "end": {
@@ -15529,11 +15529,11 @@
             "42",
             "43",
             "44",
+            "146",
+            "147",
+            "148",
             "149",
-            "150",
-            "151",
-            "152",
-            "153"
+            "150"
           ],
           "location": {
             "end": {
@@ -15555,7 +15555,7 @@
           "testsCompleted": 14,
           "static": false,
           "killedBy": [
-            "153"
+            "150"
           ],
           "coveredBy": [
             "33",
@@ -15567,11 +15567,11 @@
             "42",
             "43",
             "44",
+            "146",
+            "147",
+            "148",
             "149",
-            "150",
-            "151",
-            "152",
-            "153"
+            "150"
           ],
           "location": {
             "end": {
@@ -15605,11 +15605,11 @@
             "42",
             "43",
             "44",
+            "146",
+            "147",
+            "148",
             "149",
-            "150",
-            "151",
-            "152",
-            "153"
+            "150"
           ],
           "location": {
             "end": {
@@ -15643,11 +15643,11 @@
             "42",
             "43",
             "44",
+            "146",
+            "147",
+            "148",
             "149",
-            "150",
-            "151",
-            "152",
-            "153"
+            "150"
           ],
           "location": {
             "end": {
@@ -15922,212 +15922,150 @@
       ],
       "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport type PeriodTimeline from \"~/components/shared/Period/PeriodTimeline.vue\";\nimport type { EducationDegreeCardProps } from \"~/components/MyEducation/EducationDegreeCard/education-degree-card.types\";\nimport EducationDegreeCard from \"~/components/MyEducation/EducationDegreeCard/EducationDegreeCard.vue\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type CountryFlag from \"~/components/shared/Images/CountryFlag/CountryFlag.vue\";\nimport { SCHOOLS } from \"~/models/school/school.constants\";\nimport type { EducationDegree } from \"~/models/education-degree/education-degree.types\";\n\ndescribe(\"Education Degree Card Component\", () => {\n  const defaultProps: EducationDegreeCardProps = {\n    educationDegree: {\n      degree: {\n        name: `Degrees.ITMasterDegree`,\n        description: [\"MyEducation.firstThreeYearsInEpitech\", \"MyEducation.lastYearsInEpitech\"],\n        startedAt: new Date(\"2014-01-01T00:00:00.000Z\"),\n        obtainedAt: new Date(\"2019-01-01T00:00:00.000Z\"),\n      },\n      school: {\n        ...SCHOOLS.epitech,\n        translatedName: `Schools.${SCHOOLS.epitech.name}`,\n      },\n    },\n  };\n  let wrapper: ReturnType<typeof mount<typeof EducationDegreeCard>>;\n\n  async function mountEducationDegreeCardComponent(options: ComponentMountingOptions<typeof EducationDegreeCard> = {}):\n  Promise<ReturnType<typeof mount<typeof EducationDegreeCard>>> {\n    return mountSuspendedComponent(EducationDegreeCard, {\n      props: defaultProps,\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountEducationDegreeCardComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Period Timeline\", () => {\n    it(\"should pass education degree started date when rendered.\", () => {\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".education-timeline\");\n\n      expect(periodTimeline.props(\"startedAt\")).toBe(defaultProps.educationDegree.degree.startedAt);\n    });\n\n    it(\"should pass education degree obtained date when rendered.\", () => {\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".education-timeline\");\n\n      expect(periodTimeline.props(\"finishedAt\")).toBe(defaultProps.educationDegree.degree.obtainedAt);\n    });\n\n    it(\"should pass school image when rendered.\", () => {\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".education-timeline\");\n\n      expect(periodTimeline.props(\"image\")).toBe(defaultProps.educationDegree.school.image);\n    });\n\n    it(\"should pass school image alt as translated name when rendered.\", () => {\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".education-timeline\");\n\n      expect(periodTimeline.props(\"imageAlt\")).toBe(defaultProps.educationDegree.school.translatedName);\n    });\n\n    it(\"should pass interrogative image alt when school translated name is not found.\", async() => {\n      const educationDegreeWithoutTranslatedName: EducationDegree = {\n        ...defaultProps.educationDegree,\n        school: {\n          ...defaultProps.educationDegree.school,\n          translatedName: undefined,\n        },\n      };\n      wrapper = await mountEducationDegreeCardComponent({ props: { educationDegree: educationDegreeWithoutTranslatedName } });\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".education-timeline\");\n\n      expect(periodTimeline.props(\"imageAlt\")).toBe(\"?\");\n    });\n\n    it(\"should pass default school image when school image is not set in education degree.\", async() => {\n      const educationDegreeWithoutImage: EducationDegree = {\n        ...defaultProps.educationDegree,\n        school: {\n          ...SCHOOLS.epitech,\n          image: undefined,\n        },\n      };\n      wrapper = await mountEducationDegreeCardComponent({ props: { educationDegree: educationDegreeWithoutImage } });\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".education-timeline\");\n\n      expect(periodTimeline.props(\"image\")).toBe(\"college-icon.webp\");\n    });\n\n    it(\"should pass school url when rendered.\", () => {\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".education-timeline\");\n\n      expect(periodTimeline.props(\"url\")).toBe(defaultProps.educationDegree.school.url);\n    });\n  });\n\n  describe(\"Degree\", () => {\n    it(\"should render degree name when rendered.\", () => {\n      const degreeName = wrapper.find<HTMLDivElement>(\".degree-name\");\n\n      expect(degreeName.text()).toBe(\"Degrees.ITMasterDegree\");\n    });\n  });\n\n  describe(\"School\", () => {\n    it(\"should render school name with city when city is set in school props.\", () => {\n      const schoolLabel = wrapper.find<HTMLDivElement>(\".school-name\");\n\n      expect(schoolLabel.text()).toBe(\"Schools.epitech, Lille\");\n    });\n\n    it(\"should render school name without city when city is not set in school props.\", async() => {\n      const educationDegreeWithoutCity: EducationDegree = {\n        ...defaultProps.educationDegree,\n        school: {\n          ...defaultProps.educationDegree.school,\n          city: undefined,\n        },\n      };\n      wrapper = await mountEducationDegreeCardComponent({ props: { educationDegree: educationDegreeWithoutCity } });\n      const schoolLabel = wrapper.find<HTMLDivElement>(\".school-name\");\n\n      expect(schoolLabel.text()).toBe(\"Schools.epitech\");\n    });\n\n    it(\"should render interrogative when school translated name is not found.\", async() => {\n      const educationDegreeWithoutTranslatedName: EducationDegree = {\n        ...defaultProps.educationDegree,\n        school: {\n          ...defaultProps.educationDegree.school,\n          translatedName: undefined,\n          city: undefined,\n        },\n      };\n      wrapper = await mountEducationDegreeCardComponent({ props: { educationDegree: educationDegreeWithoutTranslatedName } });\n      const schoolLabel = wrapper.find<HTMLDivElement>(\".school-name\");\n\n      expect(schoolLabel.text()).toBe(\"?\");\n    });\n\n    it(\"should pass school country to country flag when rendered.\", () => {\n      const countryFlag = wrapper.findComponent<typeof CountryFlag>(\".school-flag\");\n\n      expect(countryFlag.props(\"country\")).toBe(defaultProps.educationDegree.school.country);\n    });\n  });\n\n  describe(\"Paragraphs\", () => {\n    it(\"should render degree paragraphs when rendered.\", () => {\n      const degreeParagraphs = wrapper.findAll<HTMLParagraphElement>(\".degree-description\");\n\n      expect(degreeParagraphs).toHaveLength(2);\n      expect(degreeParagraphs[0].text()).toBe(\"MyEducation.firstThreeYearsInEpitech\");\n      expect(degreeParagraphs[1].text()).toBe(\"MyEducation.lastYearsInEpitech\");\n    });\n  });\n});"
     },
-    "tests/unit/specs/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.nuxt.spec.ts": {
-      "tests": [
-        {
-          "id": "59",
-          "name": "Wrapped Font Awesome Icon Component should match snapshot when rendered."
-        },
-        {
-          "id": "60",
-          "name": "Wrapped Font Awesome Icon Component Icon should pass icon when rendered."
-        },
-        {
-          "id": "61",
-          "name": "Wrapped Font Awesome Icon Component Icon should pass undefined size when it is not provided in props."
-        },
-        {
-          "id": "62",
-          "name": "Wrapped Font Awesome Icon Component Icon should pass provided size when it is provided in props."
-        },
-        {
-          "id": "63",
-          "name": "Wrapped Font Awesome Icon Component Icon should pass empty class when it is not provided in props."
-        },
-        {
-          "id": "64",
-          "name": "Wrapped Font Awesome Icon Component Icon should pass provided class when it is provided in props."
-        },
-        {
-          "id": "65",
-          "name": "Wrapped Font Awesome Icon Component Icon should set icon color to default when it is not provided in props."
-        },
-        {
-          "id": "66",
-          "name": "Wrapped Font Awesome Icon Component Icon should set icon color to provided color when it is provided in props."
-        }
-      ],
-      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport type { WrappedFontAwesomeIconProps } from \"~/components/shared/Icons/WrappedFontAwesomeIcon/wrapped-font-awesome-icon.types\";\nimport WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\ndescribe(\"Wrapped Font Awesome Icon Component\", () => {\n  const defaultProps: WrappedFontAwesomeIconProps = {\n    icon: \"icon\",\n  };\n  let wrapper: ReturnType<typeof mount<typeof WrappedFontAwesomeIcon>>;\n\n  async function mountWrappedFontAwesomeIconComponent(options: ComponentMountingOptions<typeof WrappedFontAwesomeIcon> = {}):\n  Promise<ReturnType<typeof mount<typeof WrappedFontAwesomeIcon>>> {\n    return mountSuspendedComponent(WrappedFontAwesomeIcon, {\n      props: defaultProps,\n      global: {\n        stubs: {\n          ClientOnly: false,\n        },\n      },\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountWrappedFontAwesomeIconComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Icon\", () => {\n    it(\"should pass icon when rendered.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.props(\"icon\")).toBe(\"icon\");\n    });\n\n    it(\"should pass undefined size when it is not provided in props.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"size\")).toBeUndefined();\n    });\n\n    it(\"should pass provided size when it is provided in props.\", async() => {\n      wrapper = await mountWrappedFontAwesomeIconComponent({\n        props: {\n          ...defaultProps,\n          size: \"2x\",\n        },\n      });\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.props(\"size\")).toBe(\"2x\");\n    });\n\n    it(\"should pass empty class when it is not provided in props.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"class\")).toBe(\"font-awesome-icon\");\n    });\n\n    it(\"should pass provided class when it is provided in props.\", async() => {\n      wrapper = await mountWrappedFontAwesomeIconComponent({\n        props: {\n          ...defaultProps,\n          classes: \"test-class\",\n        },\n      });\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"class\")).toBe(\"font-awesome-icon test-class\");\n    });\n\n    it(\"should set icon color to default when it is not provided in props.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"style\")).toBe(\"color: #000000;\");\n    });\n\n    it(\"should set icon color to provided color when it is provided in props.\", async() => {\n      wrapper = await mountWrappedFontAwesomeIconComponent({\n        props: {\n          ...defaultProps,\n          iconColor: \"#FFFFFF\",\n        },\n      });\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"style\")).toBe(\"color: #FFFFFF;\");\n    });\n  });\n});"
-    },
     "tests/unit/specs/components/AboutMe/AboutMyPersonalInfo/AboutMyPersonalInfo.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "67",
+          "id": "59",
           "name": "AboutMyPersonalInfo Component should match snapshot when rendered."
         },
         {
-          "id": "68",
+          "id": "60",
           "name": "AboutMyPersonalInfo Component Age should render age when rendered."
         },
         {
-          "id": "69",
+          "id": "61",
           "name": "AboutMyPersonalInfo Component Phone Number should render formatted phone number when rendered."
         },
         {
-          "id": "70",
+          "id": "62",
           "name": "AboutMyPersonalInfo Component Phone Number should render ? when phone number in runtime config doesn't have a correct format."
         },
         {
-          "id": "71",
+          "id": "63",
           "name": "AboutMyPersonalInfo Component Address should render address when rendered."
         }
       ],
       "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\nimport { mockNuxtImport } from \"@nuxt/test-utils/runtime\";\n\nimport { TEST_NUXT_RUNTIME_CONFIG } from \"@tests/unit/utils/constants/nuxt-test.constants\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\nimport AboutMyPersonalInfo from \"@/components/AboutMe/AboutMyPersonalInfo/AboutMyPersonalInfo.vue\";\n\nconst { useRuntimeConfig: mockedUseRuntimeConfig } = vi.hoisted(() => ({\n  useRuntimeConfig: vi.fn<() => typeof TEST_NUXT_RUNTIME_CONFIG>(() => TEST_NUXT_RUNTIME_CONFIG),\n}));\n\ndescribe(\"AboutMyPersonalInfo Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof AboutMyPersonalInfo>>;\n\n  async function mountAboutMyPersonalInfoComponent(options: ComponentMountingOptions<typeof AboutMyPersonalInfo> = {}):\n  Promise<ReturnType<typeof mount<typeof AboutMyPersonalInfo>>> {\n    return mountSuspendedComponent(AboutMyPersonalInfo, { ...options });\n  }\n\n  beforeAll(() => {\n    mockNuxtImport(\"useRuntimeConfig\", () => mockedUseRuntimeConfig);\n  });\n\n  beforeEach(async() => {\n    mockedUseRuntimeConfig.mockImplementation(() => TEST_NUXT_RUNTIME_CONFIG);\n    wrapper = await mountAboutMyPersonalInfoComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Age\", () => {\n    it(\"should render age when rendered.\", () => {\n      const age = wrapper.find<HTMLDivElement>(\"#age\");\n\n      expect(age.text()).toBe(\"25 ans\");\n    });\n  });\n\n  describe(\"Phone Number\", () => {\n    it(\"should render formatted phone number when rendered.\", () => {\n      const phoneNumber = wrapper.find<HTMLDivElement>(\"#phone-number\");\n\n      expect(phoneNumber.text()).toBe(\"01 23 45 67 89\");\n    });\n\n    it(\"should render ? when phone number in runtime config doesn't have a correct format.\", async() => {\n      mockedUseRuntimeConfig.mockImplementation(() => ({\n        public: {\n          ...TEST_NUXT_RUNTIME_CONFIG.public,\n          phoneNumber: \"o\",\n        },\n      }));\n      wrapper = await mountAboutMyPersonalInfoComponent();\n      const phoneNumber = wrapper.find<HTMLDivElement>(\"#phone-number\");\n\n      expect(phoneNumber.text()).toBe(\"?\");\n    });\n  });\n\n  describe(\"Address\", () => {\n    it(\"should render address when rendered.\", () => {\n      const address = wrapper.find<HTMLDivElement>(\"#address\");\n\n      expect(address.text()).toBe(\"1234 Elm Street\");\n    });\n  });\n});"
     },
-    "tests/unit/specs/components/shared/Images/CountryFlag.nuxt.spec.ts": {
-      "tests": [
-        {
-          "id": "72",
-          "name": "Country Flag Component should match snapshot when rendered."
-        },
-        {
-          "id": "73",
-          "name": "Country Flag Component Flag should render France flag when country is France."
-        },
-        {
-          "id": "74",
-          "name": "Country Flag Component Flag 'should render France flag when countr…'"
-        },
-        {
-          "id": "75",
-          "name": "Country Flag Component Flag 'should render USA flag when country i…'"
-        },
-        {
-          "id": "76",
-          "name": "Country Flag Component Flag 'should render Canada flag when countr…'"
-        }
-      ],
-      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport type { NuxtImg } from \"#components\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type { CountryFlagProps } from \"~/components/shared/Images/CountryFlag/country-flag.types\";\nimport type { Country } from \"~/models/country/country.types\";\n\nimport CountryFlag from \"@/components/shared/Images/CountryFlag/CountryFlag.vue\";\n\ndescribe(\"Country Flag Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof CountryFlag>>;\n  const defaultProps: CountryFlagProps = {\n    country: \"france\",\n  };\n\n  async function mountCountryFlagComponent(options: ComponentMountingOptions<typeof CountryFlag> = {}): Promise<ReturnType<typeof mount<typeof CountryFlag>>> {\n    return mountSuspendedComponent(CountryFlag, {\n      props: defaultProps,\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountCountryFlagComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Flag\", () => {\n    it(\"should render France flag when country is France.\", () => {\n      const flag = wrapper.findComponent<typeof NuxtImg>(\".country-flag\");\n\n      expect(flag.attributes(\"src\")).toBe(\"/images/flags/france-flag.webp\");\n    });\n\n    it.each<{\n      country: Country;\n      expectedFlag: string;\n      test: string;\n    }>([\n      {\n        country: \"france\",\n        expectedFlag: \"/images/flags/france-flag.webp\",\n        test: \"should render France flag when country is France.\",\n      },\n      {\n        country: \"usa\",\n        expectedFlag: \"/images/flags/usa-flag.webp\",\n        test: \"should render USA flag when country is USA.\",\n      },\n      {\n        country: \"canada\",\n        expectedFlag: \"/images/flags/canada-flag.webp\",\n        test: \"should render Canada flag when country is Canada.\",\n      },\n    ])(\"$test\", async({ country, expectedFlag }) => {\n      wrapper = await mountCountryFlagComponent({ props: { country } });\n      const flag = wrapper.findComponent<typeof NuxtImg>(\".country-flag\");\n\n      expect(flag.attributes(\"src\")).toBe(expectedFlag);\n    });\n  });\n});"
-    },
-    "tests/unit/specs/app.nuxt.spec.ts": {
-      "tests": [
-        {
-          "id": "77",
-          "name": "App Component should match snapshot when rendered."
-        },
-        {
-          "id": "78",
-          "name": "App Component should define og image component when rendered."
-        },
-        {
-          "id": "79",
-          "name": "App Component should use head for sso purposes when rendered."
-        },
-        {
-          "id": "80",
-          "name": "App Component should stamp a comment in HTML when rendered."
-        }
-      ],
-      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\nimport { stampInHtml } from \"dev-stamp\";\n\nimport App from \"@/App.vue\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\nvi.mock(\"dev-stamp\");\n\ndescribe(\"App Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof App>>;\n\n  async function mountAppComponent(options: ComponentMountingOptions<typeof App> = {}): Promise<ReturnType<typeof mount<typeof App>>> {\n    return mountSuspendedComponent(App, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountAppComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  it(\"should define og image component when rendered.\", () => {\n    expect(defineOgImageComponent).toHaveBeenCalledExactlyOnceWith(\"DefaultOgImage\");\n  });\n\n  it(\"should use head for sso purposes when rendered.\", () => {\n    const expectedUseHeadAttribute = {\n      title: \"App.meta.title\",\n      meta: [{ name: \"description\", content: \"App.meta.description\" }],\n      htmlAttrs: { lang: \"fr\" },\n    };\n\n    expect(useHead).toHaveBeenNthCalledWith(1, expectedUseHeadAttribute);\n  });\n\n  it(\"should stamp a comment in HTML when rendered.\", () => {\n    const expectedComment = \"👋 Hey ! J'ai aussi créé 💮 `dev-stamp` qui a généré ce message ! Retrouvez le sur GitHub ou npm !\";\n\n    expect(stampInHtml).toHaveBeenCalledExactlyOnceWith(expectedComment);\n  });\n});"
-    },
     "tests/unit/specs/components/MyExperience/MyExperience.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "81",
+          "id": "64",
           "name": "My Experience Component should match snapshot when rendered."
         },
         {
-          "id": "82",
+          "id": "65",
           "name": "My Experience Component Experiences should render 6 experiences when rendered."
         },
         {
-          "id": "83",
+          "id": "66",
           "name": "My Experience Component Experiences should render fullstack developer experience card at Daveo when rendered."
         },
         {
-          "id": "84",
+          "id": "67",
           "name": "My Experience Component Experiences should render it engineer at OhMyCode when rendered."
         },
         {
-          "id": "85",
+          "id": "68",
           "name": "My Experience Component Experiences should render second intern at OhMyCode when rendered."
         },
         {
-          "id": "86",
+          "id": "69",
           "name": "My Experience Component Experiences should render first intern at OhMyCode when rendered."
         },
         {
-          "id": "87",
+          "id": "70",
           "name": "My Experience Component Experiences should render freelance developer at SoBook when rendered."
         },
         {
-          "id": "88",
+          "id": "71",
           "name": "My Experience Component Experiences should render first intern at SoBook when rendered."
         }
       ],
       "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport type ProfessionalExperienceCard from \"~/components/MyExperience/ProfessionalExperienceCard/ProfessionalExperienceCard.vue\";\nimport { MyExperience } from \"#components\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport { COMPANIES } from \"~/models/company/company.constants\";\nimport type { ProfessionalExperience } from \"~/models/professional-experience/professional-experience.types\";\n\ndescribe(\"My Experience Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof MyExperience>>;\n\n  async function mountMyExperienceComponent(options: ComponentMountingOptions<typeof MyExperience> = {}):\n  Promise<ReturnType<typeof mount<typeof MyExperience>>> {\n    return mountSuspendedComponent(MyExperience, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountMyExperienceComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Experiences\", () => {\n    it(\"should render 6 experiences when rendered.\", () => {\n      const experiences = wrapper.findAllComponents<typeof ProfessionalExperienceCard>(\".professional-experience-card\");\n\n      expect(experiences).toHaveLength(6);\n    });\n\n    it(\"should render fullstack developer experience card at Daveo when rendered.\", () => {\n      const experiences = wrapper.findAllComponents<typeof ProfessionalExperienceCard>(\".professional-experience-card\");\n      const expectedExperience: ProfessionalExperience = {\n        company: COMPANIES.Daveo,\n        job: {\n          name: \"MyExperience.fullStackDeveloperConsultant\",\n          startedAt: new Date(\"2022-04-01\"),\n          description: [\n            \"MyExperience.iJoinedDaveo\",\n            \"MyExperience.whatIsConsulting\",\n            \"MyExperience.myMissionsAsConsultant\",\n            \"MyExperience.cloudProductCertifications\",\n            \"MyExperience.conferenceAndWorkshops\",\n          ],\n        },\n      };\n\n      expect(experiences[0].props(\"professionalExperience\")).toStrictEqual<ProfessionalExperience>(expectedExperience);\n    });\n\n    it(\"should render it engineer at OhMyCode when rendered.\", () => {\n      const experiences = wrapper.findAllComponents<typeof ProfessionalExperienceCard>(\".professional-experience-card\");\n      const expectedExperience: ProfessionalExperience = {\n        company: COMPANIES.OhMyCode,\n        job: {\n          name: \"MyExperience.itR&DEngineer\",\n          startedAt: new Date(\"2019-09-01\"),\n          finishedAt: new Date(\"2022-03-31\"),\n          description: [\n            \"MyExperience.firstPermanentContract\",\n            \"MyExperience.asProjectManager\",\n            \"MyExperience.softSkills\",\n            \"MyExperience.expertiseAndTechnicalSkills\",\n          ],\n        },\n      };\n\n      expect(experiences[1].props(\"professionalExperience\")).toStrictEqual<ProfessionalExperience>(expectedExperience);\n    });\n\n    it(\"should render second intern at OhMyCode when rendered.\", () => {\n      const experiences = wrapper.findAllComponents<typeof ProfessionalExperienceCard>(\".professional-experience-card\");\n      const expectedExperience: ProfessionalExperience = {\n        company: COMPANIES.OhMyCode,\n        job: {\n          name: \"MyExperience.internFullStackDeveloper\",\n          startedAt: new Date(\"2018-09-01\"),\n          finishedAt: new Date(\"2019-08-30\"),\n          description: [\n            \"MyExperience.distributionProject\",\n            \"MyExperience.thisFinalInternship\",\n          ],\n        },\n      };\n\n      expect(experiences[2].props(\"professionalExperience\")).toStrictEqual<ProfessionalExperience>(expectedExperience);\n    });\n\n    it(\"should render first intern at OhMyCode when rendered.\", () => {\n      const experiences = wrapper.findAllComponents<typeof ProfessionalExperienceCard>(\".professional-experience-card\");\n      const expectedExperience: ProfessionalExperience = {\n        company: COMPANIES.OhMyCode,\n        job: {\n          name: \"MyExperience.internFullStackDeveloper\",\n          startedAt: new Date(\"2016-09-01\"),\n          finishedAt: new Date(\"2017-04-30\"),\n          description: [\n            \"MyExperience.firstStepsInOhMyCode\",\n            \"MyExperience.allFunctionalitiesInOnApp\",\n          ],\n        },\n      };\n\n      expect(experiences[3].props(\"professionalExperience\")).toStrictEqual<ProfessionalExperience>(expectedExperience);\n    });\n\n    it(\"should render freelance developer at SoBook when rendered.\", () => {\n      const experiences = wrapper.findAllComponents<typeof ProfessionalExperienceCard>(\".professional-experience-card\");\n      const expectedExperience: ProfessionalExperience = {\n        company: COMPANIES.SoBook,\n        job: {\n          name: \"MyExperience.freelanceFullStackDeveloper\",\n          startedAt: new Date(\"2016-02-01\"),\n          finishedAt: new Date(\"2016-08-30\"),\n          description: [\n            \"MyExperience.reiterateAsFreelance\",\n            \"MyExperience.moreResponsibilities\",\n          ],\n        },\n      };\n\n      expect(experiences[4].props(\"professionalExperience\")).toStrictEqual<ProfessionalExperience>(expectedExperience);\n    });\n\n    it(\"should render first intern at SoBook when rendered.\", () => {\n      const experiences = wrapper.findAllComponents<typeof ProfessionalExperienceCard>(\".professional-experience-card\");\n      const expectedExperience: ProfessionalExperience = {\n        company: COMPANIES.SoBook,\n        job: {\n          name: \"MyExperience.internFullStackDeveloper\",\n          startedAt: new Date(\"2015-07-01\"),\n          finishedAt: new Date(\"2015-12-31\"),\n          description: [\"MyExperience.firstInternship\"],\n        },\n      };\n\n      expect(experiences[5].props(\"professionalExperience\")).toStrictEqual<ProfessionalExperience>(expectedExperience);\n    });\n  });\n});"
     },
-    "tests/unit/specs/components/MyExperience/ProfessionalExperienceCard/ProfessionalExperienceCard.nuxt.spec.ts": {
+    "tests/unit/specs/components/OgImage/DefaultOgImage.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "89",
-          "name": "Professional Experience Card Component should match snapshot when rendered."
+          "id": "72",
+          "name": "Default Og Image Component should match snapshot when rendered."
         },
         {
-          "id": "90",
-          "name": "Professional Experience Card Component Period Timeline should pass job started date when rendered."
+          "id": "73",
+          "name": "Default Og Image Component Og Image Title should set Og Image title when rendered."
         },
         {
-          "id": "91",
-          "name": "Professional Experience Card Component Period Timeline should pass job finished date when rendered."
-        },
-        {
-          "id": "92",
-          "name": "Professional Experience Card Component Period Timeline should pass company image when rendered."
-        },
-        {
-          "id": "93",
-          "name": "Professional Experience Card Component Period Timeline should pass company url when rendered."
-        },
-        {
-          "id": "94",
-          "name": "Professional Experience Card Component Job should render job name when rendered."
-        },
-        {
-          "id": "95",
-          "name": "Professional Experience Card Component Job should render job description when rendered."
+          "id": "74",
+          "name": "Default Og Image Component Og Image Title should set Og Image subtitle when rendered."
         }
       ],
-      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type { ProfessionalExperienceCardProps } from \"~/components/MyExperience/ProfessionalExperienceCard/professional-experience-card.types\";\nimport ProfessionalExperienceCard from \"~/components/MyExperience/ProfessionalExperienceCard/ProfessionalExperienceCard.vue\";\nimport type PeriodTimeline from \"~/components/shared/Period/PeriodTimeline.vue\";\nimport { COMPANIES } from \"~/models/company/company.constants\";\n\ndescribe(\"Professional Experience Card Component\", () => {\n  const defaultProps: ProfessionalExperienceCardProps = {\n    professionalExperience: {\n      job: {\n        name: \"MyExperience.internFullStackDeveloper\",\n        description: [\"MyExperience.distributionProject\", \"MyExperience.thisFinalInternship\"],\n        startedAt: new Date(\"2018-09-01T00:00:00.000Z\"),\n        finishedAt: new Date(\"2019-08-30T00:00:00.000Z\"),\n      },\n      company: COMPANIES.OhMyCode,\n    },\n  };\n  let wrapper: ReturnType<typeof mount<typeof ProfessionalExperienceCard>>;\n\n  async function mountProfessionalExperienceCardComponent(options: ComponentMountingOptions<typeof ProfessionalExperienceCard> = {}):\n  Promise<ReturnType<typeof mount<typeof ProfessionalExperienceCard>>> {\n    return mountSuspendedComponent(ProfessionalExperienceCard, {\n      props: defaultProps,\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountProfessionalExperienceCardComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Period Timeline\", () => {\n    it(\"should pass job started date when rendered.\", () => {\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".experience-timeline\");\n\n      expect(periodTimeline.props(\"startedAt\")).toBe(defaultProps.professionalExperience.job.startedAt);\n    });\n\n    it(\"should pass job finished date when rendered.\", () => {\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".experience-timeline\");\n\n      expect(periodTimeline.props(\"finishedAt\")).toBe(defaultProps.professionalExperience.job.finishedAt);\n    });\n\n    it(\"should pass company image when rendered.\", () => {\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".experience-timeline\");\n\n      expect(periodTimeline.props(\"image\")).toBe(defaultProps.professionalExperience.company.image);\n    });\n\n    it(\"should pass company url when rendered.\", () => {\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".experience-timeline\");\n\n      expect(periodTimeline.props(\"url\")).toBe(defaultProps.professionalExperience.company.url);\n    });\n  });\n\n  describe(\"Job\", () => {\n    it(\"should render job name when rendered.\", () => {\n      const jobName = wrapper.find<HTMLDivElement>(\".job-name\");\n\n      expect(jobName.text()).toBe(\"MyExperience.internFullStackDeveloper\");\n    });\n\n    it(\"should render job description when rendered.\", () => {\n      const jobDescriptions = wrapper.findAll<HTMLParagraphElement>(\".job-description\");\n\n      expect(jobDescriptions).toHaveLength(2);\n      expect(jobDescriptions[0].text()).toBe(\"MyExperience.distributionProject\");\n      expect(jobDescriptions[1].text()).toBe(\"MyExperience.thisFinalInternship\");\n    });\n  });\n});"
+      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport { ANTOINE_ZANARDI_FULL_NAME } from \"~/shared/constants/antoine-zanardi.constants\";\n\nimport DefaultOgImage from \"@/components/OgImage/DefaultOgImage.vue\";\n\ndescribe(\"Default Og Image Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof DefaultOgImage>>;\n\n  async function mountDefaultOgImageComponent(options: ComponentMountingOptions<typeof DefaultOgImage> = {}): Promise<ReturnType<typeof mount<typeof DefaultOgImage>>> {\n    return mountSuspendedComponent(DefaultOgImage, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountDefaultOgImageComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Og Image Title\", () => {\n    it(\"should set Og Image title when rendered.\", () => {\n      const title = wrapper.find(\"#og-image-title\");\n\n      expect(title.text()).toBe(ANTOINE_ZANARDI_FULL_NAME);\n    });\n\n    it(\"should set Og Image subtitle when rendered.\", () => {\n      const subtitle = wrapper.find(\"#og-image-subtitle\");\n\n      expect(subtitle.text()).toBe(\"Expert Web FullStack basé à Lille, qui allie qualité, IA et efficacité\");\n    });\n  });\n});"
+    },
+    "tests/unit/specs/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.nuxt.spec.ts": {
+      "tests": [
+        {
+          "id": "75",
+          "name": "Wrapped Font Awesome Icon Component should match snapshot when rendered."
+        },
+        {
+          "id": "76",
+          "name": "Wrapped Font Awesome Icon Component Icon should pass icon when rendered."
+        },
+        {
+          "id": "77",
+          "name": "Wrapped Font Awesome Icon Component Icon should pass undefined size when it is not provided in props."
+        },
+        {
+          "id": "78",
+          "name": "Wrapped Font Awesome Icon Component Icon should pass provided size when it is provided in props."
+        },
+        {
+          "id": "79",
+          "name": "Wrapped Font Awesome Icon Component Icon should pass empty class when it is not provided in props."
+        },
+        {
+          "id": "80",
+          "name": "Wrapped Font Awesome Icon Component Icon should pass provided class when it is provided in props."
+        },
+        {
+          "id": "81",
+          "name": "Wrapped Font Awesome Icon Component Icon should set icon color to default when it is not provided in props."
+        },
+        {
+          "id": "82",
+          "name": "Wrapped Font Awesome Icon Component Icon should set icon color to provided color when it is provided in props."
+        }
+      ],
+      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport type { WrappedFontAwesomeIconProps } from \"~/components/shared/Icons/WrappedFontAwesomeIcon/wrapped-font-awesome-icon.types\";\nimport WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\ndescribe(\"Wrapped Font Awesome Icon Component\", () => {\n  const defaultProps: WrappedFontAwesomeIconProps = {\n    icon: \"icon\",\n  };\n  let wrapper: ReturnType<typeof mount<typeof WrappedFontAwesomeIcon>>;\n\n  async function mountWrappedFontAwesomeIconComponent(options: ComponentMountingOptions<typeof WrappedFontAwesomeIcon> = {}):\n  Promise<ReturnType<typeof mount<typeof WrappedFontAwesomeIcon>>> {\n    return mountSuspendedComponent(WrappedFontAwesomeIcon, {\n      props: defaultProps,\n      global: {\n        stubs: {\n          ClientOnly: false,\n        },\n      },\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountWrappedFontAwesomeIconComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Icon\", () => {\n    it(\"should pass icon when rendered.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.props(\"icon\")).toBe(\"icon\");\n    });\n\n    it(\"should pass undefined size when it is not provided in props.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"size\")).toBeUndefined();\n    });\n\n    it(\"should pass provided size when it is provided in props.\", async() => {\n      wrapper = await mountWrappedFontAwesomeIconComponent({\n        props: {\n          ...defaultProps,\n          size: \"2x\",\n        },\n      });\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.props(\"size\")).toBe(\"2x\");\n    });\n\n    it(\"should pass empty class when it is not provided in props.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"class\")).toBe(\"font-awesome-icon\");\n    });\n\n    it(\"should pass provided class when it is provided in props.\", async() => {\n      wrapper = await mountWrappedFontAwesomeIconComponent({\n        props: {\n          ...defaultProps,\n          classes: \"test-class\",\n        },\n      });\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"class\")).toBe(\"font-awesome-icon test-class\");\n    });\n\n    it(\"should set icon color to default when it is not provided in props.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"style\")).toBe(\"color: #000000;\");\n    });\n\n    it(\"should set icon color to provided color when it is provided in props.\", async() => {\n      wrapper = await mountWrappedFontAwesomeIconComponent({\n        props: {\n          ...defaultProps,\n          iconColor: \"#FFFFFF\",\n        },\n      });\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".font-awesome-icon\");\n\n      expect(icon.attributes(\"style\")).toBe(\"color: #FFFFFF;\");\n    });\n  });\n});"
     },
     "tests/unit/specs/components/MyEducation/MyEducation.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "96",
+          "id": "83",
           "name": "MyEducation Component should match snapshot when rendered."
         },
         {
-          "id": "97",
+          "id": "84",
           "name": "MyEducation Component Education Degrees should render 5 education degree cards when rendered."
         },
         {
-          "id": "98",
+          "id": "85",
           "name": "MyEducation Component Education Degrees should render GCP ACE education degree card when rendered."
         },
         {
-          "id": "99",
+          "id": "86",
           "name": "MyEducation Component Education Degrees should render CKAD education degree card when rendered."
         },
         {
-          "id": "100",
+          "id": "87",
           "name": "MyEducation Component Education Degrees should render IT Master degree card when rendered."
         },
         {
-          "id": "101",
+          "id": "88",
           "name": "MyEducation Component Education Degrees should render IT certification degree card when rendered."
         },
         {
-          "id": "102",
+          "id": "89",
           "name": "MyEducation Component Education Degrees should render high school degree card when rendered."
         }
       ],
@@ -16136,115 +16074,202 @@
     "tests/unit/specs/components/MySkills/SkillProgressBar/SkillProgressBar.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "103",
+          "id": "90",
           "name": "Skill Progress Bar Component should match snapshot when rendered."
         },
         {
-          "id": "104",
+          "id": "91",
           "name": "Skill Progress Bar Component Icon should pass skill icon when rendered."
         },
         {
-          "id": "105",
+          "id": "92",
           "name": "Skill Progress Bar Component Icon should pass skill color when rendered."
         },
         {
-          "id": "106",
+          "id": "93",
           "name": "Skill Progress Bar Component Skill should render skill name when rendered."
         },
         {
-          "id": "107",
+          "id": "94",
           "name": "Skill Progress Bar Component Skill should set skill url to anchor when rendered."
         },
         {
-          "id": "108",
+          "id": "95",
           "name": "Skill Progress Bar Component Progress Bar should set aria label to skill name and percent when rendered."
         },
         {
-          "id": "109",
+          "id": "96",
           "name": "Skill Progress Bar Component Progress Bar should set progress bar style when rendered."
         },
         {
-          "id": "110",
+          "id": "97",
           "name": "Skill Progress Bar Component Progress Bar should set progress bar percent in progress bar label when rendered."
         }
       ],
       "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\nimport type { SkillProgressBarProps } from \"~/components/MySkills/SkillProgressBar/skill-progress-bar.types\";\nimport SkillProgressBar from \"~/components/MySkills/SkillProgressBar/SkillProgressBar.vue\";\n\ndescribe(\"Skill Progress Bar Component\", () => {\n  const defaultProps: SkillProgressBarProps = {\n    skill: {\n      name: \"MySkills.html\",\n      iconClasses: \"fab fa-html5\",\n      color: \"#E44D27\",\n      percent: \"95%\",\n      url: \"https://fr.wikipedia.org/wiki/HTML5\",\n    },\n  };\n  let wrapper: ReturnType<typeof mount<typeof SkillProgressBar>>;\n\n  async function mountSkillProgressBarComponent(options: ComponentMountingOptions<typeof SkillProgressBar> = {}):\n  Promise<ReturnType<typeof mount<typeof SkillProgressBar>>> {\n    return mountSuspendedComponent(SkillProgressBar, {\n      props: defaultProps,\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountSkillProgressBarComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Icon\", () => {\n    it(\"should pass skill icon when rendered.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".skill-icon\");\n\n      expect(icon.props(\"icon\")).toBe(defaultProps.skill.iconClasses);\n    });\n\n    it(\"should pass skill color when rendered.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".skill-icon\");\n\n      expect(icon.props(\"iconColor\")).toBe(defaultProps.skill.color);\n    });\n  });\n\n  describe(\"Skill\", () => {\n    it(\"should render skill name when rendered.\", () => {\n      const skillName = wrapper.find<HTMLAnchorElement>(\".skill-name\");\n\n      expect(skillName.text()).toBe(defaultProps.skill.name);\n    });\n\n    it(\"should set skill url to anchor when rendered.\", () => {\n      const skillUrl = wrapper.find<HTMLAnchorElement>(\".skill-name\");\n\n      expect(skillUrl.attributes(\"href\")).toBe(defaultProps.skill.url);\n    });\n  });\n\n  describe(\"Progress Bar\", () => {\n    it(\"should set aria label to skill name and percent when rendered.\", () => {\n      const progressBar = wrapper.find<HTMLDivElement>(\".progress-bar\");\n\n      expect(progressBar.attributes(\"aria-label\")).toBe(\"SkillProgressBar.skillProgress, {\\\"skillName\\\":\\\"MySkills.html\\\",\\\"skillPercent\\\":\\\"95%\\\"}\");\n    });\n\n    it(\"should set progress bar style when rendered.\", () => {\n      const progressBar = wrapper.find<HTMLDivElement>(\".progress-bar\");\n      const expectedStyle = `width: ${defaultProps.skill.percent}; background-color: ${defaultProps.skill.color};`;\n\n      expect(progressBar.attributes(\"style\")).toBe(expectedStyle);\n    });\n\n    it(\"should set progress bar percent in progress bar label when rendered.\", () => {\n      const progressBarLabel = wrapper.find<HTMLDivElement>(\".progress-value\");\n\n      expect(progressBarLabel.text()).toBe(defaultProps.skill.percent);\n    });\n  });\n});"
     },
-    "tests/unit/specs/components/NavBar/NavBar.nuxt.spec.ts": {
+    "tests/unit/specs/components/shared/Images/CountryFlag.nuxt.spec.ts": {
       "tests": [
         {
+          "id": "98",
+          "name": "Country Flag Component should match snapshot when rendered."
+        },
+        {
+          "id": "99",
+          "name": "Country Flag Component Flag should render France flag when country is France."
+        },
+        {
+          "id": "100",
+          "name": "Country Flag Component Flag 'should render France flag when countr…'"
+        },
+        {
+          "id": "101",
+          "name": "Country Flag Component Flag 'should render USA flag when country i…'"
+        },
+        {
+          "id": "102",
+          "name": "Country Flag Component Flag 'should render Canada flag when countr…'"
+        }
+      ],
+      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport type { NuxtImg } from \"#components\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type { CountryFlagProps } from \"~/components/shared/Images/CountryFlag/country-flag.types\";\nimport type { Country } from \"~/models/country/country.types\";\n\nimport CountryFlag from \"@/components/shared/Images/CountryFlag/CountryFlag.vue\";\n\ndescribe(\"Country Flag Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof CountryFlag>>;\n  const defaultProps: CountryFlagProps = {\n    country: \"france\",\n  };\n\n  async function mountCountryFlagComponent(options: ComponentMountingOptions<typeof CountryFlag> = {}): Promise<ReturnType<typeof mount<typeof CountryFlag>>> {\n    return mountSuspendedComponent(CountryFlag, {\n      props: defaultProps,\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountCountryFlagComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Flag\", () => {\n    it(\"should render France flag when country is France.\", () => {\n      const flag = wrapper.findComponent<typeof NuxtImg>(\".country-flag\");\n\n      expect(flag.attributes(\"src\")).toBe(\"/images/flags/france-flag.webp\");\n    });\n\n    it.each<{\n      country: Country;\n      expectedFlag: string;\n      test: string;\n    }>([\n      {\n        country: \"france\",\n        expectedFlag: \"/images/flags/france-flag.webp\",\n        test: \"should render France flag when country is France.\",\n      },\n      {\n        country: \"usa\",\n        expectedFlag: \"/images/flags/usa-flag.webp\",\n        test: \"should render USA flag when country is USA.\",\n      },\n      {\n        country: \"canada\",\n        expectedFlag: \"/images/flags/canada-flag.webp\",\n        test: \"should render Canada flag when country is Canada.\",\n      },\n    ])(\"$test\", async({ country, expectedFlag }) => {\n      wrapper = await mountCountryFlagComponent({ props: { country } });\n      const flag = wrapper.findComponent<typeof NuxtImg>(\".country-flag\");\n\n      expect(flag.attributes(\"src\")).toBe(expectedFlag);\n    });\n  });\n});"
+    },
+    "tests/unit/specs/components/MyPortfolio/MyPortfolio.nuxt.spec.ts": {
+      "tests": [
+        {
+          "id": "103",
+          "name": "My Portfolio Component should match snapshot when rendered."
+        },
+        {
+          "id": "104",
+          "name": "My Portfolio Component Projects should render 4 projects when rendered."
+        },
+        {
+          "id": "105",
+          "name": "My Portfolio Component Projects should render my portfolio project when rendered."
+        },
+        {
+          "id": "106",
+          "name": "My Portfolio Component Projects should render my Werewolves Assistant project when rendered."
+        },
+        {
+          "id": "107",
+          "name": "My Portfolio Component Projects should render book distribution project when rendered."
+        },
+        {
+          "id": "108",
+          "name": "My Portfolio Component Projects should render my GitHub profile project when rendered."
+        }
+      ],
+      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport type MyProject from \"~/components/MyPortfolio/MyProject/MyProject.vue\";\nimport { MyPortfolio } from \"#components\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type { Project } from \"~/models/project/project.types\";\n\ndescribe(\"My Portfolio Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof MyPortfolio>>;\n\n  async function mountMyPortfolioComponent(options: ComponentMountingOptions<typeof MyPortfolio> = {}): Promise<ReturnType<typeof mount<typeof MyPortfolio>>> {\n    return mountSuspendedComponent(MyPortfolio, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountMyPortfolioComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Projects\", () => {\n    it(\"should render 4 projects when rendered.\", () => {\n      const projects = wrapper.findAllComponents<typeof MyProject>(\".project\");\n\n      expect(projects).toHaveLength(4);\n    });\n\n    it(\"should render my portfolio project when rendered.\", () => {\n      const projects = wrapper.findAllComponents<typeof MyProject>(\".project\");\n      const expectedProject: Project = {\n        name: \"MyPortfolio.projects.portfolio.name\",\n        description: \"MyPortfolio.projects.portfolio.description\",\n        image: \"portfolio-thumbnail.webp\",\n        url: \"https://test.antoinezanardi.fr\",\n      };\n\n      expect(projects[0].props(\"project\")).toStrictEqual<Project>(expectedProject);\n    });\n\n    it(\"should render my Werewolves Assistant project when rendered.\", () => {\n      const projects = wrapper.findAllComponents<typeof MyProject>(\".project\");\n      const expectedProject: Project = {\n        name: \"MyPortfolio.projects.werewolvesAssistant.name\",\n        description: \"MyPortfolio.projects.werewolvesAssistant.description\",\n        image: \"werewolves-assistant-thumbnail.webp\",\n        url: \"https://werewolves-assistant.com\",\n      };\n\n      expect(projects[1].props(\"project\")).toStrictEqual<Project>(expectedProject);\n    });\n\n    it(\"should render book distribution project when rendered.\", () => {\n      const projects = wrapper.findAllComponents<typeof MyProject>(\".project\");\n      const expectedProject: Project = {\n        name: \"MyPortfolio.projects.distribution.name\",\n        description: \"MyPortfolio.projects.distribution.description\",\n        image: \"distribution-thumbnail.webp\",\n        url: \"https://www.airvey-editions.fr\",\n      };\n\n      expect(projects[2].props(\"project\")).toStrictEqual<Project>(expectedProject);\n    });\n\n    it(\"should render my GitHub profile project when rendered.\", () => {\n      const projects = wrapper.findAllComponents<typeof MyProject>(\".project\");\n      const expectedProject: Project = {\n        name: \"MyPortfolio.projects.gitHub.name\",\n        description: \"MyPortfolio.projects.gitHub.description\",\n        image: \"github.webp\",\n        url: \"https://github.com/antoinezanardi/\",\n      };\n\n      expect(projects[3].props(\"project\")).toStrictEqual<Project>(expectedProject);\n    });\n  });\n});"
+    },
+    "tests/unit/specs/components/MyExperience/ProfessionalExperienceCard/ProfessionalExperienceCard.nuxt.spec.ts": {
+      "tests": [
+        {
+          "id": "109",
+          "name": "Professional Experience Card Component should match snapshot when rendered."
+        },
+        {
+          "id": "110",
+          "name": "Professional Experience Card Component Period Timeline should pass job started date when rendered."
+        },
+        {
           "id": "111",
-          "name": "NavBar Component should match snapshot when rendered."
+          "name": "Professional Experience Card Component Period Timeline should pass job finished date when rendered."
         },
         {
           "id": "112",
-          "name": "NavBar Component Navigation should not have show class when rendered."
+          "name": "Professional Experience Card Component Period Timeline should pass company image when rendered."
         },
         {
           "id": "113",
-          "name": "NavBar Component Navigation should toggle show class when clicked on a navbar toggler."
+          "name": "Professional Experience Card Component Period Timeline should pass company url when rendered."
         },
         {
           "id": "114",
-          "name": "NavBar Component Navigation should remove show class when clicked on a navbar toggler after toggling."
+          "name": "Professional Experience Card Component Job should render job name when rendered."
         },
         {
           "id": "115",
+          "name": "Professional Experience Card Component Job should render job description when rendered."
+        }
+      ],
+      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type { ProfessionalExperienceCardProps } from \"~/components/MyExperience/ProfessionalExperienceCard/professional-experience-card.types\";\nimport ProfessionalExperienceCard from \"~/components/MyExperience/ProfessionalExperienceCard/ProfessionalExperienceCard.vue\";\nimport type PeriodTimeline from \"~/components/shared/Period/PeriodTimeline.vue\";\nimport { COMPANIES } from \"~/models/company/company.constants\";\n\ndescribe(\"Professional Experience Card Component\", () => {\n  const defaultProps: ProfessionalExperienceCardProps = {\n    professionalExperience: {\n      job: {\n        name: \"MyExperience.internFullStackDeveloper\",\n        description: [\"MyExperience.distributionProject\", \"MyExperience.thisFinalInternship\"],\n        startedAt: new Date(\"2018-09-01T00:00:00.000Z\"),\n        finishedAt: new Date(\"2019-08-30T00:00:00.000Z\"),\n      },\n      company: COMPANIES.OhMyCode,\n    },\n  };\n  let wrapper: ReturnType<typeof mount<typeof ProfessionalExperienceCard>>;\n\n  async function mountProfessionalExperienceCardComponent(options: ComponentMountingOptions<typeof ProfessionalExperienceCard> = {}):\n  Promise<ReturnType<typeof mount<typeof ProfessionalExperienceCard>>> {\n    return mountSuspendedComponent(ProfessionalExperienceCard, {\n      props: defaultProps,\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountProfessionalExperienceCardComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Period Timeline\", () => {\n    it(\"should pass job started date when rendered.\", () => {\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".experience-timeline\");\n\n      expect(periodTimeline.props(\"startedAt\")).toBe(defaultProps.professionalExperience.job.startedAt);\n    });\n\n    it(\"should pass job finished date when rendered.\", () => {\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".experience-timeline\");\n\n      expect(periodTimeline.props(\"finishedAt\")).toBe(defaultProps.professionalExperience.job.finishedAt);\n    });\n\n    it(\"should pass company image when rendered.\", () => {\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".experience-timeline\");\n\n      expect(periodTimeline.props(\"image\")).toBe(defaultProps.professionalExperience.company.image);\n    });\n\n    it(\"should pass company url when rendered.\", () => {\n      const periodTimeline = wrapper.findComponent<typeof PeriodTimeline>(\".experience-timeline\");\n\n      expect(periodTimeline.props(\"url\")).toBe(defaultProps.professionalExperience.company.url);\n    });\n  });\n\n  describe(\"Job\", () => {\n    it(\"should render job name when rendered.\", () => {\n      const jobName = wrapper.find<HTMLDivElement>(\".job-name\");\n\n      expect(jobName.text()).toBe(\"MyExperience.internFullStackDeveloper\");\n    });\n\n    it(\"should render job description when rendered.\", () => {\n      const jobDescriptions = wrapper.findAll<HTMLParagraphElement>(\".job-description\");\n\n      expect(jobDescriptions).toHaveLength(2);\n      expect(jobDescriptions[0].text()).toBe(\"MyExperience.distributionProject\");\n      expect(jobDescriptions[1].text()).toBe(\"MyExperience.thisFinalInternship\");\n    });\n  });\n});"
+    },
+    "tests/unit/specs/components/AboutMe/AboutMyProfile/AboutMyProfile.nuxt.spec.ts": {
+      "tests": [
+        {
+          "id": "116",
+          "name": "AboutMyProfile Component should match snapshot when rendered."
+        }
+      ],
+      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\nimport AboutMyProfile from \"@/components/AboutMe/AboutMyProfile/AboutMyProfile.vue\";\n\ndescribe(\"AboutMyProfile Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof AboutMyProfile>>;\n\n  async function mountAboutMyProfileComponent(options: ComponentMountingOptions<typeof AboutMyProfile> = {}): Promise<ReturnType<typeof mount<typeof AboutMyProfile>>> {\n    return mountSuspendedComponent(AboutMyProfile, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountAboutMyProfileComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n});"
+    },
+    "tests/unit/specs/components/NavBar/NavBar.nuxt.spec.ts": {
+      "tests": [
+        {
+          "id": "117",
+          "name": "NavBar Component should match snapshot when rendered."
+        },
+        {
+          "id": "118",
+          "name": "NavBar Component Navigation should not have show class when rendered."
+        },
+        {
+          "id": "119",
+          "name": "NavBar Component Navigation should toggle show class when clicked on a navbar toggler."
+        },
+        {
+          "id": "120",
+          "name": "NavBar Component Navigation should remove show class when clicked on a navbar toggler after toggling."
+        },
+        {
+          "id": "121",
           "name": "NavBar Component Navigation should remove show class when clicked on a nav link after toggling."
         }
       ],
       "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { NavBar } from \"#components\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\ndescribe(\"NavBar Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof NavBar>>;\n\n  async function mountNavBarComponent(options: ComponentMountingOptions<typeof NavBar> = {}): Promise<ReturnType<typeof mount<typeof NavBar>>> {\n    return mountSuspendedComponent(NavBar, options);\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountNavBarComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Navigation\", () => {\n    it(\"should not have show class when rendered.\", () => {\n      const nav = wrapper.find<HTMLDivElement>(\"#navigation\");\n\n      expect(nav.classes()).not.toContain(\"show\");\n    });\n\n    it(\"should toggle show class when clicked on a navbar toggler.\", async() => {\n      const nav = wrapper.find<HTMLDivElement>(\"#navigation\");\n      const toggler = wrapper.find<HTMLButtonElement>(\".navbar-toggler\");\n      await toggler.trigger(\"click\");\n\n      expect(nav.classes()).toContain(\"show\");\n    });\n\n    it(\"should remove show class when clicked on a navbar toggler after toggling.\", async() => {\n      const nav = wrapper.find<HTMLDivElement>(\"#navigation\");\n      const toggler = wrapper.find<HTMLButtonElement>(\".navbar-toggler\");\n      await toggler.trigger(\"click\");\n      await toggler.trigger(\"click\");\n\n      expect(nav.classes()).not.toContain(\"show\");\n    });\n\n    it(\"should remove show class when clicked on a nav link after toggling.\", async() => {\n      const nav = wrapper.find<HTMLDivElement>(\"#navigation\");\n      const toggler = wrapper.find<HTMLButtonElement>(\".navbar-toggler\");\n      await toggler.trigger(\"click\");\n      const navLink = wrapper.find<HTMLAnchorElement>(\".nav-link\");\n      await navLink.trigger(\"click\");\n\n      expect(nav.classes()).not.toContain(\"show\");\n    });\n  });\n});"
     },
-    "tests/unit/specs/components/PageFooter/PageFooter.nuxt.spec.ts": {
+    "tests/unit/specs/app.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "116",
-          "name": "Page Footer Component should match snapshot when rendered."
+          "id": "122",
+          "name": "App Component should match snapshot when rendered."
         },
         {
-          "id": "117",
-          "name": "Page Footer Component Text should display Antoine ZANARDI and full year when rendered."
+          "id": "123",
+          "name": "App Component should define og image component when rendered."
+        },
+        {
+          "id": "124",
+          "name": "App Component should use head for sso purposes when rendered."
+        },
+        {
+          "id": "125",
+          "name": "App Component should stamp a comment in HTML when rendered."
         }
       ],
-      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { PageFooter } from \"#components\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\ndescribe(\"Page Footer Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof PageFooter>>;\n\n  async function mountPageFooterComponent(options: ComponentMountingOptions<typeof PageFooter> = {}): Promise<ReturnType<typeof mount<typeof PageFooter>>> {\n    return mountSuspendedComponent(PageFooter, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountPageFooterComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Text\", () => {\n    it(\"should display Antoine ZANARDI and full year when rendered.\", () => {\n      const title = wrapper.find<HTMLDivElement>(\".title\");\n\n      expect(title.text()).toBe(\"Antoine ZANARDI - 2022\");\n    });\n  });\n});"
-    },
-    "tests/unit/specs/components/OgImage/DefaultOgImage.nuxt.spec.ts": {
-      "tests": [
-        {
-          "id": "118",
-          "name": "Default Og Image Component should match snapshot when rendered."
-        },
-        {
-          "id": "119",
-          "name": "Default Og Image Component Og Image Title should set Og Image title when rendered."
-        },
-        {
-          "id": "120",
-          "name": "Default Og Image Component Og Image Title should set Og Image subtitle when rendered."
-        }
-      ],
-      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport { ANTOINE_ZANARDI_FULL_NAME } from \"~/shared/constants/antoine-zanardi.constants\";\n\nimport DefaultOgImage from \"@/components/OgImage/DefaultOgImage.vue\";\n\ndescribe(\"Default Og Image Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof DefaultOgImage>>;\n\n  async function mountDefaultOgImageComponent(options: ComponentMountingOptions<typeof DefaultOgImage> = {}): Promise<ReturnType<typeof mount<typeof DefaultOgImage>>> {\n    return mountSuspendedComponent(DefaultOgImage, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountDefaultOgImageComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Og Image Title\", () => {\n    it(\"should set Og Image title when rendered.\", () => {\n      const title = wrapper.find(\"#og-image-title\");\n\n      expect(title.text()).toBe(ANTOINE_ZANARDI_FULL_NAME);\n    });\n\n    it(\"should set Og Image subtitle when rendered.\", () => {\n      const subtitle = wrapper.find(\"#og-image-subtitle\");\n\n      expect(subtitle.text()).toBe(\"Expert Web FullStack basé à Lille, qui allie qualité, IA et efficacité\");\n    });\n  });\n});"
+      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\nimport { stampInHtml } from \"dev-stamp\";\n\nimport App from \"@/App.vue\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\nvi.mock(\"dev-stamp\");\n\ndescribe(\"App Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof App>>;\n\n  async function mountAppComponent(options: ComponentMountingOptions<typeof App> = {}): Promise<ReturnType<typeof mount<typeof App>>> {\n    return mountSuspendedComponent(App, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountAppComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  it(\"should define og image component when rendered.\", () => {\n    expect(defineOgImageComponent).toHaveBeenCalledExactlyOnceWith(\"DefaultOgImage\");\n  });\n\n  it(\"should use head for sso purposes when rendered.\", () => {\n    const expectedUseHeadAttribute = {\n      title: \"App.meta.title\",\n      meta: [{ name: \"description\", content: \"App.meta.description\" }],\n      htmlAttrs: { lang: \"fr\" },\n    };\n\n    expect(useHead).toHaveBeenNthCalledWith(1, expectedUseHeadAttribute);\n  });\n\n  it(\"should stamp a comment in HTML when rendered.\", () => {\n    const expectedComment = \"👋 Hey ! J'ai aussi créé 💮 `dev-stamp` qui a généré ce message ! Retrouvez le sur GitHub ou npm !\";\n\n    expect(stampInHtml).toHaveBeenCalledExactlyOnceWith(expectedComment);\n  });\n});"
     },
     "tests/unit/specs/components/MyPortfolio/MyProject/MyProject.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "121",
+          "id": "126",
           "name": "My Project Component should match snapshot when rendered."
         },
         {
-          "id": "122",
+          "id": "127",
           "name": "My Project Component Image should set alt to project name when rendered."
         },
         {
-          "id": "123",
+          "id": "128",
           "name": "My Project Component Image should set image source when rendered."
         },
         {
-          "id": "124",
+          "id": "129",
           "name": "My Project Component Project should render project name when rendered."
         },
         {
-          "id": "125",
+          "id": "130",
           "name": "My Project Component Project should render project description when rendered."
         }
       ],
@@ -16253,57 +16278,27 @@
     "tests/unit/specs/components/shared/Layouts/SectionTitle/SectionTitle.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "126",
+          "id": "131",
           "name": "Section Title Component should match snapshot when rendered."
         },
         {
-          "id": "127",
+          "id": "132",
           "name": "Section Title Component Icon should set icon source when rendered."
         },
         {
-          "id": "128",
+          "id": "133",
           "name": "Section Title Component Icon should set icon color to default when it is not provided in props."
         },
         {
-          "id": "129",
+          "id": "134",
           "name": "Section Title Component Icon should set icon color to provided color when it is provided in props."
         },
         {
-          "id": "130",
+          "id": "135",
           "name": "Section Title Component Title should set title when rendered."
         }
       ],
       "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport type WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type { SectionTitleProps } from \"~/components/shared/Layouts/SectionTitle/section-title.types\";\n\nimport SectionTitle from \"@/components/shared/Layouts/SectionTitle/SectionTitle.vue\";\n\ndescribe(\"Section Title Component\", () => {\n  const defaultProps: SectionTitleProps = {\n    icon: \"icon\",\n    title: \"title\",\n  };\n  let wrapper: ReturnType<typeof mount<typeof SectionTitle>>;\n\n  async function mountSectionTitleComponent(options: ComponentMountingOptions<typeof SectionTitle> = {}):\n  Promise<ReturnType<typeof mount<typeof SectionTitle>>> {\n    return mountSuspendedComponent(SectionTitle, {\n      props: defaultProps,\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountSectionTitleComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Icon\", () => {\n    it(\"should set icon source when rendered.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\"#section-title-icon\");\n\n      expect(icon.props(\"icon\")).toBe(\"icon\");\n    });\n\n    it(\"should set icon color to default when it is not provided in props.\", () => {\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\"#section-title-icon\");\n\n      expect(icon.attributes(\"iconcolor\")).toBe(\"#000000\");\n    });\n\n    it(\"should set icon color to provided color when it is provided in props.\", async() => {\n      wrapper = await mountSectionTitleComponent({\n        props: {\n          ...defaultProps,\n          iconColor: \"#FFFFFF\",\n        },\n      });\n      const icon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\"#section-title-icon\");\n\n      expect(icon.attributes(\"iconcolor\")).toBe(\"#FFFFFF\");\n    });\n  });\n\n  describe(\"Title\", () => {\n    it(\"should set title when rendered.\", () => {\n      const title = wrapper.find<HTMLSpanElement>(\".section-title-text\");\n\n      expect(title.text()).toBe(\"title\");\n    });\n  });\n});"
-    },
-    "tests/unit/specs/components/MySkills/MyTool/MyTool.nuxt.spec.ts": {
-      "tests": [
-        {
-          "id": "131",
-          "name": "My Tool Component should match snapshot when rendered."
-        },
-        {
-          "id": "132",
-          "name": "My Tool Component Tool Icon should pass icon classes when rendered."
-        },
-        {
-          "id": "133",
-          "name": "My Tool Component Tool Icon should pass tool color when rendered."
-        },
-        {
-          "id": "134",
-          "name": "My Tool Component Tool Icon should pass tool description when rendered."
-        }
-      ],
-      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type { MyToolProps } from \"~/components/MySkills/MyTool/my-tool.types\";\nimport MyTool from \"~/components/MySkills/MyTool/MyTool.vue\";\nimport type WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\n\ndescribe(\"My Tool Component\", () => {\n  const defaultProps: MyToolProps = {\n    tool: {\n      color: \"#3498db\",\n      description: \"MySkills.tools.vuejs\",\n      iconClasses: \"fab fa-vuejs\",\n    },\n  };\n  let wrapper: ReturnType<typeof mount<typeof MyTool>>;\n\n  async function mountMyToolComponent(options: ComponentMountingOptions<typeof MyTool> = {}): Promise<ReturnType<typeof mount<typeof MyTool>>> {\n    return mountSuspendedComponent(MyTool, {\n      props: defaultProps,\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountMyToolComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Tool Icon\", () => {\n    it(\"should pass icon classes when rendered.\", () => {\n      const toolIcon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".tool\");\n\n      expect(toolIcon.attributes(\"icon\")).toBe(defaultProps.tool.iconClasses);\n    });\n\n    it(\"should pass tool color when rendered.\", () => {\n      const toolIcon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".tool\");\n\n      expect(toolIcon.attributes(\"iconcolor\")).toBe(defaultProps.tool.color);\n    });\n\n    it(\"should pass tool description when rendered.\", () => {\n      const toolIcon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".tool\");\n\n      expect(toolIcon.attributes(\"title\")).toBe(defaultProps.tool.description);\n    });\n  });\n});"
-    },
-    "tests/unit/specs/components/AboutMe/AboutMyProfile/AboutMyProfile.nuxt.spec.ts": {
-      "tests": [
-        {
-          "id": "135",
-          "name": "AboutMyProfile Component should match snapshot when rendered."
-        }
-      ],
-      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\nimport AboutMyProfile from \"@/components/AboutMe/AboutMyProfile/AboutMyProfile.vue\";\n\ndescribe(\"AboutMyProfile Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof AboutMyProfile>>;\n\n  async function mountAboutMyProfileComponent(options: ComponentMountingOptions<typeof AboutMyProfile> = {}): Promise<ReturnType<typeof mount<typeof AboutMyProfile>>> {\n    return mountSuspendedComponent(AboutMyProfile, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountAboutMyProfileComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n});"
     },
     "tests/unit/specs/components/MyProfile/MyProfile.nuxt.spec.ts": {
       "tests": [
@@ -16314,103 +16309,108 @@
       ],
       "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { MyProfile } from \"#components\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\ndescribe(\"My Profile Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof MyProfile>>;\n\n  async function mountMyProfileComponent(options: ComponentMountingOptions<typeof MyProfile> = {}): Promise<ReturnType<typeof mount<typeof MyProfile>>> {\n    return mountSuspendedComponent(MyProfile, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountMyProfileComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n});"
     },
-    "tests/unit/specs/components/shared/Buttons/LinkedInButton.nuxt.spec.ts": {
+    "tests/unit/specs/components/MySkills/MyTool/MyTool.nuxt.spec.ts": {
       "tests": [
         {
           "id": "137",
+          "name": "My Tool Component should match snapshot when rendered."
+        },
+        {
+          "id": "138",
+          "name": "My Tool Component Tool Icon should pass icon classes when rendered."
+        },
+        {
+          "id": "139",
+          "name": "My Tool Component Tool Icon should pass tool color when rendered."
+        },
+        {
+          "id": "140",
+          "name": "My Tool Component Tool Icon should pass tool description when rendered."
+        }
+      ],
+      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type { MyToolProps } from \"~/components/MySkills/MyTool/my-tool.types\";\nimport MyTool from \"~/components/MySkills/MyTool/MyTool.vue\";\nimport type WrappedFontAwesomeIcon from \"~/components/shared/Icons/WrappedFontAwesomeIcon/WrappedFontAwesomeIcon.vue\";\n\ndescribe(\"My Tool Component\", () => {\n  const defaultProps: MyToolProps = {\n    tool: {\n      color: \"#3498db\",\n      description: \"MySkills.tools.vuejs\",\n      iconClasses: \"fab fa-vuejs\",\n    },\n  };\n  let wrapper: ReturnType<typeof mount<typeof MyTool>>;\n\n  async function mountMyToolComponent(options: ComponentMountingOptions<typeof MyTool> = {}): Promise<ReturnType<typeof mount<typeof MyTool>>> {\n    return mountSuspendedComponent(MyTool, {\n      props: defaultProps,\n      ...options,\n    });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountMyToolComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Tool Icon\", () => {\n    it(\"should pass icon classes when rendered.\", () => {\n      const toolIcon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".tool\");\n\n      expect(toolIcon.attributes(\"icon\")).toBe(defaultProps.tool.iconClasses);\n    });\n\n    it(\"should pass tool color when rendered.\", () => {\n      const toolIcon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".tool\");\n\n      expect(toolIcon.attributes(\"iconcolor\")).toBe(defaultProps.tool.color);\n    });\n\n    it(\"should pass tool description when rendered.\", () => {\n      const toolIcon = wrapper.findComponent<typeof WrappedFontAwesomeIcon>(\".tool\");\n\n      expect(toolIcon.attributes(\"title\")).toBe(defaultProps.tool.description);\n    });\n  });\n});"
+    },
+    "tests/unit/specs/components/shared/Buttons/LinkedInButton.nuxt.spec.ts": {
+      "tests": [
+        {
+          "id": "141",
           "name": "LinkedIn Button Component should match snapshot when rendered."
         }
       ],
       "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\nimport LinkedInButton from \"@/components/shared/Buttons/LinkedInButton.vue\";\n\ndescribe(\"LinkedIn Button Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof LinkedInButton>>;\n\n  async function mountLinkedInButtonComponent(options: ComponentMountingOptions<typeof LinkedInButton> = {}):\n  Promise<ReturnType<typeof mount<typeof LinkedInButton>>> {\n    return mountSuspendedComponent(LinkedInButton, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountLinkedInButtonComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n});"
     },
-    "tests/unit/specs/components/shared/Buttons/GitHubButton.nuxt.spec.ts": {
+    "tests/unit/specs/components/PageFooter/PageFooter.nuxt.spec.ts": {
       "tests": [
-        {
-          "id": "138",
-          "name": "GitHub Button Component should match snapshot when rendered."
-        }
-      ],
-      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\nimport GitHubButton from \"@/components/shared/Buttons/GitHubButton.vue\";\n\ndescribe(\"GitHub Button Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof GitHubButton>>;\n\n  async function mountGitHubButtonComponent(options: ComponentMountingOptions<typeof GitHubButton> = {}): Promise<ReturnType<typeof mount<typeof GitHubButton>>> {\n    return mountSuspendedComponent(GitHubButton, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountGitHubButtonComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n});"
-    },
-    "tests/unit/specs/components/MyPortfolio/MyPortfolio.nuxt.spec.ts": {
-      "tests": [
-        {
-          "id": "139",
-          "name": "My Portfolio Component should match snapshot when rendered."
-        },
-        {
-          "id": "140",
-          "name": "My Portfolio Component Projects should render 4 projects when rendered."
-        },
-        {
-          "id": "141",
-          "name": "My Portfolio Component Projects should render my portfolio project when rendered."
-        },
         {
           "id": "142",
-          "name": "My Portfolio Component Projects should render my Werewolves Assistant project when rendered."
+          "name": "Page Footer Component should match snapshot when rendered."
         },
         {
           "id": "143",
-          "name": "My Portfolio Component Projects should render book distribution project when rendered."
-        },
-        {
-          "id": "144",
-          "name": "My Portfolio Component Projects should render my GitHub profile project when rendered."
+          "name": "Page Footer Component Text should display Antoine ZANARDI and full year when rendered."
         }
       ],
-      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport type MyProject from \"~/components/MyPortfolio/MyProject/MyProject.vue\";\nimport { MyPortfolio } from \"#components\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\nimport type { Project } from \"~/models/project/project.types\";\n\ndescribe(\"My Portfolio Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof MyPortfolio>>;\n\n  async function mountMyPortfolioComponent(options: ComponentMountingOptions<typeof MyPortfolio> = {}): Promise<ReturnType<typeof mount<typeof MyPortfolio>>> {\n    return mountSuspendedComponent(MyPortfolio, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountMyPortfolioComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Projects\", () => {\n    it(\"should render 4 projects when rendered.\", () => {\n      const projects = wrapper.findAllComponents<typeof MyProject>(\".project\");\n\n      expect(projects).toHaveLength(4);\n    });\n\n    it(\"should render my portfolio project when rendered.\", () => {\n      const projects = wrapper.findAllComponents<typeof MyProject>(\".project\");\n      const expectedProject: Project = {\n        name: \"MyPortfolio.projects.portfolio.name\",\n        description: \"MyPortfolio.projects.portfolio.description\",\n        image: \"portfolio-thumbnail.webp\",\n        url: \"https://test.antoinezanardi.fr\",\n      };\n\n      expect(projects[0].props(\"project\")).toStrictEqual<Project>(expectedProject);\n    });\n\n    it(\"should render my Werewolves Assistant project when rendered.\", () => {\n      const projects = wrapper.findAllComponents<typeof MyProject>(\".project\");\n      const expectedProject: Project = {\n        name: \"MyPortfolio.projects.werewolvesAssistant.name\",\n        description: \"MyPortfolio.projects.werewolvesAssistant.description\",\n        image: \"werewolves-assistant-thumbnail.webp\",\n        url: \"https://werewolves-assistant.com\",\n      };\n\n      expect(projects[1].props(\"project\")).toStrictEqual<Project>(expectedProject);\n    });\n\n    it(\"should render book distribution project when rendered.\", () => {\n      const projects = wrapper.findAllComponents<typeof MyProject>(\".project\");\n      const expectedProject: Project = {\n        name: \"MyPortfolio.projects.distribution.name\",\n        description: \"MyPortfolio.projects.distribution.description\",\n        image: \"distribution-thumbnail.webp\",\n        url: \"https://www.airvey-editions.fr\",\n      };\n\n      expect(projects[2].props(\"project\")).toStrictEqual<Project>(expectedProject);\n    });\n\n    it(\"should render my GitHub profile project when rendered.\", () => {\n      const projects = wrapper.findAllComponents<typeof MyProject>(\".project\");\n      const expectedProject: Project = {\n        name: \"MyPortfolio.projects.gitHub.name\",\n        description: \"MyPortfolio.projects.gitHub.description\",\n        image: \"github.webp\",\n        url: \"https://github.com/antoinezanardi/\",\n      };\n\n      expect(projects[3].props(\"project\")).toStrictEqual<Project>(expectedProject);\n    });\n  });\n});"
+      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { PageFooter } from \"#components\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\ndescribe(\"Page Footer Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof PageFooter>>;\n\n  async function mountPageFooterComponent(options: ComponentMountingOptions<typeof PageFooter> = {}): Promise<ReturnType<typeof mount<typeof PageFooter>>> {\n    return mountSuspendedComponent(PageFooter, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountPageFooterComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n\n  describe(\"Text\", () => {\n    it(\"should display Antoine ZANARDI and full year when rendered.\", () => {\n      const title = wrapper.find<HTMLDivElement>(\".title\");\n\n      expect(title.text()).toBe(\"Antoine ZANARDI - 2022\");\n    });\n  });\n});"
     },
     "tests/unit/specs/components/AboutMe/AboutMe.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "145",
+          "id": "144",
           "name": "About Me Component should match snapshot when rendered."
         }
       ],
       "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { AboutMe } from \"#components\";\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\ndescribe(\"About Me Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof AboutMe>>;\n\n  async function mountAboutMeComponent(options: ComponentMountingOptions<typeof AboutMe> = {}): Promise<ReturnType<typeof mount<typeof AboutMe>>> {\n    return mountSuspendedComponent(AboutMe, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountAboutMeComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n});"
     },
-    "tests/unit/specs/composables/useAppSchemaOrg.spec.ts": {
+    "tests/unit/specs/components/shared/Buttons/GitHubButton.nuxt.spec.ts": {
       "tests": [
         {
-          "id": "146",
-          "name": "Use App Schema Org Composable getAppSchemaOrgWebSite should get app schema org website when called."
-        },
-        {
-          "id": "147",
-          "name": "Use App Schema Org Composable getAppSchemaOrgPerson should get app schema org person when called."
-        },
-        {
-          "id": "148",
-          "name": "Use App Schema Org Composable setupAppSchemaOrg should setup app schema org when called."
+          "id": "145",
+          "name": "GitHub Button Component should match snapshot when rendered."
         }
       ],
-      "source": "import type { definePerson, defineWebSite } from \"nuxt-schema-org/schema\";\n\nimport { TEST_NUXT_RUNTIME_CONFIG, TEST_NUXT_SITE_CONFIG } from \"@tests/unit/utils/constants/nuxt-test.constants\";\nimport { useAppSchemaOrg } from \"~/composables/useAppSchemaOrg\";\nimport { ANTOINE_ZANARDI_BIRTH_DATE, ANTOINE_ZANARDI_FULL_NAME, ANTOINE_ZANARDI_GITHUB_AVATAR_URL, ANTOINE_ZANARDI_GITHUB_URL, ANTOINE_ZANARDI_LINKEDIN_URL } from \"~/shared/constants/antoine-zanardi.constants\";\n\nconst EXPECTED_WEBSITE_SCHEMA = Object.freeze({\n  \"@type\": \"WebSite\",\n  \"_resolver\": \"webSite\",\n  \"name\": TEST_NUXT_SITE_CONFIG.name,\n  \"description\": \"App.meta.description\",\n  \"inLanguage\": \"fr\",\n});\n\nconst EXPECTED_PERSON_SCHEMA = Object.freeze({\n  \"@type\": \"Person\",\n  \"_resolver\": \"person\",\n  \"address\": {\n    \"@type\": \"PostalAddress\",\n    \"addressCountry\": \"Countries.france\",\n    \"addressLocality\": \"1234 Elm Street\",\n  },\n  \"alumniOf\": {\n    \"@type\": \"CollegeOrUniversity\",\n    \"name\": \"EPITECH\",\n    \"url\": \"https://www.epitech.eu/\",\n  },\n  \"award\": [\n    \"Degrees.highSchoolDiploma\",\n    \"Degrees.ITCertification\",\n    \"Degrees.ITMasterDegree\",\n    \"Degrees.CKAD\",\n    \"Degrees.gcpACE\",\n  ],\n  \"birthDate\": ANTOINE_ZANARDI_BIRTH_DATE,\n  \"description\": \"App.meta.smallDescription\",\n  \"email\": TEST_NUXT_RUNTIME_CONFIG.public.email,\n  \"gender\": \"Male\",\n  \"hasOccupation\": {\n    \"@type\": \"Occupation\",\n    \"name\": \"MyProfile.itConsultant\",\n    \"description\": \"MyProfile.fullStackWebExpert\",\n  },\n  \"image\": ANTOINE_ZANARDI_GITHUB_AVATAR_URL,\n  \"jobTitle\": \"MyProfile.itConsultant\",\n  \"knowsAbout\": [\n    \"MySkills.html\",\n    \"MySkills.css\",\n    \"MySkills.javascript\",\n    \"MySkills.typescript\",\n    \"MySkills.vue\",\n    \"MySkills.nuxt\",\n    \"MySkills.mysql\",\n    \"MySkills.mongodb\",\n    \"MySkills.rust\",\n  ],\n  \"knowsLanguage\": [\n    {\n      \"@type\": \"Language\",\n      \"name\": \"Languages.french\",\n      \"alternateName\": \"fr\",\n    },\n    {\n      \"@type\": \"Language\",\n      \"name\": \"Languages.english\",\n      \"alternateName\": \"en\",\n    },\n  ],\n  \"name\": ANTOINE_ZANARDI_FULL_NAME,\n  \"nationality\": {\n    \"@type\": \"Country\",\n    \"name\": \"Countries.france\",\n  },\n  \"sameAs\": [\n    ANTOINE_ZANARDI_LINKEDIN_URL,\n    ANTOINE_ZANARDI_GITHUB_URL,\n  ],\n  \"subjectOf\": {\n    \"@type\": \"CreativeWork\",\n    \"name\": \"MyPortfolio.projects.werewolvesAssistant.name\",\n    \"description\": \"MyPortfolio.projects.werewolvesAssistant.description\",\n    \"url\": \"https://werewolves-assistant.com/\",\n  },\n  \"telephone\": TEST_NUXT_RUNTIME_CONFIG.public.phoneNumber,\n  \"url\": TEST_NUXT_SITE_CONFIG.url,\n  \"worksFor\": {\n    \"@type\": \"Organization\",\n    \"name\": \"Daveo\",\n    \"url\": \"https://www.daveo.fr/\",\n  },\n});\n\ndescribe(\"Use App Schema Org Composable\", () => {\n  describe(\"getAppSchemaOrgWebSite\", () => {\n    it(\"should get app schema org website when called.\", () => {\n      const { getAppSchemaOrgWebSite } = useAppSchemaOrg();\n      const result = getAppSchemaOrgWebSite();\n\n      expect(result).toStrictEqual<ReturnType<typeof defineWebSite>>(EXPECTED_WEBSITE_SCHEMA);\n    });\n  });\n\n  describe(\"getAppSchemaOrgPerson\", () => {\n    it(\"should get app schema org person when called.\", () => {\n      const { getAppSchemaOrgPerson } = useAppSchemaOrg();\n      const result = getAppSchemaOrgPerson();\n\n      expect(result).toStrictEqual<ReturnType<typeof definePerson>>(EXPECTED_PERSON_SCHEMA);\n    });\n  });\n\n  describe(\"setupAppSchemaOrg\", () => {\n    it(\"should setup app schema org when called.\", () => {\n      const { setupAppSchemaOrg } = useAppSchemaOrg();\n      const expectedSchemaOrgParameters = [\n        EXPECTED_WEBSITE_SCHEMA,\n        EXPECTED_PERSON_SCHEMA,\n      ];\n      setupAppSchemaOrg();\n\n      expect(useSchemaOrg).toHaveBeenCalledExactlyOnceWith(expectedSchemaOrgParameters);\n    });\n  });\n});"
+      "source": "import type { mount } from \"@vue/test-utils\";\nimport type { ComponentMountingOptions } from \"@vue/test-utils/dist/mount\";\n\nimport { mountSuspendedComponent } from \"@tests/unit/utils/helpers/mount.helpers\";\n\nimport GitHubButton from \"@/components/shared/Buttons/GitHubButton.vue\";\n\ndescribe(\"GitHub Button Component\", () => {\n  let wrapper: ReturnType<typeof mount<typeof GitHubButton>>;\n\n  async function mountGitHubButtonComponent(options: ComponentMountingOptions<typeof GitHubButton> = {}): Promise<ReturnType<typeof mount<typeof GitHubButton>>> {\n    return mountSuspendedComponent(GitHubButton, { ...options });\n  }\n\n  beforeEach(async() => {\n    wrapper = await mountGitHubButtonComponent();\n  });\n\n  it(\"should match snapshot when rendered.\", () => {\n    expect(wrapper).toBeTruthy();\n    expect(wrapper.html()).toMatchSnapshot();\n  });\n});"
     },
     "tests/unit/specs/models/period/period.class.spec.ts": {
       "tests": [
         {
-          "id": "149",
+          "id": "146",
           "name": "Period Class constructor should set month and year properties when there are only 2 months."
         },
         {
-          "id": "150",
+          "id": "147",
           "name": "Period Class constructor should set month and year properties when there are 13 months."
         },
         {
-          "id": "151",
+          "id": "148",
           "name": "Period Class constructor should set month and year properties when there are 25 months."
         },
         {
-          "id": "152",
+          "id": "149",
           "name": "Period Class constructor should set only year property when there are 12 months."
         },
         {
-          "id": "153",
+          "id": "150",
           "name": "Period Class constructor should set only month property when there are 4 months."
         }
       ],
       "source": "import { Period } from \"~/models/period/period.class\";\n\ndescribe(\"Period Class\", () => {\n  describe(\"constructor\", () => {\n    it(\"should set month and year properties when there are only 2 months.\", () => {\n      const period = new Period(new Date(\"2022-01-01\"), new Date(\"2022-02-01\"));\n\n      expect(period.month).toBe(2);\n      expect(period.year).toBe(0);\n    });\n\n    it(\"should set month and year properties when there are 13 months.\", () => {\n      const period = new Period(new Date(\"2022-01-01\"), new Date(\"2023-02-01\"));\n\n      expect(period.month).toBe(2);\n      expect(period.year).toBe(1);\n    });\n\n    it(\"should set month and year properties when there are 25 months.\", () => {\n      const period = new Period(new Date(\"2022-01-01\"), new Date(\"2024-02-01\"));\n\n      expect(period.month).toBe(2);\n      expect(period.year).toBe(2);\n    });\n\n    it(\"should set only year property when there are 12 months.\", () => {\n      const period = new Period(new Date(\"2022-01-01\"), new Date(\"2022-12-31\"));\n\n      expect(period.month).toBe(0);\n      expect(period.year).toBe(1);\n    });\n\n    it(\"should set only month property when there are 4 months.\", () => {\n      const period = new Period(new Date(\"2022-12-24\"), new Date(\"2023-03-24\"));\n\n      expect(period.month).toBe(4);\n      expect(period.year).toBe(0);\n    });\n  });\n});"
+    },
+    "tests/unit/specs/composables/useAppSchemaOrg.spec.ts": {
+      "tests": [
+        {
+          "id": "151",
+          "name": "Use App Schema Org Composable getAppSchemaOrgWebSite should get app schema org website when called."
+        },
+        {
+          "id": "152",
+          "name": "Use App Schema Org Composable getAppSchemaOrgPerson should get app schema org person when called."
+        },
+        {
+          "id": "153",
+          "name": "Use App Schema Org Composable setupAppSchemaOrg should setup app schema org when called."
+        }
+      ],
+      "source": "import type { definePerson, defineWebSite } from \"nuxt-schema-org/schema\";\n\nimport { TEST_NUXT_RUNTIME_CONFIG, TEST_NUXT_SITE_CONFIG } from \"@tests/unit/utils/constants/nuxt-test.constants\";\nimport { useAppSchemaOrg } from \"~/composables/useAppSchemaOrg\";\nimport { ANTOINE_ZANARDI_BIRTH_DATE, ANTOINE_ZANARDI_FULL_NAME, ANTOINE_ZANARDI_GITHUB_AVATAR_URL, ANTOINE_ZANARDI_GITHUB_URL, ANTOINE_ZANARDI_LINKEDIN_URL } from \"~/shared/constants/antoine-zanardi.constants\";\n\nconst EXPECTED_WEBSITE_SCHEMA = Object.freeze({\n  \"@type\": \"WebSite\",\n  \"_resolver\": \"webSite\",\n  \"name\": TEST_NUXT_SITE_CONFIG.name,\n  \"description\": \"App.meta.description\",\n  \"inLanguage\": \"fr\",\n});\n\nconst EXPECTED_PERSON_SCHEMA = Object.freeze({\n  \"@type\": \"Person\",\n  \"_resolver\": \"person\",\n  \"address\": {\n    \"@type\": \"PostalAddress\",\n    \"addressCountry\": \"Countries.france\",\n    \"addressLocality\": \"1234 Elm Street\",\n  },\n  \"alumniOf\": {\n    \"@type\": \"CollegeOrUniversity\",\n    \"name\": \"EPITECH\",\n    \"url\": \"https://www.epitech.eu/\",\n  },\n  \"award\": [\n    \"Degrees.highSchoolDiploma\",\n    \"Degrees.ITCertification\",\n    \"Degrees.ITMasterDegree\",\n    \"Degrees.CKAD\",\n    \"Degrees.gcpACE\",\n  ],\n  \"birthDate\": ANTOINE_ZANARDI_BIRTH_DATE,\n  \"description\": \"App.meta.smallDescription\",\n  \"email\": TEST_NUXT_RUNTIME_CONFIG.public.email,\n  \"gender\": \"Male\",\n  \"hasOccupation\": {\n    \"@type\": \"Occupation\",\n    \"name\": \"MyProfile.itConsultant\",\n    \"description\": \"MyProfile.fullStackWebExpert\",\n  },\n  \"image\": ANTOINE_ZANARDI_GITHUB_AVATAR_URL,\n  \"jobTitle\": \"MyProfile.itConsultant\",\n  \"knowsAbout\": [\n    \"MySkills.html\",\n    \"MySkills.css\",\n    \"MySkills.javascript\",\n    \"MySkills.typescript\",\n    \"MySkills.vue\",\n    \"MySkills.nuxt\",\n    \"MySkills.mysql\",\n    \"MySkills.mongodb\",\n    \"MySkills.rust\",\n  ],\n  \"knowsLanguage\": [\n    {\n      \"@type\": \"Language\",\n      \"name\": \"Languages.french\",\n      \"alternateName\": \"fr\",\n    },\n    {\n      \"@type\": \"Language\",\n      \"name\": \"Languages.english\",\n      \"alternateName\": \"en\",\n    },\n  ],\n  \"name\": ANTOINE_ZANARDI_FULL_NAME,\n  \"nationality\": {\n    \"@type\": \"Country\",\n    \"name\": \"Countries.france\",\n  },\n  \"sameAs\": [\n    ANTOINE_ZANARDI_LINKEDIN_URL,\n    ANTOINE_ZANARDI_GITHUB_URL,\n  ],\n  \"subjectOf\": {\n    \"@type\": \"CreativeWork\",\n    \"name\": \"MyPortfolio.projects.werewolvesAssistant.name\",\n    \"description\": \"MyPortfolio.projects.werewolvesAssistant.description\",\n    \"url\": \"https://werewolves-assistant.com/\",\n  },\n  \"telephone\": TEST_NUXT_RUNTIME_CONFIG.public.phoneNumber,\n  \"url\": TEST_NUXT_SITE_CONFIG.url,\n  \"worksFor\": {\n    \"@type\": \"Organization\",\n    \"name\": \"Daveo\",\n    \"url\": \"https://www.daveo.fr/\",\n  },\n});\n\ndescribe(\"Use App Schema Org Composable\", () => {\n  describe(\"getAppSchemaOrgWebSite\", () => {\n    it(\"should get app schema org website when called.\", () => {\n      const { getAppSchemaOrgWebSite } = useAppSchemaOrg();\n      const result = getAppSchemaOrgWebSite();\n\n      expect(result).toStrictEqual<ReturnType<typeof defineWebSite>>(EXPECTED_WEBSITE_SCHEMA);\n    });\n  });\n\n  describe(\"getAppSchemaOrgPerson\", () => {\n    it(\"should get app schema org person when called.\", () => {\n      const { getAppSchemaOrgPerson } = useAppSchemaOrg();\n      const result = getAppSchemaOrgPerson();\n\n      expect(result).toStrictEqual<ReturnType<typeof definePerson>>(EXPECTED_PERSON_SCHEMA);\n    });\n  });\n\n  describe(\"setupAppSchemaOrg\", () => {\n    it(\"should setup app schema org when called.\", () => {\n      const { setupAppSchemaOrg } = useAppSchemaOrg();\n      const expectedSchemaOrgParameters = [\n        EXPECTED_WEBSITE_SCHEMA,\n        EXPECTED_PERSON_SCHEMA,\n      ];\n      setupAppSchemaOrg();\n\n      expect(useSchemaOrg).toHaveBeenCalledExactlyOnceWith(expectedSchemaOrgParameters);\n    });\n  });\n});"
     },
     "tests/unit/specs/composables/useDates.spec.ts": {
       "tests": [

--- a/tests/unit/specs/components/AboutMe/AboutMyPersonalInfo/__snapshots__/AboutMyPersonalInfo.nuxt.spec.ts.snap
+++ b/tests/unit/specs/components/AboutMe/AboutMyPersonalInfo/__snapshots__/AboutMyPersonalInfo.nuxt.spec.ts.snap
@@ -15,6 +15,12 @@ exports[`AboutMyPersonalInfo Component > should match snapshot when rendered. 1`
       <div data-v-b7a042bc="" class="col-sm-4"><b data-v-b7a042bc="" class="text-uppercase">Age :</b></div>
       <div data-v-b7a042bc="" id="age" class="col-sm-8">25 ans</div>
     </div>
+    <div data-v-b7a042bc="" class="align-items-center mt-3 row">
+      <div data-v-b7a042bc="" class="col-sm-4"><b data-v-b7a042bc="" class="text-uppercase">Personnalité :</b></div>
+      <div data-v-b7a042bc="" id="personality" class="align-items-center col-sm-8 d-flex gap-1">
+        <nuxt-img-stub data-v-b7a042bc="" height="24" loading="lazy" src="/svg/entj-personality.svg" width="24" preload="false" crossorigin="false" placeholder="false" custom="false" aria-hidden="true"></nuxt-img-stub><a data-v-b7a042bc="" href="https://www.16personalities.com/fr/la-personnalite-entj" rel="noopener noreferrer" target="_blank">ENTJ - Commandant <wrapped-font-awesome-icon-stub data-v-b7a042bc="" icon="fa-arrow-up-right-from-square" iconcolor="#12671D" classes=""></wrapped-font-awesome-icon-stub></a>
+      </div>
+    </div>
     <div data-v-b7a042bc="" class="mt-3 row">
       <div data-v-b7a042bc="" class="col-sm-4"><b data-v-b7a042bc="" class="text-uppercase">email :</b></div>
       <div data-v-b7a042bc="" class="col-sm-8"><b data-v-b7a042bc=""><a data-v-b7a042bc="" aria-label="Envoyez-moi un email à john@doe.com" href="mailto:john@doe.com">john@doe.com</a></b></div>

--- a/tests/unit/specs/components/shared/Period/__snapshots__/PeriodTimeline.nuxt.spec.ts.snap
+++ b/tests/unit/specs/components/shared/Period/__snapshots__/PeriodTimeline.nuxt.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`Period Timeline Component > Periods > Period > should match snapshot wh
   <div data-v-a56b5921="" class="d-flex flex-column flex-grow-1">
     <div data-v-a56b5921="" id="period-dates" aria-label="PeriodTimeline.periodDatesAriaLabel, {&quot;startedAt&quot;:&quot;janvier 2022&quot;,&quot;finishedAt&quot;:&quot;mars 2024&quot;}" class="align-items-center d-flex flex-column flex-grow-1 justify-content-center" role="region">
       <div data-v-a56b5921="" id="finished-at-date" class="period-date">mars 2024</div>
-      <wrapped-font-awesome-icon-stub data-v-a56b5921="" icon="fa-arrow-up" iconcolor="#00000" size="2x" classes="my-3" id="arrow-up-icon"></wrapped-font-awesome-icon-stub>
+      <wrapped-font-awesome-icon-stub data-v-a56b5921="" icon="fa-arrow-up" iconcolor="#FFFFFF" size="2x" classes="my-3" id="arrow-up-icon"></wrapped-font-awesome-icon-stub>
       <div data-v-a56b5921="" id="started-at-date" class="period-date">janvier 2022</div>
     </div>
     <div data-v-a56b5921="" id="period-label" class="align-items-center d-flex flex-column">
@@ -27,7 +27,7 @@ exports[`Period Timeline Component > Periods > Started at date > should match sn
   <div data-v-a56b5921="" class="d-flex flex-column flex-grow-1">
     <div data-v-a56b5921="" id="period-dates" aria-label="PeriodTimeline.periodDatesAriaLabel, {&quot;startedAt&quot;:&quot;janvier 2022&quot;,&quot;finishedAt&quot;:&quot;shared.today&quot;}" class="align-items-center d-flex flex-column flex-grow-1 justify-content-center" role="region">
       <div data-v-a56b5921="" id="finished-at-date" class="period-date">shared.today</div>
-      <wrapped-font-awesome-icon-stub data-v-a56b5921="" icon="fa-arrow-up" iconcolor="#00000" size="2x" classes="my-3" id="arrow-up-icon"></wrapped-font-awesome-icon-stub>
+      <wrapped-font-awesome-icon-stub data-v-a56b5921="" icon="fa-arrow-up" iconcolor="#FFFFFF" size="2x" classes="my-3" id="arrow-up-icon"></wrapped-font-awesome-icon-stub>
       <div data-v-a56b5921="" id="started-at-date" class="period-date">janvier 2022</div>
     </div>
     <div data-v-a56b5921="" id="period-label" class="align-items-center d-flex flex-column">


### PR DESCRIPTION
This pull request introduces a new "Personality" section to the About Me page, displaying the ENTJ personality type with a link and icon. Additionally, it centralizes color constants for consistent styling and updates components to use these constants. Tests and translations are updated to reflect these changes.

**About Me section improvements:**
* Added a new "Personality" field to the `AboutMyPersonalInfo` component, displaying the ENTJ type with an icon, localized label, and external link. [[1]](diffhunk://#diff-b7a042bc5cfd39ca6e4ec9de60c298e0291c5536aa745d4d498e6f55a7942045R51-R86) [[2]](diffhunk://#diff-4bba4b9201250a7f3f7366e783b3a9fcbda095abc23020bc700947054f418745R1-R5) [[3]](diffhunk://#diff-b7a042bc5cfd39ca6e4ec9de60c298e0291c5536aa745d4d498e6f55a7942045R225-R228) [[4]](diffhunk://#diff-66d8707b2fcb99f48028d08d06a5f2275a3521867a546731b4e89c10e6356f7fR31-R32)
* Updated acceptance and unit tests to verify the presence and rendering of the new "Personality" field. [[1]](diffhunk://#diff-a3dfd30005a9485b9f9bc407b78e0af14952235aa5fa75002fb3f3882c03c0b3R23-R24) [[2]](diffhunk://#diff-7302fdaa61a60d3577be093f83d721795b6afe3a33b0a6be7aa25624775174e7R18-R23)

**Styling improvements:**
* Introduced `PRIMARY_COLOR`, `BLACK_COLOR`, and `WHITE_COLOR` constants in `style.constants.ts` for consistent color usage across the app.
* Updated components (`MyProject.vue`, `PeriodTimeline.vue`) to use the new color constants instead of hardcoded color values. [[1]](diffhunk://#diff-09377792b762a462eb8c6e5a4905bc6f60f9bbafe13cc0c761706371d49181afL36-R36) [[2]](diffhunk://#diff-09377792b762a462eb8c6e5a4905bc6f60f9bbafe13cc0c761706371d49181afR49) [[3]](diffhunk://#diff-a56b59218cd6ba08cfa50f0c097bc9e7540101cc7c6be2ae7868f4639e137a02L41-R41) [[4]](diffhunk://#diff-a56b59218cd6ba08cfa50f0c097bc9e7540101cc7c6be2ae7868f4639e137a02R76)
* Updated related unit test snapshots to reflect the new color usage in icons. [[1]](diffhunk://#diff-30c2f4661a2fdff428755956bda7bf640bc9af18b4f3eb40a847c7506f04fb89L11-R11) [[2]](diffhunk://#diff-30c2f4661a2fdff428755956bda7bf640bc9af18b4f3eb40a847c7506f04fb89L30-R30)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a “Personality” row in About Me showing ENTJ with an external link and icon styled in the primary color.
  * Added French translations for the new labels (“Personnalité”, “ENTJ - Commandant”).
* Refactor
  * Standardized icon colors across components using a shared color palette (no visual changes).
* Tests
  * Expanded acceptance tests to validate the new “Personality” row and translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->