### PR TITLE
feat(badges): add action to generate coverage and scenarii badges

### DIFF
--- a/.github/actions/acceptance-tests/action.yml
+++ b/.github/actions/acceptance-tests/action.yml
@@ -8,6 +8,11 @@ inputs:
     required: true
     default: tests/acceptance/reports
 
+outputs:
+  acceptance-tests-count:
+    description: Number of acceptance tests (scenarios) executed.
+    value: ${{ steps.cucumber-results.outputs.acceptance-tests-count }}
+
 runs:
   using: composite
   steps:
@@ -23,6 +28,14 @@ runs:
       continue-on-error: true
       shell: bash
       run: pnpm run test:cucumber
+
+    - name: Set Cucumber Results As Outputs 📝
+      id: cucumber-results
+      continue-on-error: true
+      shell: bash
+      run: | 
+        ${{ github.workspace }}/scripts/transform-cucumber-report-as-env-variables.sh >> "$GITHUB_ENV"
+        echo "acceptance-tests-count=${{ env.CUCUMBER_SCENARIOS_COUNT }}" >> "$GITHUB_OUTPUT"
 
     - name: Save acceptance tests reports as artifact 💎
       uses: actions/upload-artifact@v4

--- a/.github/actions/acceptance-tests/action.yml
+++ b/.github/actions/acceptance-tests/action.yml
@@ -27,15 +27,15 @@ runs:
       id: acceptance-tests
       continue-on-error: true
       shell: bash
-      run: pnpm run test:cucumber
+      run: | 
+        pnpm run test:cucumber
+        ${{ github.workspace }}/scripts/transform-cucumber-report-as-env-variables.sh >> "$GITHUB_ENV"
 
     - name: Set Cucumber Results As Outputs 📝
       id: cucumber-results
       continue-on-error: true
       shell: bash
-      run: |
-        source ${{ github.workspace }}/scripts/transform-cucumber-report-as-env-variables.sh
-        echo "acceptance-tests-count=${CUCUMBER_SCENARIOS_COUNT}" >> "$GITHUB_OUTPUT"
+      run: echo "acceptance-tests-count=${{ env.CUCUMBER_SCENARIOS_COUNT }}" >> "$GITHUB_OUTPUT"
 
     - name: Save acceptance tests reports as artifact 💎
       uses: actions/upload-artifact@v4

--- a/.github/actions/acceptance-tests/action.yml
+++ b/.github/actions/acceptance-tests/action.yml
@@ -33,9 +33,9 @@ runs:
       id: cucumber-results
       continue-on-error: true
       shell: bash
-      run: | 
-        ${{ github.workspace }}/scripts/transform-cucumber-report-as-env-variables.sh >> "$GITHUB_ENV"
-        echo "acceptance-tests-count=${{ env.CUCUMBER_SCENARIOS_COUNT }}" >> "$GITHUB_OUTPUT"
+      run: |
+        source ${{ github.workspace }}/scripts/transform-cucumber-report-as-env-variables.sh
+        echo "acceptance-tests-count=${CUCUMBER_SCENARIOS_COUNT}" >> "$GITHUB_OUTPUT"
 
     - name: Save acceptance tests reports as artifact 💎
       uses: actions/upload-artifact@v4

--- a/.github/actions/badges/action.yml
+++ b/.github/actions/badges/action.yml
@@ -1,0 +1,109 @@
+name: Generate Badges 💠
+description: Generate coverage and scenarios badges based on tests results.
+author: Antoine ZANARDI
+
+inputs:
+  byob-token:
+    description: GitHub token to create/update badges
+    required: true
+  unit-tests-count:
+    description: Number of unit tests executed
+    required: true
+  unit-tests-covered-statements:
+    description: Number of statements covered by unit tests
+    required: true
+  unit-tests-covered-branches:
+    description: Number of branches covered by unit tests
+    required: true
+  unit-tests-covered-functions:
+    description: Number of functions covered by unit tests
+    required: true
+  unit-tests-covered-lines:
+    description: Number of lines covered by unit tests
+    required: true
+  unit-tests-statements-percent:
+    description: Percentage of statements covered by unit tests
+    required: true
+  unit-tests-branches-percent:
+    description: Percentage of branches covered by unit tests
+    required: true
+  unit-tests-functions-percent:
+    description: Percentage of functions covered by unit tests
+    required: true
+  unit-tests-lines-percent:
+    description: Percentage of lines covered by unit tests
+    required: true
+  acceptance-tests-count:
+    description: Number of acceptance tests (scenarios) executed
+    required: true
+  unit-tests-badge-color:
+    description: Color of the unit tests badges (hex without #)
+    required: false
+    default: "109B08"
+  acceptance-tests-badge-color:
+    description: Color of the acceptance tests badges (hex without #)
+    required: false
+    default: "169652"
+
+runs:
+  using: composite
+  steps:
+    - name: Unit Tests – Count Badge 💠
+      uses: RubbaBoy/BYOB@v1.3.0
+      with:
+        name: unit-tests-count
+        label: Unit Tests
+        status: ${{ inputs.unit-tests-count }}
+        icon: https://cdn.simpleicons.org/vitest/white
+        color: ${{ inputs.unit-tests-badge-color }}
+        github_token: ${{ inputs.byob-token }}
+
+    - name: Unit Tests – Covered Statements Badge 💠
+      uses: RubbaBoy/BYOB@v1.3.0
+      with:
+        name: unit-tests-covered-statements
+        label: Statements
+        status: ${{ inputs.unit-tests-covered-statements }} covered (${{ inputs.unit-tests-statements-percent }})
+        icon: https://cdn.simpleicons.org/codecov/white
+        color: ${{ inputs.unit-tests-badge-color }}
+        github_token: ${{ inputs.byob-token }}
+
+    - name: Unit Tests – Covered Branches Badge 💠
+      uses: RubbaBoy/BYOB@v1.3.0
+      with:
+        name: unit-tests-covered-branches
+        label: Branches
+        status: ${{ inputs.unit-tests-covered-branches }} covered (${{ inputs.unit-tests-branches-percent }})
+        icon: https://cdn.simpleicons.org/codecov/white
+        color: ${{ inputs.unit-tests-badge-color }}
+        github_token: ${{ inputs.byob-token }}
+
+    - name: Unit Tests – Covered Functions Badge 💠
+      uses: RubbaBoy/BYOB@v1.3.0
+      with:
+        name: unit-tests-covered-functions
+        label: Functions
+        status: ${{ inputs.unit-tests-covered-functions }} covered (${{ inputs.unit-tests-functions-percent }})
+        icon: https://cdn.simpleicons.org/codecov/white
+        color: ${{ inputs.unit-tests-badge-color }}
+        github_token: ${{ inputs.byob-token }}
+
+    - name: Unit Tests – Covered Lines Badge 💠
+      uses: RubbaBoy/BYOB@v1.3.0
+      with:
+        name: unit-tests-covered-lines
+        label: Lines
+        status: ${{ inputs.unit-tests-covered-lines }} covered (${{ inputs.unit-tests-lines-percent }})
+        icon: https://cdn.simpleicons.org/codecov/white
+        color: ${{ inputs.unit-tests-badge-color }}
+        github_token: ${{ inputs.byob-token }}
+
+    - name: Acceptance Tests – Scenarios Badge 💠
+      uses: RubbaBoy/BYOB@v1.3.0
+      with:
+        name: scenarios
+        label: Scenarios
+        status: ${{ inputs.acceptance-tests-count }}
+        icon: https://cdn.simpleicons.org/cucumber/white
+        color: ${{ inputs.acceptance-tests-badge-color }}
+        github_token: ${{ inputs.byob-token }}

--- a/.github/actions/badges/action.yml
+++ b/.github/actions/badges/action.yml
@@ -1,5 +1,5 @@
 name: Generate Badges 💠
-description: Generate coverage and scenarios badges based on tests results.
+description: Generate coverage and scenarios badges based on test results.
 author: Antoine ZANARDI
 
 inputs:

--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -15,31 +15,31 @@ inputs:
 outputs:
   vitest-tests-count:
     description: Number of Vitest tests executed
-    value: ${{ steps.vitest-results.outputs.VITEST_TESTS_COUNT }}
+    value: ${{ steps.vitest-results.outputs.vitest-tests-count }}
   vitest-statements-count:
     description: Number of statements covered by Vitest
-    value: ${{ steps.vitest-results.outputs.VITEST_STATEMENTS_COUNT }}
+    value: ${{ steps.vitest-results.outputs.vitest-statements-count }}
   vitest-branches-count:
     description: Number of branches covered by Vitest
-    value: ${{ steps.vitest-results.outputs.VITEST_BRANCHES_COUNT }}
+    value: ${{ steps.vitest-results.outputs.vitest-branches-count }}
   vitest-functions-count:
     description: Number of functions covered by Vitest
-    value: ${{ steps.vitest-results.outputs.VITEST_FUNCTIONS_COUNT }}
+    value: ${{ steps.vitest-results.outputs.vitest-functions-count }}
   vitest-lines-count:
     description: Number of lines covered by Vitest
-    value: ${{ steps.vitest-results.outputs.VITEST_LINES_COUNT }}
+    value: ${{ steps.vitest-results.outputs.vitest-lines-count }}
   vitest-statements-percent:
     description: Percentage of statements covered by Vitest
-    value: ${{ steps.vitest-results.outputs.VITEST_STATEMENTS_PERCENT }}
+    value: ${{ steps.vitest-results.outputs.vitest-statements-percent }}
   vitest-branches-percent:
     description: Percentage of branches covered by Vitest
-    value: ${{ steps.vitest-results.outputs.VITEST_BRANCHES_PERCENT }}
+    value: ${{ steps.vitest-results.outputs.vitest-branches-percent }}
   vitest-functions-percent:
     description: Percentage of functions covered by Vitest
-    value: ${{ steps.vitest-results.outputs.VITEST_FUNCTIONS_PERCENT }}
+    value: ${{ steps.vitest-results.outputs.vitest-functions-percent }}
   vitest-lines-percent:
     description: Percentage of lines covered by Vitest
-    value: ${{ steps.vitest-results.outputs.VITEST_LINES_PERCENT }}
+    value: ${{ steps.vitest-results.outputs.vitest-lines-percent }}
 
 runs:
   using: composite
@@ -65,15 +65,15 @@ runs:
       shell: bash
       run: |
         {
-          echo "VITEST_TESTS_COUNT=${{ env.VITEST_TESTS_COUNT }}"
-          echo "VITEST_STATEMENTS_COUNT=${{ env.VITEST_STATEMENTS_COUNT }}"
-          echo "VITEST_BRANCHES_COUNT=${{ env.VITEST_BRANCHES_COUNT }}"
-          echo "VITEST_FUNCTIONS_COUNT=${{ env.VITEST_FUNCTIONS_COUNT }}"
-          echo "VITEST_LINES_COUNT=${{ env.VITEST_LINES_COUNT }}"
-          echo "VITEST_STATEMENTS_PERCENT=${{ env.VITEST_STATEMENTS_PERCENT }}"
-          echo "VITEST_BRANCHES_PERCENT=${{ env.VITEST_BRANCHES_PERCENT }}"
-          echo "VITEST_FUNCTIONS_PERCENT=${{ env.VITEST_FUNCTIONS_PERCENT }}"
-          echo "VITEST_LINES_PERCENT=${{ env.VITEST_LINES_PERCENT }}"
+          echo "vitest-tests-count=${{ env.VITEST_TESTS_COUNT }}"
+          echo "vitest-statements-count=${{ env.VITEST_STATEMENTS_COUNT }}"
+          echo "vitest-branches-count=${{ env.VITEST_BRANCHES_COUNT }}"
+          echo "vitest-functions-count=${{ env.VITEST_FUNCTIONS_COUNT }}"
+          echo "vitest-lines-count=${{ env.VITEST_LINES_COUNT }}"
+          echo "vitest-statements-percent=${{ env.VITEST_STATEMENTS_PERCENT }}"
+          echo "vitest-branches-percent=${{ env.VITEST_BRANCHES_PERCENT }}"
+          echo "vitest-functions-percent=${{ env.VITEST_FUNCTIONS_PERCENT }}"
+          echo "vitest-lines-percent=${{ env.VITEST_LINES_PERCENT }}"
         } >> "$GITHUB_OUTPUT"
 
     - name: Save unit tests coverage in cache 🥡

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,11 +107,22 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - install
+    outputs:
+      vitest-tests-count: ${{ steps.unit-tests.outputs.vitest-tests-count }}
+      vitest-statements-count: ${{ steps.unit-tests.outputs.vitest-statements-count }}
+      vitest-branches-count: ${{ steps.unit-tests.outputs.vitest-branches-count }}
+      vitest-functions-count: ${{ steps.unit-tests.outputs.vitest-functions-count }}
+      vitest-lines-count: ${{ steps.unit-tests.outputs.vitest-lines-count }}
+      vitest-statements-percent: ${{ steps.unit-tests.outputs.vitest-statements-percent }}
+      vitest-branches-percent: ${{ steps.unit-tests.outputs.vitest-branches-percent }}
+      vitest-functions-percent: ${{ steps.unit-tests.outputs.vitest-functions-percent }}
+      vitest-lines-percent: ${{ steps.unit-tests.outputs.vitest-lines-percent }}
     steps:
       - name: Checkout GitHub repository 📡
         uses: actions/checkout@v5
 
       - name: Unit Tests 🧪
+        id: unit-tests
         uses: ./.github/actions/unit-tests
 
   mutant-tests:
@@ -138,11 +149,14 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - install
+    outputs:
+      acceptance-tests-count: ${{ steps.acceptance-tests.outputs.acceptance-tests-count }}
     steps:
       - name: Checkout GitHub repository 📡
         uses: actions/checkout@v5
 
       - name: Acceptance Tests 🥒
+        id: acceptance-tests
         uses: ./.github/actions/acceptance-tests
 
   badges:
@@ -168,7 +182,7 @@ jobs:
           unit-tests-branches-percent: ${{ needs.unit-tests.outputs.vitest-branches-percent }}
           unit-tests-functions-percent: ${{ needs.unit-tests.outputs.vitest-functions-percent }}
           unit-tests-lines-percent: ${{ needs.unit-tests.outputs.vitest-lines-percent }}
-          acceptance-tests-count: ${{ needs.acceptance-tests.outputs.cucumber-tests-count }}
+          acceptance-tests-count: ${{ needs.acceptance-tests.outputs.acceptance-tests-count }}
 
   sonarcloud:
     name: SonarCloud Analysis 🌥️

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,6 +145,31 @@ jobs:
       - name: Acceptance Tests 🥒
         uses: ./.github/actions/acceptance-tests
 
+  badges:
+    name: Generate Badges 💠
+    runs-on: ubuntu-latest
+    needs:
+      - unit-tests
+      - acceptance-tests
+    steps:
+      - name: Checkout GitHub repository 📡
+        uses: actions/checkout@v5
+
+      - name: Generate Badges 💠
+        uses: ./.github/actions/badges
+        with:
+          byob-token: ${{ secrets.BYOB_TOKEN }}
+          unit-tests-count: ${{ needs.unit-tests.outputs.vitest-tests-count }}
+          unit-tests-covered-statements: ${{ needs.unit-tests.outputs.vitest-statements-count }}
+          unit-tests-covered-branches: ${{ needs.unit-tests.outputs.vitest-branches-count }}
+          unit-tests-covered-functions: ${{ needs.unit-tests.outputs.vitest-functions-count }}
+          unit-tests-covered-lines: ${{ needs.unit-tests.outputs.vitest-lines-count }}
+          unit-tests-statements-percent: ${{ needs.unit-tests.outputs.vitest-statements-percent }}
+          unit-tests-branches-percent: ${{ needs.unit-tests.outputs.vitest-branches-percent }}
+          unit-tests-functions-percent: ${{ needs.unit-tests.outputs.vitest-functions-percent }}
+          unit-tests-lines-percent: ${{ needs.unit-tests.outputs.vitest-lines-percent }}
+          acceptance-tests-count: ${{ needs.acceptance-tests.outputs.cucumber-tests-count }}
+
   sonarcloud:
     name: SonarCloud Analysis 🌥️
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,16 +107,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - install
-    outputs:
-      vitest-tests-count: ${{ steps.unit-tests.outputs.vitest-tests-count }}
-      vitest-statements-count: ${{ steps.unit-tests.outputs.vitest-statements-count }}
-      vitest-branches-count: ${{ steps.unit-tests.outputs.vitest-branches-count }}
-      vitest-functions-count: ${{ steps.unit-tests.outputs.vitest-functions-count }}
-      vitest-lines-count: ${{ steps.unit-tests.outputs.vitest-lines-count }}
-      vitest-statements-percent: ${{ steps.unit-tests.outputs.vitest-statements-percent }}
-      vitest-branches-percent: ${{ steps.unit-tests.outputs.vitest-branches-percent }}
-      vitest-functions-percent: ${{ steps.unit-tests.outputs.vitest-functions-percent }}
-      vitest-lines-percent: ${{ steps.unit-tests.outputs.vitest-lines-percent }}
     steps:
       - name: Checkout GitHub repository 📡
         uses: actions/checkout@v5
@@ -149,8 +139,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - install
-    outputs:
-      acceptance-tests-count: ${{ steps.acceptance-tests.outputs.acceptance-tests-count }}
     steps:
       - name: Checkout GitHub repository 📡
         uses: actions/checkout@v5
@@ -158,31 +146,6 @@ jobs:
       - name: Acceptance Tests 🥒
         id: acceptance-tests
         uses: ./.github/actions/acceptance-tests
-
-  badges:
-    name: Generate Badges 💠
-    runs-on: ubuntu-latest
-    needs:
-      - unit-tests
-      - acceptance-tests
-    steps:
-      - name: Checkout GitHub repository 📡
-        uses: actions/checkout@v5
-
-      - name: Generate Badges 💠
-        uses: ./.github/actions/badges
-        with:
-          byob-token: ${{ secrets.BYOB_TOKEN }}
-          unit-tests-count: ${{ needs.unit-tests.outputs.vitest-tests-count }}
-          unit-tests-covered-statements: ${{ needs.unit-tests.outputs.vitest-statements-count }}
-          unit-tests-covered-branches: ${{ needs.unit-tests.outputs.vitest-branches-count }}
-          unit-tests-covered-functions: ${{ needs.unit-tests.outputs.vitest-functions-count }}
-          unit-tests-covered-lines: ${{ needs.unit-tests.outputs.vitest-lines-count }}
-          unit-tests-statements-percent: ${{ needs.unit-tests.outputs.vitest-statements-percent }}
-          unit-tests-branches-percent: ${{ needs.unit-tests.outputs.vitest-branches-percent }}
-          unit-tests-functions-percent: ${{ needs.unit-tests.outputs.vitest-functions-percent }}
-          unit-tests-lines-percent: ${{ needs.unit-tests.outputs.vitest-lines-percent }}
-          acceptance-tests-count: ${{ needs.acceptance-tests.outputs.acceptance-tests-count }}
 
   sonarcloud:
     name: SonarCloud Analysis 🌥️

--- a/.github/workflows/release-creation.yml
+++ b/.github/workflows/release-creation.yml
@@ -98,6 +98,46 @@ jobs:
         with:
           stryker-dashboard-api-key: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
 
+  acceptance-tests:
+    name: Acceptance Tests 🥒
+    runs-on: ubuntu-latest
+    needs:
+      - install
+    outputs:
+      acceptance-tests-count: ${{ steps.acceptance-tests.outputs.acceptance-tests-count }}
+    steps:
+      - name: Checkout GitHub repository 📡
+        uses: actions/checkout@v5
+
+      - name: Acceptance Tests 🥒
+        id: acceptance-tests
+        uses: ./.github/actions/acceptance-tests
+
+  badges:
+    name: Generate Badges 💠
+    runs-on: ubuntu-latest
+    needs:
+      - unit-tests
+      - acceptance-tests
+    steps:
+      - name: Checkout GitHub repository 📡
+        uses: actions/checkout@v5
+
+      - name: Generate Badges 💠
+        uses: ./.github/actions/badges
+        with:
+          byob-token: ${{ secrets.BYOB_TOKEN }}
+          unit-tests-count: ${{ needs.unit-tests.outputs.vitest-tests-count }}
+          unit-tests-covered-statements: ${{ needs.unit-tests.outputs.vitest-statements-count }}
+          unit-tests-covered-branches: ${{ needs.unit-tests.outputs.vitest-branches-count }}
+          unit-tests-covered-functions: ${{ needs.unit-tests.outputs.vitest-functions-count }}
+          unit-tests-covered-lines: ${{ needs.unit-tests.outputs.vitest-lines-count }}
+          unit-tests-statements-percent: ${{ needs.unit-tests.outputs.vitest-statements-percent }}
+          unit-tests-branches-percent: ${{ needs.unit-tests.outputs.vitest-branches-percent }}
+          unit-tests-functions-percent: ${{ needs.unit-tests.outputs.vitest-functions-percent }}
+          unit-tests-lines-percent: ${{ needs.unit-tests.outputs.vitest-lines-percent }}
+          acceptance-tests-count: ${{ needs.acceptance-tests.outputs.acceptance-tests-count }}
+
   sonarcloud:
     name: SonarCloud Analysis 🌥️
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -56,6 +56,60 @@ This repository demonstrates how I build reliable software with strong testing s
 - **Code quality and coverage** — [SonarCloud](https://sonarcloud.io/).
 - **CI/CD pipelines** — [GitHub Actions](https://github.com/features/actions).
 
+### 🧪 Robustness
+
+#### 💯 Unit Testing
+
+![Vitest](https://img.shields.io/badge/-Vitest-black?style=for-the-badge&logoColor=yellow&logo=vitest&color=30420a)
+
+[![Tests count](https://byob.yarr.is/antoinezanardi/antoinezanardi.fr/unit-tests-count)](https://byob.yarr.is/antoinezanardi/antoinezanardi.fr/unit-tests-count)
+
+[![Unit Tests Statements Coverage](https://byob.yarr.is/antoinezanardi/antoinezanardi.fr/unit-tests-covered-statements)](https://byob.yarr.is/antoinezanardi/antoinezanardi.fr/unit-tests-covered-statements)
+[![Unit Tests Functions Coverage](https://byob.yarr.is/antoinezanardi/antoinezanardi.fr/unit-tests-covered-functions)](https://byob.yarr.is/antoinezanardi/antoinezanardi.fr/unit-tests-covered-functions)
+
+[![Unit Tests Lines Coverage](https://byob.yarr.is/antoinezanardi/antoinezanardi.fr/unit-tests-covered-lines)](https://byob.yarr.is/antoinezanardi/antoinezanardi.fr/unit-tests-covered-lines)
+[![Unit Tests Branches Coverage](https://byob.yarr.is/antoinezanardi/antoinezanardi.fr/unit-tests-covered-branches)](https://byob.yarr.is/antoinezanardi/antoinezanardi.fr/unit-tests-covered-branches)
+
+This project is designed to be robust and handle various scenarios.
+
+To achieve this, it is 100% unit tested with [Vitest](https://vitest.dev/) and has 100% code coverage.
+
+#### 🎭 End-to-End Testing
+
+![Playwright](https://img.shields.io/badge/-Playwright-black?style=for-the-badge&logoColor=white&logo=playwright&color=1D8D22)
+![Cucumber](https://img.shields.io/badge/-Cucumber-black?style=for-the-badge&logoColor=white&logo=cucumber&color=169652)
+
+[![Scenarios](https://byob.yarr.is/antoinezanardi/antoinezanardi.fr/scenarios)](https://byob.yarr.is/antoinezanardi/antoinezanardi.fr/scenarios)
+
+End-to-End tests are implemented using [Playwright](https://playwright.dev/) to ensure the application works as expected from the user's perspective.
+
+#### 🐋 Code Quality Scanner
+
+![SonarCloud](https://img.shields.io/badge/-SonarCloud-black?style=for-the-badge&logoColor=white&logo=sonar&color=4E9BCD)
+![CodeRabbit](https://img.shields.io/badge/-CodeRabbit-black?style=for-the-badge&logoColor=white&logo=coderabbit&color=E94E1B)
+
+The code quality is continuously monitored using [SonarCloud](https://sonarcloud.io/).
+
+You can check the code quality by clicking on one of the badges below:
+
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=antoinezanardi_antoinezanardi.fr&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=antoinezanardi_antoinezanardi.fr)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=antoinezanardi_antoinezanardi.fr&metric=coverage)](https://sonarcloud.io/summary/new_code?id=antoinezanardi_antoinezanardi.fr)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=antoinezanardi_antoinezanardi.fr&metric=bugs)](https://sonarcloud.io/summary/new_code?id=antoinezanardi_antoinezanardi.fr)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=antoinezanardi_antoinezanardi.fr&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=antoinezanardi_antoinezanardi.fr)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=antoinezanardi_antoinezanardi.fr&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=antoinezanardi_antoinezanardi.fr)
+
+Also, [CodeRabbit](https://coderabbit.io/) is used to ensure best practices are followed on each commit.
+
+#### 👽 Mutation Testing
+
+![Stryker](https://img.shields.io/badge/-Stryker-black?style=for-the-badge&logoColor=white&logo=stryker&color=7F1B10)
+
+[StrykerJS](https://stryker-mutator.io/) is used to ensure the code is resilient to mutations.
+
+You can check the mutation testing results by clicking on the badges below:
+
+[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fantoinezanardi%2Fantoinezanardi.fr%2Fmaster)](https://dashboard.stryker-mutator.io/reports/github.com/antoinezanardi/antoinezanardi.fr/master)
+
 ---
 
 ## <a name="deployment-workflow"></a>🔄 Deployment Workflow


### PR DESCRIPTION
This pull request introduces a new workflow step for generating test coverage and scenario badges, enhancing visibility of test results directly in the repository. The main changes include the addition of a custom composite GitHub Action for badge generation and its integration into the CI pipeline.

**Badge Generation Integration:**

* Added a new composite GitHub Action in `.github/actions/badges/action.yml` to generate badges for unit test counts, coverage metrics (statements, branches, functions, lines), and acceptance test scenarios using the RubbaBoy/BYOB action. This action takes various test result inputs and creates/update badges accordingly.
* Updated `.github/workflows/build.yml` to include a new `badges` job that runs after unit and acceptance tests, checks out the repository, and invokes the badge generation action with the relevant test outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automated generation and publication of test-status badges for unit tests and acceptance scenarios after test jobs complete.

- Chores
  - Badges include unit test counts and coverage (statements, branches, functions, lines) and acceptance scenario counts; badge colors configurable with sensible defaults.
  - Test workflows now expose the metrics required for badge generation so badges reflect latest results.

- Refactor
  - Standardized metric naming for consistent badge consumption.

- Documentation
  - Added a “Robustness” section describing testing and quality checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->